### PR TITLE
fix: migrate evening winners workflow to channel-based destination secret

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Run evening winners script
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_WINNERS_THREAD_ID: ${{ secrets.DISCORD_WINNERS_THREAD_ID }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
         run: python evening_winners.py

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -14,7 +14,7 @@ BASE_BACKOFF_SECONDS = 2
 REQUEST_TIMEOUT_SECONDS = 30
 
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
-DISCORD_WINNERS_THREAD_ID = os.getenv("DISCORD_WINNERS_THREAD_ID")
+DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
 
 
 SECTION_CONFIG = {
@@ -123,16 +123,16 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
     return "\n".join(lines).strip()
 
 
-def post_winners_message(thread_id: str, headers: Dict[str, str], message: str) -> None:
-    url = f"{DISCORD_API_BASE}/channels/{thread_id}/messages"
+def post_winners_message(channel_id: str, headers: Dict[str, str], message: str) -> None:
+    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
     request_with_retry("POST", url, headers, json_payload={"content": message})
 
 
 def main() -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
-    if not DISCORD_WINNERS_THREAD_ID:
-        raise RuntimeError("DISCORD_WINNERS_THREAD_ID is not set.")
+    if not DISCORD_WINNERS_CHANNEL_ID:
+        raise RuntimeError("DISCORD_WINNERS_CHANNEL_ID is not set.")
 
     daily_posts = load_discord_daily_posts()
     day_key = datetime.now(timezone.utc).date().isoformat()
@@ -172,7 +172,7 @@ def main() -> None:
         )
 
     message = build_winners_message(winners_by_section)
-    post_winners_message(DISCORD_WINNERS_THREAD_ID, headers, message)
+    post_winners_message(DISCORD_WINNERS_CHANNEL_ID, headers, message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The evening winners automation was still wired to the deleted `DISCORD_WINNERS_THREAD_ID` secret, causing a config mismatch with the new channel-based winners destination.

### Description
- Updated `.github/workflows/evening-winners.yml` to provide `DISCORD_WINNERS_CHANNEL_ID` from repository secrets instead of the removed thread secret.
- Updated `evening_winners.py` to read `DISCORD_WINNERS_CHANNEL_ID`, to use `channel_id` terminology in the posting helper, and to check/raise on `DISCORD_WINNERS_CHANNEL_ID` at runtime while preserving the `/channels/{id}/messages` API route and existing winners logic.
- Cleaned up variable/argument names and runtime error text where touched, without changing morning workflow behavior or winners business logic.
- Confirmations included: morning picks remain on `DISCORD_WEBHOOK_URL` / `xianngpt-bot-daily-vote-here`, evening winners now use `DISCORD_WINNERS_CHANNEL_ID` / `daily-game-picks`, and the old `DISCORD_WINNERS_THREAD_ID` dependency was removed from the active evening winners path.

### Testing
- Validated workflow YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/evening-winners.yml')"` which succeeded.
- Ran Python compile check with `python -m py_compile evening_winners.py` which succeeded.
- Searched for remaining references with `rg -n "DISCORD_WINNERS_THREAD_ID|DISCORD_WINNERS_CHANNEL_ID|DISCORD_WEBHOOK_URL" .github/workflows evening_winners.py main.py` and confirmed `DISCORD_WINNERS_THREAD_ID` is no longer present in the active evening winners path and `DISCORD_WEBHOOK_URL` usage for morning remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fea9cf34832695439b87c2983d7a)