### PR TITLE
chore: prune discord daily posts history to latest 30 days

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ STATE_FILE = "seen_ids.json"
 PAGE_STATE_FILE = "page_state.json"
 INSTAGRAM_STATE_FILE = "instagram_seen.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
+DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -798,8 +799,18 @@ def load_discord_daily_posts() -> Dict[str, dict]:
 
 
 def save_discord_daily_posts(data: Dict[str, dict]) -> None:
+    data = prune_discord_daily_posts(data)
     with open(DISCORD_DAILY_POSTS_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, sort_keys=True)
+
+
+def prune_discord_daily_posts(data: Dict[str, dict]) -> Dict[str, dict]:
+    if len(data) <= DISCORD_DAILY_POSTS_RETENTION_DAYS:
+        return data
+
+    retained_keys = sorted(data.keys())[-DISCORD_DAILY_POSTS_RETENTION_DAYS:]
+    retained_key_set = set(retained_keys)
+    return {key: value for key, value in data.items() if key in retained_key_set}
 
 
 def add_thumbs_up_reaction(channel_id: str, message_id: str) -> None:


### PR DESCRIPTION
### Motivation
- `discord_daily_posts.json` currently grows without bound while the winners workflow only needs recent days, so add a minimal retention policy to avoid unbounded state growth.

### Description
- Modified `main.py` only: added `DISCORD_DAILY_POSTS_RETENTION_DAYS = 30`, implemented `prune_discord_daily_posts(data)` that lexically sorts ISO date keys and keeps the newest 30 keys, and invoked pruning from `save_discord_daily_posts(...)` so pruning runs automatically on every save while preserving retained-day entries exactly as-is; no changes to `evening_winners.py` or any workflow/calendar/winner/business logic.

### Testing
- Ran `python -m py_compile main.py` successfully to validate syntax.
- Performed a local validation script that created 35 ISO-date keys, ran `prune_discord_daily_posts(...)`, and confirmed the result contained exactly `30` keys with the expected oldest/newest retained keys and that retained values were unchanged, demonstrating pruning behavior works as intended.

This is a safe retention-only cleanup and should not impact morning picks or evening winners logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6102f2f8883269d6ef15da6e72b17)