### PR TITLE
Persist weekly scheduling message IDs and commit state from workflow

### DIFF
--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 13 * * 6'
 
+permissions:
+  contents: write
+
 jobs:
   post-weekly-availability:
     runs-on: ubuntu-latest
@@ -26,3 +29,17 @@ jobs:
           DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
           DISCORD_SCHEDULING_THREAD_ID: ${{ secrets.DISCORD_SCHEDULING_THREAD_ID }}
         run: python scripts/post_weekly_availability.py
+
+      - name: Commit weekly schedule state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/scheduling/weekly_schedule_messages.json
+
+          if git diff --cached --quiet; then
+            echo "No weekly schedule state changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: update weekly schedule message state"
+          git push

--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -1,10 +1,11 @@
 """Post weekly availability prompts to a Discord scheduling thread and add reactions."""
 
+import json
 import os
 import sys
 import time
 import urllib.parse
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import requests
@@ -13,6 +14,7 @@ import requests
 DISCORD_API_BASE = "https://discord.com/api/v10"
 REQUEST_TIMEOUT_SECONDS = 30
 USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
+WEEKLY_SCHEDULE_MESSAGES_FILE = "data/scheduling/weekly_schedule_messages.json"
 
 INTRO_MESSAGE_TEMPLATE = """🗓️ Weekly Availability — react below for next week
 Week of {date_range}
@@ -90,8 +92,8 @@ def build_reaction_url(thread_id: str, message_id: str, emoji: str) -> str:
     )
 
 
-def get_next_week_date_range(today: date | None = None) -> str:
-    """Return next week's Monday-Sunday range, formatted for the intro message."""
+def get_next_week_bounds(today: date | None = None) -> tuple[date, date]:
+    """Return next week's Monday and Sunday dates."""
     current_date = today or date.today()
 
     days_until_next_monday = (7 - current_date.weekday()) % 7
@@ -100,16 +102,91 @@ def get_next_week_date_range(today: date | None = None) -> str:
 
     next_monday = current_date + timedelta(days=days_until_next_monday)
     next_sunday = next_monday + timedelta(days=6)
+    return next_monday, next_sunday
+
+
+def get_next_week_date_range(today: date | None = None) -> str:
+    """Return next week's Monday-Sunday range, formatted for the intro message."""
+    next_monday, next_sunday = get_next_week_bounds(today=today)
+    return format_week_date_range(next_monday, next_sunday)
+
+
+def format_week_date_range(start_date: date, end_date: date) -> str:
+    """Return a Monday-Sunday range formatted for the intro message."""
+    next_monday = start_date
+    next_sunday = end_date
 
     if next_monday.year == next_sunday.year:
         if next_monday.month == next_sunday.month:
-            return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
+            return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"
         return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
 
     return (
         f"{next_monday:%b} {next_monday.day}, {next_monday.year}"
         f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"
     )
+
+
+def get_week_key(start_date: date, end_date: date) -> str:
+    """Return the stable week key for persisted message IDs."""
+    return f"{start_date.isoformat()}_to_{end_date.isoformat()}"
+
+
+def ensure_parent_dir(path: str) -> None:
+    """Create the parent directory for a file path if needed."""
+    parent_dir = os.path.dirname(path)
+    if parent_dir:
+        try:
+            os.makedirs(parent_dir, exist_ok=True)
+        except OSError as error:
+            fail(f"Failed to create directory {parent_dir}: {error}")
+
+
+def get_current_utc_timestamp() -> str:
+    """Return the current UTC timestamp in ISO-like format with Z suffix."""
+    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
+    """Keep only the latest N week entries ordered by week key."""
+    week_keys = sorted(data.keys())
+    if len(week_keys) <= keep_last:
+        return data
+
+    keys_to_keep = set(week_keys[-keep_last:])
+    return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
+
+
+def load_json_file(path: str) -> dict[str, Any]:
+    """Load a JSON object from disk, creating an empty one if missing."""
+    if not os.path.exists(path):
+        save_json_file(path, {})
+        return {}
+
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            loaded = json.load(file)
+    except json.JSONDecodeError:
+        fail(f"Invalid JSON in {path}")
+    except OSError as error:
+        fail(f"Failed to read {path}: {error}")
+
+    if not isinstance(loaded, dict):
+        fail(f"Expected top-level JSON object in {path}")
+
+    return loaded
+
+
+def save_json_file(path: str, data: dict[str, Any]) -> None:
+    """Write a JSON object to disk using UTF-8 and pretty indentation."""
+    ensure_parent_dir(path)
+
+    try:
+        with open(path, "w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+    except OSError as error:
+        fail(f"Failed to write {path}: {error}")
 
 
 def post_message(session: requests.Session, thread_id: str, content: str) -> str:
@@ -182,19 +259,41 @@ def main() -> None:
             }
         )
 
-        date_range = get_next_week_date_range()
+        week_start, week_end = get_next_week_bounds()
+        week_key = get_week_key(week_start, week_end)
+        date_range = format_week_date_range(week_start, week_end)
         intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
 
         intro_message_id = post_message(session, thread_id, intro_message)
         print(f"Posted intro message (message_id={intro_message_id})")
 
+        day_message_ids: dict[str, str] = {}
         for day_name, day_message in DAY_MESSAGES:
             day_message_id = post_message(session, thread_id, day_message)
             print(f"Posted day message: {day_name} (message_id={day_message_id})")
+            day_message_ids[day_name] = day_message_id
 
             for reaction in AVAILABILITY_REACTIONS:
                 add_reaction(session, thread_id, day_message_id, reaction)
                 print(f"Added reaction {reaction} to {day_name}")
+
+    weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
+    weekly_messages[week_key] = {
+        "thread_id": thread_id,
+        "date_range": date_range,
+        "created_at_utc": get_current_utc_timestamp(),
+        "intro_message_id": intro_message_id,
+        "days": day_message_ids,
+    }
+    pruned_weekly_messages = prune_weeks(weekly_messages, keep_last=12)
+    if len(pruned_weekly_messages) < len(weekly_messages):
+        print("Pruned weekly schedule history to last 12 weeks")
+
+    save_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned_weekly_messages)
+    print(
+        f"Saved weekly schedule message IDs for {week_key} "
+        f"to {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+    )
 
     print("Finished successfully")
 


### PR DESCRIPTION
### Motivation
- Persist posted weekly scheduling message IDs and metadata to repository state so future runs can reference or audit past posts and avoid duplicated work.

### Description
- Grant the workflow `contents: write` permission and add a step to commit `data/scheduling/weekly_schedule_messages.json` when the script produces changes.
- Enhance `scripts/post_weekly_availability.py` to compute stable week bounds, format date ranges, and produce a stable `week_key` for persisted state via `get_next_week_bounds`, `format_week_date_range`, and `get_week_key`.
- Add JSON persistence helpers (`load_json_file`, `save_json_file`, `ensure_parent_dir`, `prune_weeks`), timestamping with `get_current_utc_timestamp`, and logic to save the intro message ID and per-day message IDs into `data/scheduling/weekly_schedule_messages.json` while pruning history to the last 12 weeks.
- Minor API/date handling adjustments and refactors including import of `json`, use of `datetime.timezone`, and clearer separation of responsibilities in message posting and reaction seeding.

### Testing
- No unit tests were added for this change and no CI test suite was executed as part of this PR.
- Performed a basic Python syntax check with `python -m py_compile scripts/post_weekly_availability.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d597da2e9083269951afeb846a575a)