### PR TITLE
chore: correct current-day tracked source channel ids for winners retest

### DIFF
--- a/discord_daily_posts.json
+++ b/discord_daily_posts.json
@@ -285,7 +285,7 @@
   "2026-04-08": {
     "items": [
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319485846655008",
         "posted_at": "2026-04-08T06:11:13.354043+00:00",
         "section": "free",
@@ -294,7 +294,7 @@
         "url": "https://store.steampowered.com/app/1457950/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319493698387998",
         "posted_at": "2026-04-08T06:11:15.200201+00:00",
         "section": "free",
@@ -303,7 +303,7 @@
         "url": "https://store.steampowered.com/app/2939260/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319501449330728",
         "posted_at": "2026-04-08T06:11:17.127832+00:00",
         "section": "free",
@@ -312,7 +312,7 @@
         "url": "https://store.steampowered.com/app/2963870/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319509628223658",
         "posted_at": "2026-04-08T06:11:18.890862+00:00",
         "section": "free",
@@ -321,7 +321,7 @@
         "url": "https://store.steampowered.com/app/3798230/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319517207593051",
         "posted_at": "2026-04-08T06:11:20.863519+00:00",
         "section": "free",
@@ -330,7 +330,7 @@
         "url": "https://store.steampowered.com/app/378760/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319524920918049",
         "posted_at": "2026-04-08T06:11:22.626234+00:00",
         "section": "free",
@@ -339,7 +339,7 @@
         "url": "https://store.steampowered.com/app/1549250/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319532764270632",
         "posted_at": "2026-04-08T06:11:24.430407+00:00",
         "section": "free",
@@ -348,7 +348,7 @@
         "url": "https://store.steampowered.com/app/994910/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319539697193022",
         "posted_at": "2026-04-08T06:11:26.115524+00:00",
         "section": "free",
@@ -357,7 +357,7 @@
         "url": "https://store.steampowered.com/app/39120/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319547481952408",
         "posted_at": "2026-04-08T06:11:28.008108+00:00",
         "section": "free",
@@ -366,7 +366,7 @@
         "url": "https://store.steampowered.com/app/1969870/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319555224633504",
         "posted_at": "2026-04-08T06:11:30.298330+00:00",
         "section": "free",
@@ -375,7 +375,7 @@
         "url": "https://store.steampowered.com/app/1674010/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319571389349930",
         "posted_at": "2026-04-08T06:11:33.625982+00:00",
         "section": "paid",
@@ -384,7 +384,7 @@
         "url": "https://store.steampowered.com/app/2794590/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319578423197819",
         "posted_at": "2026-04-08T06:11:35.438642+00:00",
         "section": "paid",
@@ -393,7 +393,7 @@
         "url": "https://store.steampowered.com/app/2306620/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319586514276574",
         "posted_at": "2026-04-08T06:11:37.213447+00:00",
         "section": "paid",
@@ -402,7 +402,7 @@
         "url": "https://store.steampowered.com/app/3015760/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319593740927026",
         "posted_at": "2026-04-08T06:11:38.956905+00:00",
         "section": "paid",
@@ -411,7 +411,7 @@
         "url": "https://store.steampowered.com/app/589290/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319601102061669",
         "posted_at": "2026-04-08T06:11:40.653770+00:00",
         "section": "paid",
@@ -420,7 +420,7 @@
         "url": "https://store.steampowered.com/app/3174120/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319608505012244",
         "posted_at": "2026-04-08T06:11:42.694291+00:00",
         "section": "paid",
@@ -429,7 +429,7 @@
         "url": "https://store.steampowered.com/app/1763250/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319616394231892",
         "posted_at": "2026-04-08T06:11:44.749030+00:00",
         "section": "paid",
@@ -438,7 +438,7 @@
         "url": "https://store.steampowered.com/app/327030/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319625030438994",
         "posted_at": "2026-04-08T06:11:46.530284+00:00",
         "section": "paid",
@@ -447,7 +447,7 @@
         "url": "https://store.steampowered.com/app/1631270/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319632961998868",
         "posted_at": "2026-04-08T06:11:48.372308+00:00",
         "section": "paid",
@@ -456,7 +456,7 @@
         "url": "https://store.steampowered.com/app/602960/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319640775983104",
         "posted_at": "2026-04-08T06:11:50.338901+00:00",
         "section": "paid",
@@ -465,7 +465,7 @@
         "url": "https://store.steampowered.com/app/2168680/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319655472697494",
         "posted_at": "2026-04-08T06:11:53.726639+00:00",
         "section": "instagram",
@@ -474,7 +474,7 @@
         "url": "https://www.instagram.com/p/DWRKHq5u9JY/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319663064252558",
         "posted_at": "2026-04-08T06:11:56.542817+00:00",
         "section": "instagram",
@@ -483,7 +483,7 @@
         "url": "https://www.instagram.com/p/DUWaIsyCS1S/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319674821152829",
         "posted_at": "2026-04-08T06:11:58.638260+00:00",
         "section": "instagram",
@@ -492,7 +492,7 @@
         "url": "https://www.instagram.com/p/DUn5shSD-Wy/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319683893166201",
         "posted_at": "2026-04-08T06:12:00.513362+00:00",
         "section": "instagram",
@@ -501,7 +501,7 @@
         "url": "https://www.instagram.com/p/DUYmFtqjihc/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319691225075863",
         "posted_at": "2026-04-08T06:12:02.235597+00:00",
         "section": "instagram",
@@ -510,7 +510,7 @@
         "url": "https://www.instagram.com/p/DM1yR2DsscV/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319698988597308",
         "posted_at": "2026-04-08T06:12:04.287460+00:00",
         "section": "instagram",
@@ -519,7 +519,7 @@
         "url": "https://www.instagram.com/p/DW2yyoqI98H/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319707935178883",
         "posted_at": "2026-04-08T06:12:06.333390+00:00",
         "section": "instagram",
@@ -528,7 +528,7 @@
         "url": "https://www.instagram.com/p/DW12u8_DIp4/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319715946303508",
         "posted_at": "2026-04-08T06:12:08.102237+00:00",
         "section": "instagram",
@@ -537,7 +537,7 @@
         "url": "https://www.instagram.com/p/DW1mE_tjOsS/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319723701440512",
         "posted_at": "2026-04-08T06:12:10.100094+00:00",
         "section": "instagram",
@@ -546,7 +546,7 @@
         "url": "https://www.instagram.com/p/DW1aFieibhN/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319731389730817",
         "posted_at": "2026-04-08T06:12:11.750554+00:00",
         "section": "instagram",
@@ -555,7 +555,7 @@
         "url": "https://www.instagram.com/p/DWzK6PzDdlD/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319738687815861",
         "posted_at": "2026-04-08T06:12:13.492271+00:00",
         "section": "instagram",
@@ -564,7 +564,7 @@
         "url": "https://www.instagram.com/p/DAQ2OI7vRoc/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319746161807380",
         "posted_at": "2026-04-08T06:12:15.546383+00:00",
         "section": "instagram",
@@ -573,7 +573,7 @@
         "url": "https://www.instagram.com/p/DW1q5HyDw9y/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319754600747248",
         "posted_at": "2026-04-08T06:12:17.435826+00:00",
         "section": "instagram",
@@ -582,7 +582,7 @@
         "url": "https://www.instagram.com/p/DW13R0JDQN9/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319762058477713",
         "posted_at": "2026-04-08T06:12:19.296676+00:00",
         "section": "instagram",
@@ -591,7 +591,7 @@
         "url": "https://www.instagram.com/p/DWySrQ5DV7T/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319770325319780",
         "posted_at": "2026-04-08T06:12:21.756728+00:00",
         "section": "instagram",
@@ -600,7 +600,7 @@
         "url": "https://www.instagram.com/p/DW2VHTdj5JC/"
       },
       {
-        "channel_id": "1491294533751799809",
+        "channel_id": "592534544708796474",
         "message_id": "1491319780651569313",
         "posted_at": "2026-04-08T06:12:23.874232+00:00",
         "section": "instagram",


### PR DESCRIPTION
### Motivation
- The stored `channel_id` values for `2026-04-08.items` were incorrect which prevents the evening winners workflow from locating the original source messages for today's retest. 

### Description
- Updated only `discord_daily_posts.json` by replacing every `channel_id` under `2026-04-08.items` from `"1491294533751799809"` to `"592534544708796474"` without changing any `message_id`, `title`, `url`, `posted_at`, or other date entries. 
- This is a one-time, state-only change and does not modify any code, workflows, scheduling, or architecture. 
- Only `discord_daily_posts.json` was modified and JSON formatting/newline at EOF was preserved. 

### Testing
- Validated JSON syntax with `python -m json.tool discord_daily_posts.json` which succeeded. 
- Ran a small Python check to confirm all 36 items under `2026-04-08.items` now report a single unique `channel_id` of `592534544708796474`. 
- Verified the repository diff includes only `discord_daily_posts.json` as the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6034f29a483269adadd14975d7a81)