### PR TITLE
fix: document DST limitation for daily Steam workflow cron

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,7 +3,8 @@ name: Steam Free Games
 on:
   workflow_dispatch:
   schedule:
-    # 9:00 AM New York (EST) = 14:00 UTC; 9:00 AM New York (EDT) = 13:00 UTC
+    # GitHub Actions cron uses UTC only (no timezone/DST support).
+    # This runs at 13:00 UTC year-round: 9:00 AM in New York during EDT, 8:00 AM during EST.
     - cron: "0 13 * * *"
 
 permissions:


### PR DESCRIPTION
### Motivation
- The workflow previously included a comment implying the single UTC cron would be 9:00 AM New York year‑round, but a single UTC cron cannot track New York DST shifts, so the comment was misleading and needed to be corrected.

### Description
- Update `.github/workflows/daily.yml` comments only: make explicit that GitHub Actions cron is UTC-only and that the schedule remains `0 13 * * *` (which is 9:00 AM New York during EDT and 8:00 AM during EST), preserving the morning-only cadence and documenting this DST compromise.

### Testing
- Ran automated checks: YAML load/inspection via `ruby` succeeded and shows exactly one `schedule` entry; a `python` YAML load attempt failed due to missing `PyYAML` in the environment (tooling limitation); `git` verification confirmed only `.github/workflows/daily.yml` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e11093148326b76b4e5117e592c2)