### PR TITLE
Temporary reset of current week scheduling summary dedupe state

### DIFF
--- a/data/scheduling/weekly_schedule_bot_outputs.json
+++ b/data/scheduling/weekly_schedule_bot_outputs.json
@@ -1,7 +1,6 @@
 {
   "2026-04-13_to_2026-04-19": {
-    "summary_posted": true,
-    "summary_message_id": "1491281337255198752",
+    "summary_posted": false,
     "reminder_message_id": "1491288257118601216",
     "reminder_missing_users": [
       "150522802292785152",


### PR DESCRIPTION
### Motivation
- Temporary test-only reset to allow one fresh summary post for the current week `2026-04-13_to_2026-04-19` so the updated summary formatting can be validated in Discord.

### Description
- Updated `data/scheduling/weekly_schedule_bot_outputs.json` for `2026-04-13_to_2026-04-19` to set `"summary_posted": false` and remove `"summary_message_id"` while preserving `reminder_message_id` and `reminder_missing_users`, with no other files changed.

### Testing
- Ran `python -m json.tool data/scheduling/weekly_schedule_bot_outputs.json` for JSON validity, `git diff -- data/scheduling/weekly_schedule_bot_outputs.json`, and `git status --short`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5d5e9d5148326acc3129ee5ab3485)