### PR TITLE
feat: re-enable automatic evening cadence for daily game picks winners

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -2,6 +2,10 @@ name: Daily Game Picks Winners
 
 on:
   workflow_dispatch:
+  schedule:
+    # GitHub Actions cron uses UTC only (no timezone/DST support).
+    # This runs at 23:00 UTC year-round: 7:00 PM in New York during EDT, 6:00 PM during EST.
+    - cron: "0 23 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- The Daily Game Picks Winners workflow was manual-only and is the last remaining roadmap item to restore automatic evening runs. 
- The intent is to enable an automatic nightly run around 7:00 PM New York time while preserving manual dispatch support.

### Description
- Restored a `schedule` trigger in `.github/workflows/evening-winners.yml` alongside the existing `workflow_dispatch` trigger. 
- Added cron `0 23 * * *` with a UTC/DST comment noting this runs at 23:00 UTC (7:00 PM New York during EDT, 6:00 PM during EST). 
- Kept all winners behavior and script logic unchanged and preserved use of `DISCORD_BOT_TOKEN` and `DISCORD_WINNERS_CHANNEL_ID` in the workflow. 
- This change re-enables the final remaining roadmap item by restoring the automatic evening cadence for winners.

### Testing
- Validated YAML parsing via `ruby -e 'require "yaml"; ...'`, confirming `on` contains both `workflow_dispatch` and `schedule` and the cron is `0 23 * * *` (success). 
- Verified the workflow step still exposes `DISCORD_BOT_TOKEN` and `DISCORD_WINNERS_CHANNEL_ID` (success). 
- Confirmed `git diff --name-only` shows only `.github/workflows/evening-winners.yml` was modified (success). 
- Attempted to validate with a Python `yaml` check but `PyYAML` was not installed in the environment so that specific check was skipped (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60d70e19c8326a319313c704177d0)