### PR TITLE
fix: persist weekly schedule bot output state in sync workflow

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/scheduling/weekly_schedule_responses.json data/scheduling/weekly_schedule_summary.json
+          git add data/scheduling/weekly_schedule_responses.json data/scheduling/weekly_schedule_summary.json data/scheduling/weekly_schedule_bot_outputs.json
 
           if git diff --cached --quiet; then
             echo "No weekly schedule response changes to commit"


### PR DESCRIPTION
### Motivation
- The scheduled sync workflow was not committing `data/scheduling/weekly_schedule_bot_outputs.json`, which meant bot output dedupe state was not persisted between the twice-daily runs and could lead to duplicate reminder/summary posts.

### Description
- Update `.github/workflows/weekly-scheduling-responses-sync.yml` to include `data/scheduling/weekly_schedule_bot_outputs.json` in the `git add` command alongside `data/scheduling/weekly_schedule_responses.json` and `data/scheduling/weekly_schedule_summary.json`, with no other changes to scripts, scheduling cadence, or content.

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/weekly-scheduling-responses-sync.yml')"`, confirmed the `git add` line via `rg`, and verified via `git status` and `git log` that only the workflow file changed and the commit was recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5cc451e8083269144cf52bd3f1cd0)