### PR TITLE
Use Instaloader session file for Instagram auth and always run creator scrape

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,11 +28,15 @@ jobs:
       - name: Install packages
         run: pip install -r requirements.txt
 
+      - name: Restore Instagram session
+        shell: bash
+        run: |
+          echo "${{ secrets.INSTAGRAM_SESSION_B64 }}" | base64 -d > instaloader.session
+
       - name: Run Steam script
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
-          INSTAGRAM_PASSWORD: ${{ secrets.INSTAGRAM_PASSWORD }}
         run: python main.py
 
       - name: Save updated state files

--- a/main.py
+++ b/main.py
@@ -720,17 +720,21 @@ def fetch_instagram_posts():
         quiet=True,
     )
     instagram_username = os.getenv("INSTAGRAM_USERNAME")
-    instagram_password = os.getenv("INSTAGRAM_PASSWORD")
+    session_file = "instaloader.session"
 
-    if instagram_username and instagram_password:
-        try:
-            loader.login(instagram_username, instagram_password)
-            print(f"Logged into Instagram as {instagram_username}")
-        except Exception as e:
-            print(f"Instagram login failed: {e}")
-            return []
-    else:
-        print("Instagram credentials missing; skipping Instagram login")
+    if not instagram_username:
+        print("INSTAGRAM_USERNAME missing; skipping Instagram")
+        return []
+
+    if not os.path.exists(session_file):
+        print("instaloader.session missing; skipping Instagram")
+        return []
+
+    try:
+        loader.load_session_from_file(instagram_username, session_file)
+        print(f"Loaded Instagram session for {instagram_username}")
+    except Exception as e:
+        print(f"Instagram session load failed: {e}")
         return []
 
     for username in INSTAGRAM_CREATORS:
@@ -770,6 +774,7 @@ def fetch_instagram_posts():
             continue
 
     save_instagram_seen(seen)
+    print(f"Instagram posts found this run: {len(all_new_posts)}")
     return all_new_posts
     
 def main():
@@ -847,7 +852,7 @@ def main():
     print(f"Qualified paid items before cap: {len(qualified_paid)}")
 
     if not free_items and not paid_items:
-        print("No qualifying games found. Nothing will be posted to Discord.")
+        print("No qualifying games found from Steam.")
     else:
         if free_items:
             free_chunks = build_message_chunks(
@@ -865,41 +870,41 @@ def main():
             )
             post_message_chunks(paid_chunks)
 
-        instagram_posts = fetch_instagram_posts()
+    instagram_posts = fetch_instagram_posts()
 
-        if instagram_posts:
-            instagram_lines = ["📸 **New Instagram Creator Picks**", ""]
+    if instagram_posts:
+        instagram_lines = ["📸 **New Instagram Creator Picks**", ""]
 
-            for idx, post in enumerate(instagram_posts, start=1):
-                instagram_lines.append(
-                    f"{idx}. @{post['username']} — {post['caption']}"
-                )
-                instagram_lines.append(post["url"])
-                instagram_lines.append("")
-
-            post_message_chunks(["\n".join(instagram_lines)])
-
-        for item in free_items + paid_items:
-            update_state_for_post(item["id"], item["type"], state)
-
-        save_state(state)
-
-        total = len(free_items) + len(paid_items)
-        print(f"Posted {total} item(s) to Discord.")
-        print(f"Free items selected: {len(free_items)}")
-        print(f"Paid items selected: {len(paid_items)}")
-
-        for item in free_items:
-            print(
-                f"FREE: {item['title']} ({item['type']}) "
-                f"score={item['score']} review_score={item.get('review_score', 0)}"
+        for idx, post in enumerate(instagram_posts, start=1):
+            instagram_lines.append(
+                f"{idx}. @{post['username']} — {post['caption']}"
             )
+            instagram_lines.append(post["url"])
+            instagram_lines.append("")
 
-        for item in paid_items:
-            print(
-                f"PAID: {item['title']} ({item['type']}) "
-                f"score={item['score']} review_score={item.get('review_score', 0)}"
-            )
+        post_message_chunks(["\n".join(instagram_lines)])
+
+    for item in free_items + paid_items:
+        update_state_for_post(item["id"], item["type"], state)
+
+    save_state(state)
+
+    total = len(free_items) + len(paid_items)
+    print(f"Posted {total} Steam item(s) to Discord.")
+    print(f"Free items selected: {len(free_items)}")
+    print(f"Paid items selected: {len(paid_items)}")
+
+    for item in free_items:
+        print(
+            f"FREE: {item['title']} ({item['type']}) "
+            f"score={item['score']} review_score={item.get('review_score', 0)}"
+        )
+
+    for item in paid_items:
+        print(
+            f"PAID: {item['title']} ({item['type']}) "
+            f"score={item['score']} review_score={item.get('review_score', 0)}"
+        )
 
     next_start_page = get_next_start_page(start_page)
     save_page_state(next_start_page)


### PR DESCRIPTION
### Motivation

- Password-based Instagram login was failing (checkpoint/null login), so switching to a persistent `instaloader.session` avoids interactive auth problems.
- Instagram scraping should run independently of whether Steam produced any results so creator posts are not skipped.
- Add defensive logging to make session and per-creator failures visible and non-fatal.

### Description

- Replace password login in `fetch_instagram_posts()` with `loader.load_session_from_file(instagram_username, "instaloader.session")` and add guards to skip when `INSTAGRAM_USERNAME` or the session file is missing.
- Preserve existing Instagram behavior: use `instagram_seen.json`, only include truly new posts, cap to `MAX_INSTAGRAM_POSTS_PER_ACCOUNT`, and continue on per-creator errors while recording seen shortcodes.
- Add informative `print()` logs for session load success/failure, per-creator errors, and total Instagram posts found this run.
- Move the Instagram scraping/posting call so it runs even when there are zero qualifying Steam free/paid items and update the posting flow to remain unchanged otherwise.
- Update `.github/workflows/daily.yml` to restore `instaloader.session` from the `INSTAGRAM_SESSION_B64` secret before running `main.py` and remove `INSTAGRAM_PASSWORD` from the runtime environment.

### Testing

- Ran `python -m py_compile main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4851812348326a39c045678e5f6ae)