### PR TITLE
Add second nightly run for weekly scheduling responses sync

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 23 * * *'
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
### Motivation
- Run the weekly responses sync twice nightly to capture late-evening reaction changes the same night instead of waiting until the next day.

### Description
- Updated ` .github/workflows/weekly-scheduling-responses-sync.yml` to keep the existing `- cron: '0 23 * * *'` run and add `- cron: '0 3 * * *'` so the workflow runs at ~7:00 PM and ~11:00 PM New York time.

### Testing
- Verified YAML parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/weekly-scheduling-responses-sync.yml'); puts 'YAML_OK'"` (returned `YAML_OK`), observed a Python `yaml.safe_load` attempt failed due to missing `PyYAML`, confirmed via `git diff` that only ` .github/workflows/weekly-scheduling-responses-sync.yml` changed, and created a commit and PR successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5be2ae71c8326b2520c571cf51852)