### PR TITLE
fix: repair weekly scheduling post flow and add nightly response sync

### DIFF
--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -24,15 +24,10 @@ Use 📝 only if you want to reply with a custom time.
 Availability:
 
 ✅ Free all day (alpha chad)
-
 🌅 Morning
-
 ☀️ Afternoon
-
 🌙 Evening
-
 ❌ Not free (I'm a gayboi)
-
 📝 Other / custom time
 
 If needed, reply under a day message for custom availability, for example:
@@ -41,535 +36,257 @@ Wed after 6
 Sat 1–4 PM"""
 
 DAY_MESSAGES: list[tuple[str, str]] = [
-("Monday", "🇲 Monday"),
-("Tuesday", "🇹 Tuesday"),
-("Wednesday", "🇼 Wednesday"),
-("Thursday", "🇷 Thursday"),
-("Friday", "🇫 Friday"),
-("Saturday", "🇸 Saturday"),
-("Sunday", "🇺 Sunday"),
+    ("Monday", "🇲 Monday"),
+    ("Tuesday", "🇹 Tuesday"),
+    ("Wednesday", "🇼 Wednesday"),
+    ("Thursday", "🇷 Thursday"),
+    ("Friday", "🇫 Friday"),
+    ("Saturday", "🇸 Saturday"),
+    ("Sunday", "🇺 Sunday"),
 ]
 
-AVAILABILITY_REACTIONS: list[str] = [
-"✅",
-"🌅",
-"☀️",
-"🌙",
-"❌",
-"📝",
-]
+AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
+
 
 def fail(message: str) -> None:
-"""Print an error and exit with a non-zero status."""
-print(f"ERROR: {message}", file=sys.stderr)
-sys.exit(1)
+    """Print an error and exit with a non-zero status."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
 
 def require_env(name: str) -> str:
-"""Return a required environment variable or exit if it is missing."""
-value = os.getenv(name)
-if not value:
-fail(f"Missing required environment variable: {name}")
-return value
+    """Return a required environment variable or exit if it is missing."""
+    value = os.getenv(name)
+    if not value:
+        fail(f"Missing required environment variable: {name}")
+    return value
+
 
 def check_response(response: requests.Response, context: str) -> None:
-"""Exit with details when a Discord API response is not successful."""
-if not response.ok:
-print(f"ERROR: {context}", file=sys.stderr)
-print(f"HTTP status: {response.status_code}", file=sys.stderr)
-print(f"Response body: {response.text}", file=sys.stderr)
-sys.exit(1)
+    """Exit with details when a Discord API response is not successful."""
+    if not response.ok:
+        print(f"ERROR: {context}", file=sys.stderr)
+        print(f"HTTP status: {response.status_code}", file=sys.stderr)
+        print(f"Response body: {response.text}", file=sys.stderr)
+        sys.exit(1)
+
 
 def build_message_url(thread_id: str) -> str:
-"""Build the Discord API URL for creating a message in a thread."""
-return f"{DISCORD_API_BASE}/channels/{thread_id}/messages"
+    """Build the Discord API URL for creating a message in a thread."""
+    return f"{DISCORD_API_BASE}/channels/{thread_id}/messages"
+
 
 def build_reaction_url(thread_id: str, message_id: str, emoji: str) -> str:
-"""Build the Discord API URL for adding a reaction to a message."""
-encoded_emoji = urllib.parse.quote(emoji, safe="")
-return (
-f"{DISCORD_API_BASE}/channels/{thread_id}/messages/"
-f"{message_id}/reactions/{encoded_emoji}/@me"
-)
+    """Build the Discord API URL for adding a reaction to a message."""
+    encoded_emoji = urllib.parse.quote(emoji, safe="")
+    return (
+        f"{DISCORD_API_BASE}/channels/{thread_id}/messages/"
+        f"{message_id}/reactions/{encoded_emoji}/@me"
+    )
+
 
 def get_next_week_bounds(today: date | None = None) -> tuple[date, date]:
-"""Return next week's Monday and Sunday dates."""
-current_date = today or date.today()
+    """Return next week's Monday and Sunday dates."""
+    current_date = today or date.today()
 
-days_until_next_monday = (7 - current_date.weekday()) % 7
-if days_until_next_monday == 0:
-    days_until_next_monday = 7
+    days_until_next_monday = (7 - current_date.weekday()) % 7
+    if days_until_next_monday == 0:
+        days_until_next_monday = 7
 
-next_monday = current_date + timedelta(days=days_until_next_monday)
-next_sunday = next_monday + timedelta(days=6)
-return next_monday, next_sunday
+    next_monday = current_date + timedelta(days=days_until_next_monday)
+    next_sunday = next_monday + timedelta(days=6)
+    return next_monday, next_sunday
+
+
 def get_next_week_date_range(today: date | None = None) -> str:
-"""Return next week's Monday-Sunday range, formatted for the intro message."""
-next_monday, next_sunday = get_next_week_bounds(today=today)
-return format_week_date_range(next_monday, next_sunday)
+    """Return next week's Monday-Sunday range, formatted for the intro message."""
+    next_monday, next_sunday = get_next_week_bounds(today=today)
+    return format_week_date_range(next_monday, next_sunday)
+
 
 def format_week_date_range(start_date: date, end_date: date) -> str:
-"""Return a Monday-Sunday range formatted for the intro message."""
-next_monday = start_date
-next_sunday = end_date
+    """Return a Monday-Sunday range formatted for the intro message."""
+    next_monday = start_date
+    next_sunday = end_date
 
-if next_monday.year == next_sunday.year:
-    if next_monday.month == next_sunday.month:
-        return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"
-    return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
+    if next_monday.year == next_sunday.year:
+        if next_monday.month == next_sunday.month:
+            return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"
+        return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
 
-return (
-    f"{next_monday:%b} {next_monday.day}, {next_monday.year}"
-    f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"
-)
+    return (
+        f"{next_monday:%b} {next_monday.day}, {next_monday.year}"
+        f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"
+    )
+
+
 def get_week_key(start_date: date, end_date: date) -> str:
     """Return the stable week key for persisted message IDs."""
     return f"{start_date.isoformat()}_to_{end_date.isoformat()}"
 
-def ensure_parent_dir(path: str) -> None:
-"""Create the parent directory for a file path if needed."""
-parent_dir = os.path.dirname(path)
-if parent_dir:
-try:
-os.makedirs(parent_dir, exist_ok=True)
-except OSError as error:
-fail(f"Failed to create directory {parent_dir}: {error}")
-
-def get_current_utc_timestamp() -> str:
-"""Return the current UTC timestamp in ISO-like format with Z suffix."""
-return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
-"""Keep only the latest N week entries ordered by week key."""
-week_keys = sorted(data.keys())
-if len(week_keys) <= keep_last:
-return data
-
-keys_to_keep = set(week_keys[-keep_last:])
-return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
-def load_json_file(path: str) -> dict[str, Any]:
-"""Load a JSON object from disk, creating an empty one if missing."""
-if not os.path.exists(path):
-save_json_file(path, {})
-return {}
-
-try:
-    with open(path, "r", encoding="utf-8") as file:
-        loaded = json.load(file)
-except json.JSONDecodeError:
-    fail(f"Invalid JSON in {path}")
-except OSError as error:
-    fail(f"Failed to read {path}: {error}")
-
-if not isinstance(loaded, dict):
-    fail(f"Expected top-level JSON object in {path}")
-
-return loaded
-def save_json_file(path: str, data: dict[str, Any]) -> None:
-"""Write a JSON object to disk using UTF-8 and pretty indentation."""
-ensure_parent_dir(path)
-
-try:
-    with open(path, "w", encoding="utf-8") as file:
-        json.dump(data, file, indent=2, ensure_ascii=False)
-        file.write("\n")
-except OSError as error:
-    fail(f"Failed to write {path}: {error}")
-def post_message(session: requests.Session, thread_id: str, content: str) -> str:
-"""Post a message and return the created Discord message ID."""
-url = build_message_url(thread_id)
-response = session.post(url, json={"content": content}, timeout=REQUEST_TIMEOUT_SECONDS)
-check_response(response, "Failed to post Discord message")
-
-try:
-    payload: dict[str, Any] = response.json()
-except ValueError:
-    fail("Discord response was not valid JSON when posting message")
-
-message_id = payload.get("id")
-if not message_id:
-    fail("Discord response JSON did not include message id")
-
-return str(message_id)
-def add_reaction(
-session: requests.Session, thread_id: str, message_id: str, emoji: str
-) -> None:
-"""Add a single emoji reaction to a posted Discord message."""
-url = build_reaction_url(thread_id, message_id, emoji)
-
-for attempt in range(1, 4):
-    response = session.put(url, timeout=REQUEST_TIMEOUT_SECONDS)
-    if response.status_code != 429:
-        check_response(response, f"Failed to add reaction: {emoji}")
-        return
-
-    retry_after_seconds = 1.0
-    try:
-        payload: dict[str, Any] = response.json()
-        retry_after_value = payload.get("retry_after")
-        if isinstance(retry_after_value, (int, float)):
-            retry_after_seconds = float(retry_after_value)
-        elif isinstance(retry_after_value, str):
-            retry_after_seconds = float(retry_after_value)
-    except (ValueError, TypeError):
-        retry_after_seconds = 1.0
-
-    if retry_after_seconds < 0:
-        retry_after_seconds = 1.0
-
-    if attempt < 3:
-        print(
-            f"Rate limited adding reaction {emoji}, "
-            f"sleeping {retry_after_seconds} seconds before retry"
-        )
-        time.sleep(retry_after_seconds)
-
-check_response(response, f"Failed to add reaction: {emoji}")
-def main() -> None:
-"""Run the weekly availability post flow and seed day-specific reactions."""
-token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
-thread_id = require_env("DISCORD_SCHEDULING_THREAD_ID")
-
-print(f"Starting weekly availability post (thread_id={thread_id})")
-
-with requests.Session() as session:
-    session.headers.update(
-        {
-            "Authorization": f"Bot {token}",
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-        }
-    )
-
-    week_start, week_end = get_next_week_bounds()
-    week_key = get_week_key(week_start, week_end)
-    date_range = format_week_date_range(week_start, week_end)
-    intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
-
-    intro_message_id = post_message(session, thread_id, intro_message)
-    print(f"Posted intro message (message_id={intro_message_id})")
-
-    day_message_ids: dict[str, str] = {}
-    for day_name, day_message in DAY_MESSAGES:
-        day_message_id = post_message(session, thread_id, day_message)
-        print(f"Posted day message: {day_name} (message_id={day_message_id})")
-        day_message_ids[day_name] = day_message_id
-
-        for reaction in AVAILABILITY_REACTIONS:
-            add_reaction(session, thread_id, day_message_id, reaction)
-            print(f"Added reaction {reaction} to {day_name}")
-
-    weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
-    weekly_messages[week_key] = {
-        "thread_id": thread_id,
-        "date_range": date_range,
-        "created_at_utc": get_current_utc_timestamp(),
-        "intro_message_id": intro_message_id,
-        "days": day_message_ids,
-    }
-    pruned_weekly_messages = prune_weeks(weekly_messages, keep_last=12)
-    if len(pruned_weekly_messages) < len(weekly_messages):
-        print("Pruned weekly schedule history to last 12 weeks")
-
-    save_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned_weekly_messages)
-    print(
-        f"Saved weekly schedule message IDs for {week_key} "
-        f"to {WEEKLY_SCHEDULE_MESSAGES_FILE}"
-    )
-
-print("Finished successfully")
-if name == "main":
-main()
-
-Please make exactly two edits in scripts/post_weekly_availability.py and output only the two corrected code snippets, not the whole file.\n\n1. Replace the entire get_week_key function with:\n\ndef get_week_key(start_date: date, end_date: date) -> str:\n    """Return the stable week key for persisted message IDs."""\n    return f"{start_date.isoformat()}_to_{end_date.isoformat()}"\n\n2. Replace the bottom of the file with:\n\nif __name__ == "__main__":\n    main()
-Copy
-def get_week_key(start_date: date, end_date: date) -> str:
-"""Return the stable week key for persisted message IDs."""
-return f"{start_date.isoformat()}to{end_date.isoformat()}"
-
-if name == "main":
-main()
-
-I need you to cleanly fix scripts/post_weekly_availability.py.\n\nImportant:\n- The current file is close, but it contains leftover merge-conflict duplication and a few bad duplicate lines.\n- Do NOT redesign the script.\n- Do NOT change behavior.\n- Do NOT touch any other file.\n- Only fix and clean scripts/post_weekly_availability.py.\n\nDesired final behavior of this file:\n- It remains the weekly POSTING flow only\n- It should:\n  - post the intro message\n  - post the seven day messages\n  - add reactions to the day messages\n  - persist only:\n    data/scheduling/weekly_schedule_messages.json\n- It should NOT:\n  - read reaction users\n  - write weekly_schedule_responses.json\n  - include any response-sync logic\n\nPlease apply these exact cleanup rules:\n\n1. Keep this import block clean:\n- keep:\n  from datetime import date, datetime, timedelta, timezone\n- remove any duplicate datetime/date/timedelta import lines\n\n2. Keep only one definition each of:\n- get_next_week_bounds\n- get_next_week_date_range\n- format_week_date_range\n- get_week_key\n\n3. In format_week_date_range(), the intended behavior is:\n- same month and same year:\n  Apr 13–19, 2026\n- different month, same year:\n  Apr 29–May 5, 2026\n- different year:\n  Dec 29, 2026–Jan 4, 2027\n\nSo the function should be:\n\ndef format_week_date_range(start_date: date, end_date: date) -> str:\n    """Return a Monday-Sunday range formatted for the intro message."""\n    next_monday = start_date\n    next_sunday = end_date\n\n    if next_monday.year == next_sunday.year:\n        if next_monday.month == next_sunday.month:\n            return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"\n        return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"\n\n    return (\n        f"{next_monday:%b} {next_monday.day}, {next_monday.year}"\n        f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"\n    )\n\n4. get_week_key() must be exactly:\n\ndef get_week_key(start_date: date, end_date: date) -> str:\n    """Return the stable week key for persisted message IDs."""\n    return f"{start_date.isoformat()}_to_{end_date.isoformat()}"\n\n5. In main():\n- keep:\n  week_start, week_end = get_next_week_bounds()\n  week_key = get_week_key(week_start, week_end)\n  date_range = format_week_date_range(week_start, week_end)\n- remove any old duplicate line like:\n  date_range = get_next_week_date_range()\n\n6. Keep only ONE weekly_messages save block\n- It must stay INSIDE the with requests.Session() block\n- Remove any duplicate or leftover copy outside the session block\n\n7. Preserve these helpers and behavior:\n- fail\n- require_env\n- check_response\n- build_message_url\n- build_reaction_url\n- ensure_parent_dir\n- get_current_utc_timestamp\n- prune_weeks\n- load_json_file\n- save_json_file\n- post_message\n- add_reaction\n- existing 429 retry handling for add_reaction\n\n8. Keep the main guard exactly as:\n\nif __name__ == "__main__":\n    main()\n\n9. Remove all merge conflict markers and any dead/unreachable duplicate lines\n\n10. Preserve normal Python formatting and indentation\n- The output must be valid Python\n- Do not compress indentation\n- Do not remove docstrings\n- Do not add markdown fences\n\nDeliverable:\n- Output only the complete final cleaned contents of scripts/post_weekly_availability.py\n- No explanations\n- No patch\n- No diff
-Copy
-"""Post weekly availability prompts to a Discord scheduling thread and add reactions."""
-
-import json
-import os
-import sys
-import time
-import urllib.parse
-from datetime import date, datetime, timedelta, timezone
-from typing import Any
-
-import requests
-
-DISCORD_API_BASE = "https://discord.com/api/v10"
-REQUEST_TIMEOUT_SECONDS = 30
-USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
-WEEKLY_SCHEDULE_MESSAGES_FILE = "data/scheduling/weekly_schedule_messages.json"
-
-INTRO_MESSAGE_TEMPLATE = """🗓️ Weekly Availability — react below for next week
-Week of {date_range}
-
-React on each day message with your availability.
-Use 📝 only if you want to reply with a custom time.
-
-Availability:
-
-✅ Free all day (alpha chad)
-
-🌅 Morning
-
-☀️ Afternoon
-
-🌙 Evening
-
-❌ Not free (I'm a gayboi)
-
-📝 Other / custom time
-
-If needed, reply under a day message for custom availability, for example:
-Tue 7–9 PM
-Wed after 6
-Sat 1–4 PM"""
-
-DAY_MESSAGES: list[tuple[str, str]] = [
-("Monday", "🇲 Monday"),
-("Tuesday", "🇹 Tuesday"),
-("Wednesday", "🇼 Wednesday"),
-("Thursday", "🇷 Thursday"),
-("Friday", "🇫 Friday"),
-("Saturday", "🇸 Saturday"),
-("Sunday", "🇺 Sunday"),
-]
-
-AVAILABILITY_REACTIONS: list[str] = [
-"✅",
-"🌅",
-"☀️",
-"🌙",
-"❌",
-"📝",
-]
-
-def fail(message: str) -> None:
-"""Print an error and exit with a non-zero status."""
-print(f"ERROR: {message}", file=sys.stderr)
-sys.exit(1)
-
-def require_env(name: str) -> str:
-"""Return a required environment variable or exit if it is missing."""
-value = os.getenv(name)
-if not value:
-fail(f"Missing required environment variable: {name}")
-return value
-
-def check_response(response: requests.Response, context: str) -> None:
-"""Exit with details when a Discord API response is not successful."""
-if not response.ok:
-print(f"ERROR: {context}", file=sys.stderr)
-print(f"HTTP status: {response.status_code}", file=sys.stderr)
-print(f"Response body: {response.text}", file=sys.stderr)
-sys.exit(1)
-
-def build_message_url(thread_id: str) -> str:
-"""Build the Discord API URL for creating a message in a thread."""
-return f"{DISCORD_API_BASE}/channels/{thread_id}/messages"
-
-def build_reaction_url(thread_id: str, message_id: str, emoji: str) -> str:
-"""Build the Discord API URL for adding a reaction to a message."""
-encoded_emoji = urllib.parse.quote(emoji, safe="")
-return (
-f"{DISCORD_API_BASE}/channels/{thread_id}/messages/"
-f"{message_id}/reactions/{encoded_emoji}/@me"
-)
-
-def get_next_week_bounds(today: date | None = None) -> tuple[date, date]:
-"""Return next week's Monday and Sunday dates."""
-current_date = today or date.today()
-
-days_until_next_monday = (7 - current_date.weekday()) % 7
-if days_until_next_monday == 0:
-    days_until_next_monday = 7
-
-next_monday = current_date + timedelta(days=days_until_next_monday)
-next_sunday = next_monday + timedelta(days=6)
-return next_monday, next_sunday
-def get_next_week_date_range(today: date | None = None) -> str:
-"""Return next week's Monday-Sunday range, formatted for the intro message."""
-next_monday, next_sunday = get_next_week_bounds(today=today)
-return format_week_date_range(next_monday, next_sunday)
-
-def format_week_date_range(start_date: date, end_date: date) -> str:
-"""Return a Monday-Sunday range formatted for the intro message."""
-next_monday = start_date
-next_sunday = end_date
-
-if next_monday.year == next_sunday.year:
-    if next_monday.month == next_sunday.month:
-        return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"
-    return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
-
-return (
-    f"{next_monday:%b} {next_monday.day}, {next_monday.year}"
-    f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"
-)
-def get_week_key(start_date: date, end_date: date) -> str:
-"""Return the stable week key for persisted message IDs."""
-return f"{start_date.isoformat()}to{end_date.isoformat()}"
 
 def ensure_parent_dir(path: str) -> None:
-"""Create the parent directory for a file path if needed."""
-parent_dir = os.path.dirname(path)
-if parent_dir:
-try:
-os.makedirs(parent_dir, exist_ok=True)
-except OSError as error:
-fail(f"Failed to create directory {parent_dir}: {error}")
+    """Create the parent directory for a file path if needed."""
+    parent_dir = os.path.dirname(path)
+    if parent_dir:
+        try:
+            os.makedirs(parent_dir, exist_ok=True)
+        except OSError as error:
+            fail(f"Failed to create directory {parent_dir}: {error}")
+
 
 def get_current_utc_timestamp() -> str:
-"""Return the current UTC timestamp in ISO-like format with Z suffix."""
-return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+    """Return the current UTC timestamp in ISO-like format with Z suffix."""
+    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
 
 def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
-"""Keep only the latest N week entries ordered by week key."""
-week_keys = sorted(data.keys())
-if len(week_keys) <= keep_last:
-return data
+    """Keep only the latest N week entries ordered by week key."""
+    week_keys = sorted(data.keys())
+    if len(week_keys) <= keep_last:
+        return data
 
-keys_to_keep = set(week_keys[-keep_last:])
-return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
+    keys_to_keep = set(week_keys[-keep_last:])
+    return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
+
+
 def load_json_file(path: str) -> dict[str, Any]:
-"""Load a JSON object from disk, creating an empty one if missing."""
-if not os.path.exists(path):
-save_json_file(path, {})
-return {}
+    """Load a JSON object from disk, creating an empty one if missing."""
+    if not os.path.exists(path):
+        save_json_file(path, {})
+        return {}
 
-try:
-    with open(path, "r", encoding="utf-8") as file:
-        loaded = json.load(file)
-except json.JSONDecodeError:
-    fail(f"Invalid JSON in {path}")
-except OSError as error:
-    fail(f"Failed to read {path}: {error}")
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            loaded = json.load(file)
+    except json.JSONDecodeError:
+        fail(f"Invalid JSON in {path}")
+    except OSError as error:
+        fail(f"Failed to read {path}: {error}")
 
-if not isinstance(loaded, dict):
-    fail(f"Expected top-level JSON object in {path}")
+    if not isinstance(loaded, dict):
+        fail(f"Expected top-level JSON object in {path}")
 
-return loaded
+    return loaded
+
+
 def save_json_file(path: str, data: dict[str, Any]) -> None:
-"""Write a JSON object to disk using UTF-8 and pretty indentation."""
-ensure_parent_dir(path)
+    """Write a JSON object to disk using UTF-8 and pretty indentation."""
+    ensure_parent_dir(path)
 
-try:
-    with open(path, "w", encoding="utf-8") as file:
-        json.dump(data, file, indent=2, ensure_ascii=False)
-        file.write("\n")
-except OSError as error:
-    fail(f"Failed to write {path}: {error}")
+    try:
+        with open(path, "w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+    except OSError as error:
+        fail(f"Failed to write {path}: {error}")
+
+
 def post_message(session: requests.Session, thread_id: str, content: str) -> str:
-"""Post a message and return the created Discord message ID."""
-url = build_message_url(thread_id)
-response = session.post(url, json={"content": content}, timeout=REQUEST_TIMEOUT_SECONDS)
-check_response(response, "Failed to post Discord message")
+    """Post a message and return the created Discord message ID."""
+    url = build_message_url(thread_id)
+    response = session.post(url, json={"content": content}, timeout=REQUEST_TIMEOUT_SECONDS)
+    check_response(response, "Failed to post Discord message")
 
-try:
-    payload: dict[str, Any] = response.json()
-except ValueError:
-    fail("Discord response was not valid JSON when posting message")
-
-message_id = payload.get("id")
-if not message_id:
-    fail("Discord response JSON did not include message id")
-
-return str(message_id)
-def add_reaction(
-session: requests.Session, thread_id: str, message_id: str, emoji: str
-) -> None:
-"""Add a single emoji reaction to a posted Discord message."""
-url = build_reaction_url(thread_id, message_id, emoji)
-
-for attempt in range(1, 4):
-    response = session.put(url, timeout=REQUEST_TIMEOUT_SECONDS)
-    if response.status_code != 429:
-        check_response(response, f"Failed to add reaction: {emoji}")
-        return
-
-    retry_after_seconds = 1.0
     try:
         payload: dict[str, Any] = response.json()
-        retry_after_value = payload.get("retry_after")
-        if isinstance(retry_after_value, (int, float)):
-            retry_after_seconds = float(retry_after_value)
-        elif isinstance(retry_after_value, str):
-            retry_after_seconds = float(retry_after_value)
-    except (ValueError, TypeError):
+    except ValueError:
+        fail("Discord response was not valid JSON when posting message")
+
+    message_id = payload.get("id")
+    if not message_id:
+        fail("Discord response JSON did not include message id")
+
+    return str(message_id)
+
+
+def add_reaction(session: requests.Session, thread_id: str, message_id: str, emoji: str) -> None:
+    """Add a single emoji reaction to a posted Discord message."""
+    url = build_reaction_url(thread_id, message_id, emoji)
+
+    for attempt in range(1, 4):
+        response = session.put(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        if response.status_code != 429:
+            check_response(response, f"Failed to add reaction: {emoji}")
+            return
+
         retry_after_seconds = 1.0
+        try:
+            payload: dict[str, Any] = response.json()
+            retry_after_value = payload.get("retry_after")
+            if isinstance(retry_after_value, (int, float)):
+                retry_after_seconds = float(retry_after_value)
+            elif isinstance(retry_after_value, str):
+                retry_after_seconds = float(retry_after_value)
+        except (ValueError, TypeError):
+            retry_after_seconds = 1.0
 
-    if retry_after_seconds < 0:
-        retry_after_seconds = 1.0
+        if retry_after_seconds < 0:
+            retry_after_seconds = 1.0
 
-    if attempt < 3:
-        print(
-            f"Rate limited adding reaction {emoji}, "
-            f"sleeping {retry_after_seconds} seconds before retry"
-        )
-        time.sleep(retry_after_seconds)
+        if attempt < 3:
+            print(
+                f"Rate limited adding reaction {emoji}, "
+                f"sleeping {retry_after_seconds} seconds before retry"
+            )
+            time.sleep(retry_after_seconds)
 
-check_response(response, f"Failed to add reaction: {emoji}")
+    check_response(response, f"Failed to add reaction: {emoji}")
+
+
 def main() -> None:
-"""Run the weekly availability post flow and seed day-specific reactions."""
-token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
-thread_id = require_env("DISCORD_SCHEDULING_THREAD_ID")
+    """Run the weekly availability post flow and seed day-specific reactions."""
+    token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
+    thread_id = require_env("DISCORD_SCHEDULING_THREAD_ID")
 
-print(f"Starting weekly availability post (thread_id={thread_id})")
+    print(f"Starting weekly availability post (thread_id={thread_id})")
 
-with requests.Session() as session:
-    session.headers.update(
-        {
-            "Authorization": f"Bot {token}",
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
+    with requests.Session() as session:
+        session.headers.update(
+            {
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+            }
+        )
+
+        week_start, week_end = get_next_week_bounds()
+        week_key = get_week_key(week_start, week_end)
+        date_range = format_week_date_range(week_start, week_end)
+        intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
+
+        intro_message_id = post_message(session, thread_id, intro_message)
+        print(f"Posted intro message (message_id={intro_message_id})")
+
+        day_message_ids: dict[str, str] = {}
+        for day_name, day_message in DAY_MESSAGES:
+            day_message_id = post_message(session, thread_id, day_message)
+            print(f"Posted day message: {day_name} (message_id={day_message_id})")
+            day_message_ids[day_name] = day_message_id
+
+            for reaction in AVAILABILITY_REACTIONS:
+                add_reaction(session, thread_id, day_message_id, reaction)
+                print(f"Added reaction {reaction} to {day_name}")
+
+        weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
+        weekly_messages[week_key] = {
+            "thread_id": thread_id,
+            "date_range": date_range,
+            "created_at_utc": get_current_utc_timestamp(),
+            "intro_message_id": intro_message_id,
+            "days": day_message_ids,
         }
-    )
+        pruned_weekly_messages = prune_weeks(weekly_messages, keep_last=12)
+        if len(pruned_weekly_messages) < len(weekly_messages):
+            print("Pruned weekly schedule history to last 12 weeks")
 
-    week_start, week_end = get_next_week_bounds()
-    week_key = get_week_key(week_start, week_end)
-    date_range = format_week_date_range(week_start, week_end)
-    intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
+        save_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned_weekly_messages)
+        print(
+            f"Saved weekly schedule message IDs for {week_key} "
+            f"to {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+        )
 
-    intro_message_id = post_message(session, thread_id, intro_message)
-    print(f"Posted intro message (message_id={intro_message_id})")
-
-    day_message_ids: dict[str, str] = {}
-    for day_name, day_message in DAY_MESSAGES:
-        day_message_id = post_message(session, thread_id, day_message)
-        print(f"Posted day message: {day_name} (message_id={day_message_id})")
-        day_message_ids[day_name] = day_message_id
-
-        for reaction in AVAILABILITY_REACTIONS:
-            add_reaction(session, thread_id, day_message_id, reaction)
-            print(f"Added reaction {reaction} to {day_name}")
-
-    weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
-    weekly_messages[week_key] = {
-        "thread_id": thread_id,
-        "date_range": date_range,
-        "created_at_utc": get_current_utc_timestamp(),
-        "intro_message_id": intro_message_id,
-        "days": day_message_ids,
-    }
-    pruned_weekly_messages = prune_weeks(weekly_messages, keep_last=12)
-    if len(pruned_weekly_messages) < len(weekly_messages):
-        print("Pruned weekly schedule history to last 12 weeks")
-
-    save_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned_weekly_messages)
-    print(
-        f"Saved weekly schedule message IDs for {week_key} "
-        f"to {WEEKLY_SCHEDULE_MESSAGES_FILE}"
-    )
-
-print("Finished successfully")
+    print("Finished successfully")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -1,15 +1,13 @@
-"""Sync weekly scheduling reaction responses from Discord into durable JSON state."""
+"""Sync weekly scheduling reactions from Discord into durable JSON state."""
 
 import json
 import os
 import sys
 import time
 import urllib.parse
-from datetime import datetime, timezone
 from typing import Any
 
 import requests
-
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
 REQUEST_TIMEOUT_SECONDS = 30
@@ -27,14 +25,7 @@ DAY_NAMES: list[str] = [
     "Sunday",
 ]
 
-AVAILABILITY_REACTIONS: list[str] = [
-    "✅",
-    "🌅",
-    "☀️",
-    "🌙",
-    "❌",
-    "📝",
-]
+AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
 
 
 def fail(message: str) -> None:
@@ -112,19 +103,6 @@ def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
     return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
 
 
-def get_current_utc_timestamp() -> str:
-    """Return the current UTC timestamp in ISO-like format with Z suffix."""
-    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def get_latest_week_key(data: dict[str, Any]) -> str:
-    """Return the latest week key by chronological (ISO string) order."""
-    if not data:
-        fail(f"No weekly message state found in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
-
-    return sorted(data.keys())[-1]
-
-
 def build_current_user_url() -> str:
     """Build the Discord API URL for fetching the current bot user."""
     return f"{DISCORD_API_BASE}/users/@me"
@@ -139,8 +117,8 @@ def build_reaction_users_url(thread_id: str, message_id: str, emoji: str) -> str
     )
 
 
-def get_bot_user(session: requests.Session) -> dict[str, Any]:
-    """Fetch and return the current bot user object."""
+def get_bot_user_id(session: requests.Session) -> str:
+    """Fetch and return the current bot user id."""
     response = session.get(build_current_user_url(), timeout=REQUEST_TIMEOUT_SECONDS)
     check_response(response, "Failed to fetch current bot user")
 
@@ -153,22 +131,7 @@ def get_bot_user(session: requests.Session) -> dict[str, Any]:
     if not user_id:
         fail("Discord response JSON did not include bot user id")
 
-    return payload
-
-
-def normalize_user(user: dict[str, Any]) -> dict[str, Any]:
-    """Normalize a Discord user object for stored response data."""
-    user_id = user.get("id")
-    username = user.get("username")
-
-    if not user_id or not username:
-        fail("Discord reaction user object missing required id/username fields")
-
-    return {
-        "user_id": str(user_id),
-        "username": str(username),
-        "global_name": user.get("global_name"),
-    }
+    return str(user_id)
 
 
 def fetch_reaction_users(
@@ -240,29 +203,33 @@ def fetch_reaction_users(
     return all_users
 
 
+def get_user_label(user: dict[str, Any]) -> str:
+    """Return display label for a Discord user."""
+    global_name = user.get("global_name")
+    username = user.get("username")
+
+    if isinstance(global_name, str) and global_name.strip():
+        return global_name.strip()
+    if isinstance(username, str) and username.strip():
+        return username.strip()
+
+    user_id = user.get("id")
+    if not user_id:
+        fail("Discord reaction user object missing id")
+    return str(user_id)
+
+
 def main() -> None:
-    """Fetch and persist reaction responses for the latest scheduled week."""
+    """Fetch and persist reaction responses for recorded scheduled weeks."""
     token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
 
     weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
-    week_key = get_latest_week_key(weekly_messages)
+    if not weekly_messages:
+        print("No weekly message state found; nothing to sync")
+        return
 
-    latest_week_data = weekly_messages.get(week_key)
-    if not isinstance(latest_week_data, dict):
-        fail(f"Invalid week payload for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
-
-    thread_id = latest_week_data.get("thread_id")
-    date_range = latest_week_data.get("date_range")
-    days = latest_week_data.get("days")
-
-    if not thread_id or not isinstance(thread_id, str):
-        fail(f"Missing or invalid thread_id for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
-    if not date_range or not isinstance(date_range, str):
-        fail(f"Missing or invalid date_range for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
-    if not isinstance(days, dict):
-        fail(f"Missing or invalid days mapping for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
-
-    print(f"Starting weekly schedule response sync (thread_id={thread_id}, week_key={week_key})")
+    week_keys = sorted(weekly_messages.keys())[-12:]
+    print(f"Starting weekly schedule response sync for {len(week_keys)} week(s)")
 
     with requests.Session() as session:
         session.headers.update(
@@ -273,49 +240,65 @@ def main() -> None:
             }
         )
 
-        bot_user = get_bot_user(session)
-        bot_user_id = str(bot_user["id"])
+        bot_user_id = get_bot_user_id(session)
         print(f"Fetched bot user (user_id={bot_user_id})")
 
-        responses_by_day: dict[str, dict[str, list[dict[str, Any]]]] = {}
+        weekly_responses: dict[str, Any] = {}
 
-        for day_name in DAY_NAMES:
-            day_message_id = days.get(day_name)
-            if not day_message_id:
-                fail(
-                    f"Missing message ID for {day_name} in week {week_key} "
-                    f"from {WEEKLY_SCHEDULE_MESSAGES_FILE}"
-                )
+        for week_key in week_keys:
+            latest_week_data = weekly_messages.get(week_key)
+            if not isinstance(latest_week_data, dict):
+                fail(f"Invalid week payload for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
 
-            responses_by_day[day_name] = {}
-            for reaction in AVAILABILITY_REACTIONS:
-                reaction_users = fetch_reaction_users(session, thread_id, str(day_message_id), reaction)
-                filtered_users = [
-                    normalize_user(user)
-                    for user in reaction_users
-                    if str(user.get("id", "")) != bot_user_id
-                ]
-                responses_by_day[day_name][reaction] = filtered_users
-                print(
-                    f"Fetched {len(filtered_users)} human users for "
-                    f"{day_name} reaction {reaction}"
-                )
+            thread_id = latest_week_data.get("thread_id")
+            date_range = latest_week_data.get("date_range")
+            days = latest_week_data.get("days")
 
-    weekly_responses = load_json_file(WEEKLY_SCHEDULE_RESPONSES_FILE)
-    weekly_responses[week_key] = {
-        "thread_id": thread_id,
-        "date_range": date_range,
-        "created_at_utc": get_current_utc_timestamp(),
-        "days": responses_by_day,
-    }
+            if not thread_id or not isinstance(thread_id, str):
+                fail(f"Missing or invalid thread_id for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+            if not date_range or not isinstance(date_range, str):
+                fail(f"Missing or invalid date_range for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+            if not isinstance(days, dict):
+                fail(f"Missing or invalid days mapping for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+
+            users_map: dict[str, dict[str, list[str]]] = {}
+            for day_name in DAY_NAMES:
+                day_message_id = days.get(day_name)
+                if not day_message_id:
+                    fail(
+                        f"Missing message ID for {day_name} in week {week_key} "
+                        f"from {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+                    )
+
+                for reaction in AVAILABILITY_REACTIONS:
+                    reaction_users = fetch_reaction_users(session, thread_id, str(day_message_id), reaction)
+                    for user in reaction_users:
+                        user_id = str(user.get("id", ""))
+                        if not user_id:
+                            continue
+
+                        if user_id == bot_user_id:
+                            continue
+                        if bool(user.get("bot")):
+                            continue
+
+                        user_label = get_user_label(user)
+                        if user_label not in users_map:
+                            users_map[user_label] = {day: [] for day in DAY_NAMES}
+
+                        if reaction not in users_map[user_label][day_name]:
+                            users_map[user_label][day_name].append(reaction)
+
+            weekly_responses[week_key] = {
+                "date_range": date_range,
+                "users": users_map,
+            }
+            print(f"Synced week {week_key}")
 
     pruned_weekly_responses = prune_weeks(weekly_responses, keep_last=12)
-    if len(pruned_weekly_responses) < len(weekly_responses):
-        print("Pruned weekly schedule history to last 12 weeks")
-
     save_json_file(WEEKLY_SCHEDULE_RESPONSES_FILE, pruned_weekly_responses)
     print(
-        f"Saved weekly schedule responses for {week_key} "
+        f"Saved weekly schedule responses for {len(pruned_weekly_responses)} week(s) "
         f"to {WEEKLY_SCHEDULE_RESPONSES_FILE}"
     )
     print("Finished successfully")


### PR DESCRIPTION
### Motivation
- The weekly posting script was corrupted by leftover merge conflict/prompt text and produced invalid Python, breaking the scheduled posting flow. 
- A separate nightly reaction sync (Phase 2) was required to collect availability reactions into durable state while keeping posting and sync logic separate.

### Description
- Repaired `scripts/post_weekly_availability.py` to valid Python and restored the posting-only flow that posts the intro + seven day messages, seeds reactions, and persists `data/scheduling/weekly_schedule_messages.json` (12-week retention). 
- Added `scripts/sync_weekly_schedule_responses.py` implementing the nightly reaction sync that reads `data/scheduling/weekly_schedule_messages.json`, fetches reactions per day (ignoring the scheduling bot and other bots), maps users to per-day emoji selections, and writes `data/scheduling/weekly_schedule_responses.json` with 12-week retention. 
- Exact files changed: `scripts/post_weekly_availability.py` and `scripts/sync_weekly_schedule_responses.py`. 
- Intentionally not implemented yet: parsing `📝` custom reply text, overlap summaries, best overlap window, most-available-day calculation, missing-responder logic, and automated reminder messages.

### Testing
- Compiled both scripts with `python -m py_compile scripts/post_weekly_availability.py scripts/sync_weekly_schedule_responses.py` and the compilation succeeded. 
- Verified presence and expected strings with `rg` checks for schedule filenames, prune logic, and main guard and those grep checks passed. 
- Validated workflow YAMLs' syntax using `ruby -e 'require "yaml"; YAML.load_file(...)'` which returned `YAML_OK` for the workflow files. 
- Attempted to validate YAML with Python `yaml` but `PyYAML` was not installed in the environment (warning only). 

Manual post-merge steps
1. Merge hotfix. 
2. Manually run Weekly Scheduling Bot. 
3. Manually run Weekly Scheduling Responses Sync.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b3fca1b0832682fbb400f20dedcd)