### PR TITLE
PR 1 — Safety & Infrastructure: idempotent Discord posts, shared state helpers, and recovery

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,11 @@ name: Steam Free Games
 
 on:
   workflow_dispatch:
+    inputs:
+      daily_date_utc:
+        description: "Optional UTC date key (YYYY-MM-DD) for manual rerun state targeting"
+        required: false
+        type: string
   schedule:
     # GitHub Actions cron uses UTC only (no timezone/DST support).
     # This runs at 13:00 UTC year-round: 9:00 AM in New York during EDT, 8:00 AM during EST.
@@ -36,6 +41,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
         run: python main.py
 
       - name: Save updated state files

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -2,6 +2,11 @@ name: Daily Game Picks Winners
 
 on:
   workflow_dispatch:
+    inputs:
+      winners_date_utc:
+        description: "Optional UTC date key (YYYY-MM-DD) for manual winners rerun"
+        required: false
+        type: string
   schedule:
     # GitHub Actions cron uses UTC only (no timezone/DST support).
     # This runs at 23:00 UTC year-round: 7:00 PM in New York during EDT, 6:00 PM during EST.
@@ -30,4 +35,5 @@ jobs:
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python evening_winners.py

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -2,6 +2,11 @@ name: Weekly Scheduling Bot
 
 on:
   workflow_dispatch:
+    inputs:
+      schedule_week_start:
+        description: 'Optional Monday date (YYYY-MM-DD) to target instead of next week'
+        required: false
+        type: string
   schedule:
     - cron: '0 13 * * 6'
 
@@ -28,6 +33,7 @@ jobs:
         env:
           DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
           DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+          SCHEDULE_WEEK_START: ${{ inputs.schedule_week_start }}
         run: python scripts/post_weekly_availability.py
 
       - name: Commit weekly schedule state

--- a/discord_api.py
+++ b/discord_api.py
@@ -1,0 +1,117 @@
+"""Small Discord API helper utilities with retry and recovery signals."""
+
+import time
+from typing import Any
+
+import requests
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+DEFAULT_TIMEOUT_SECONDS = 30
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+
+class DiscordApiError(RuntimeError):
+    def __init__(self, message: str, response: requests.Response | None = None):
+        super().__init__(message)
+        self.response = response
+
+
+class DiscordMessageNotFoundError(DiscordApiError):
+    pass
+
+
+class DiscordClient:
+    def __init__(self, session: requests.Session, *, timeout: int = DEFAULT_TIMEOUT_SECONDS, max_retries: int = 5):
+        self.session = session
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+    def request(self, method: str, url: str, *, context: str, json_payload: dict[str, Any] | None = None, params: dict[str, Any] | None = None) -> requests.Response:
+        last_error: Exception | None = None
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.session.request(method=method, url=url, json=json_payload, params=params, timeout=self.timeout)
+            except requests.RequestException as error:
+                last_error = error
+                if attempt == self.max_retries:
+                    raise DiscordApiError(f"{context} failed after retries: {error}") from error
+                sleep_seconds = float(attempt)
+                print(f"DISCORD RETRY: {context}; attempt={attempt}/{self.max_retries}; request exception={error}; sleeping {sleep_seconds:.1f}s")
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code in RETRY_STATUSES:
+                if attempt == self.max_retries:
+                    self._raise_for_status(response, context)
+                sleep_seconds = self._get_retry_after_seconds(response, attempt)
+                print(f"DISCORD RETRY: {context}; attempt={attempt}/{self.max_retries}; status={response.status_code}; sleeping {sleep_seconds:.1f}s")
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code == 404 and self._is_unknown_message(response):
+                raise DiscordMessageNotFoundError(f"{context}: Discord message not found", response=response)
+
+            self._raise_for_status(response, context)
+            return response
+
+        raise DiscordApiError(f"{context} exhausted retries unexpectedly: {last_error}")
+
+    def get_message(self, channel_id: str, message_id: str, *, context: str) -> dict[str, Any]:
+        response = self.request("GET", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context)
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def post_message(self, channel_id: str, content: str, *, context: str) -> dict[str, Any]:
+        response = self.request("POST", f"{DISCORD_API_BASE}/channels/{channel_id}/messages", context=context, json_payload={"content": content})
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def edit_message(self, channel_id: str, message_id: str, content: str, *, context: str) -> dict[str, Any]:
+        response = self.request("PATCH", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context, json_payload={"content": content})
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def put_reaction(self, channel_id: str, message_id: str, encoded_emoji: str, *, context: str) -> None:
+        self.request("PUT", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{encoded_emoji}/@me", context=context)
+
+    @staticmethod
+    def _parse_json_object(response: requests.Response, context: str) -> dict[str, Any]:
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise DiscordApiError(f"{context} was not valid JSON") from error
+        if not isinstance(payload, dict):
+            raise DiscordApiError(f"{context} did not return an object")
+        return payload
+
+    @staticmethod
+    def _get_retry_after_seconds(response: requests.Response, attempt: int) -> float:
+        header_value = response.headers.get("Retry-After")
+        if header_value is not None:
+            try:
+                return max(float(header_value), 0.0)
+            except ValueError:
+                pass
+
+        try:
+            payload = response.json()
+            retry_after = payload.get("retry_after")
+            if isinstance(retry_after, (int, float)):
+                return max(float(retry_after), 0.0)
+        except ValueError:
+            pass
+
+        return float(attempt)
+
+    @staticmethod
+    def _is_unknown_message(response: requests.Response) -> bool:
+        try:
+            payload = response.json()
+        except ValueError:
+            return False
+        return isinstance(payload, dict) and int(payload.get("code", 0)) == 10008
+
+    @staticmethod
+    def _raise_for_status(response: requests.Response, context: str) -> None:
+        if response.ok:
+            return
+        body = response.text[:500]
+        raise DiscordApiError(f"{context} failed: HTTP {response.status_code}; body={body}", response=response)

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -1,21 +1,19 @@
-import json
+import hashlib
 import os
-import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import requests
 
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import load_json_object, save_json_object_atomic
+
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
-DISCORD_API_BASE = "https://discord.com/api/v10"
 THUMBS_UP_EMOJI = "👍"
-MAX_RETRIES = 5
-BASE_BACKOFF_SECONDS = 2
-REQUEST_TIMEOUT_SECONDS = 30
 
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
-
+WINNERS_DATE_OVERRIDE_ENV = "WINNERS_DATE_UTC"
 
 SECTION_CONFIG = {
     "free": "Free Picks",
@@ -26,69 +24,19 @@ SECTION_ORDER = ["free", "paid", "instagram"]
 
 
 def load_discord_daily_posts() -> Dict[str, dict]:
-    if not os.path.exists(DISCORD_DAILY_POSTS_FILE):
-        return {}
-
-    with open(DISCORD_DAILY_POSTS_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
-
-    return data if isinstance(data, dict) else {}
+    return load_json_object(DISCORD_DAILY_POSTS_FILE, log=print)
 
 
-def request_with_retry(method: str, url: str, headers: Dict[str, str], json_payload: Optional[dict] = None) -> requests.Response:
-    last_exc: Optional[Exception] = None
-
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            response = requests.request(
-                method=method,
-                url=url,
-                headers=headers,
-                json=json_payload,
-                timeout=REQUEST_TIMEOUT_SECONDS,
-            )
-
-            if response.status_code in (429, 500, 502, 503, 504):
-                retry_after = response.headers.get("Retry-After")
-                if retry_after:
-                    try:
-                        sleep_seconds = max(float(retry_after), 0.0)
-                    except ValueError:
-                        sleep_seconds = BASE_BACKOFF_SECONDS * attempt
-                else:
-                    sleep_seconds = BASE_BACKOFF_SECONDS * attempt
-
-                if attempt == MAX_RETRIES:
-                    response.raise_for_status()
-
-                print(
-                    f"RETRYABLE DISCORD ERROR: status={response.status_code} attempt={attempt}/{MAX_RETRIES}; sleeping {sleep_seconds:.1f}s"
-                )
-                time.sleep(sleep_seconds)
-                continue
-
-            response.raise_for_status()
-            return response
-        except requests.RequestException as exc:
-            last_exc = exc
-            if attempt == MAX_RETRIES:
-                raise
-
-            sleep_seconds = BASE_BACKOFF_SECONDS * attempt
-            print(
-                f"REQUEST EXCEPTION: attempt={attempt}/{MAX_RETRIES}; sleeping {sleep_seconds:.1f}s | error={exc}"
-            )
-            time.sleep(sleep_seconds)
-
-    if last_exc:
-        raise last_exc
-    raise RuntimeError("request_with_retry exhausted retries unexpectedly")
+def save_discord_daily_posts(data: Dict[str, dict]) -> None:
+    save_json_object_atomic(DISCORD_DAILY_POSTS_FILE, data)
 
 
-def fetch_message(channel_id: str, message_id: str, headers: Dict[str, str]) -> dict:
-    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
-    response = request_with_retry("GET", url, headers)
-    return response.json()
+def get_target_day_key() -> str:
+    manual_day = (os.getenv(WINNERS_DATE_OVERRIDE_ENV, "") or "").strip()
+    if not manual_day:
+        return datetime.now(timezone.utc).date().isoformat()
+    datetime.fromisoformat(manual_day)
+    return manual_day
 
 
 def get_thumbsup_count(message_payload: dict) -> int:
@@ -123,9 +71,12 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
     return "\n".join(lines).strip()
 
 
-def post_winners_message(channel_id: str, headers: Dict[str, str], message: str) -> None:
-    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
-    request_with_retry("POST", url, headers, json_payload={"content": message})
+def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
+    payload = client.post_message(channel_id, message, context="post winners message")
+    message_id = str(payload.get("id", ""))
+    if not message_id:
+        raise RuntimeError("Discord response missing winners message id")
+    return message_id
 
 
 def main() -> None:
@@ -134,45 +85,106 @@ def main() -> None:
     if not DISCORD_WINNERS_CHANNEL_ID:
         raise RuntimeError("DISCORD_WINNERS_CHANNEL_ID is not set.")
 
-    daily_posts = load_discord_daily_posts()
-    day_key = datetime.now(timezone.utc).date().isoformat()
-    today_entry = daily_posts.get(day_key, {})
-    items = today_entry.get("items", []) if isinstance(today_entry, dict) else []
+    day_key = get_target_day_key()
+    print(f"Starting evening winners for day={day_key}")
 
-    headers = {
-        "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-        "Content-Type": "application/json",
-    }
+    daily_posts = load_discord_daily_posts()
+    today_entry = daily_posts.get(day_key, {})
+    if not isinstance(today_entry, dict):
+        today_entry = {}
+        daily_posts[day_key] = today_entry
+    items = today_entry.get("items", []) if isinstance(today_entry, dict) else []
 
     winners_by_section: Dict[str, List[dict]] = {key: [] for key in SECTION_ORDER}
 
-    for item in items:
-        section = item.get("section")
-        channel_id = item.get("channel_id")
-        message_id = item.get("message_id")
-
-        if section not in SECTION_CONFIG:
-            continue
-        if not channel_id or not message_id:
-            continue
-
-        message_payload = fetch_message(channel_id=str(channel_id), message_id=str(message_id), headers=headers)
-        raw_thumbsup_count = get_thumbsup_count(message_payload)
-        human_votes = raw_thumbsup_count - 1
-
-        if human_votes < 1:
-            continue
-
-        winners_by_section[section].append(
+    with requests.Session() as session:
+        session.headers.update(
             {
-                "title": item.get("title", "Untitled"),
-                "url": item.get("url", ""),
-                "human_votes": human_votes,
+                "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+                "Content-Type": "application/json",
             }
         )
+        client = DiscordClient(session)
 
-    message = build_winners_message(winners_by_section)
-    post_winners_message(DISCORD_WINNERS_CHANNEL_ID, headers, message)
+        for item in items:
+            section = item.get("section")
+            channel_id = item.get("channel_id")
+            message_id = item.get("message_id")
+
+            if section not in SECTION_CONFIG:
+                continue
+            if not channel_id or not message_id:
+                continue
+
+            try:
+                message_payload = client.get_message(
+                    channel_id=str(channel_id),
+                    message_id=str(message_id),
+                    context=f"fetch votes for {item.get('title', 'item')}",
+                )
+            except DiscordMessageNotFoundError:
+                print(f"RECOVER: stale/deleted daily item message skipped (message_id={message_id})")
+                continue
+
+            raw_thumbsup_count = get_thumbsup_count(message_payload)
+            human_votes = raw_thumbsup_count - 1
+
+            if human_votes < 1:
+                continue
+
+            winners_by_section[section].append(
+                {
+                    "title": item.get("title", "Untitled"),
+                    "url": item.get("url", ""),
+                    "human_votes": human_votes,
+                }
+            )
+
+        message = build_winners_message(winners_by_section)
+        winners_state = today_entry.get("winners_state")
+        if not isinstance(winners_state, dict):
+            winners_state = {}
+            today_entry["winners_state"] = winners_state
+
+        content_hash = hashlib.sha256(message.encode("utf-8")).hexdigest()
+        previous_message_id = winners_state.get("message_id")
+        previous_content_hash = winners_state.get("content_hash")
+
+        if isinstance(previous_message_id, str) and previous_message_id:
+            try:
+                client.get_message(
+                    DISCORD_WINNERS_CHANNEL_ID,
+                    previous_message_id,
+                    context=f"verify winners message for {day_key}",
+                )
+                if previous_content_hash == content_hash:
+                    print(f"SKIP: winners already posted and unchanged for {day_key}")
+                    return
+                client.edit_message(
+                    DISCORD_WINNERS_CHANNEL_ID,
+                    previous_message_id,
+                    message,
+                    context=f"edit winners message for {day_key}",
+                )
+                winners_state["content_hash"] = content_hash
+                winners_state["last_action"] = "edit"
+                winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+                save_discord_daily_posts(daily_posts)
+                print(f"EDIT: updated winners message for {day_key} (message_id={previous_message_id})")
+                return
+            except DiscordMessageNotFoundError:
+                print(
+                    f"RECOVER: stale/deleted winners message for {day_key} "
+                    f"(message_id={previous_message_id}); posting replacement"
+                )
+
+        new_message_id = post_winners_message(client, DISCORD_WINNERS_CHANNEL_ID, message)
+        winners_state["message_id"] = new_message_id
+        winners_state["content_hash"] = content_hash
+        winners_state["last_action"] = "create"
+        winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
+        save_discord_daily_posts(daily_posts)
+        print(f"CREATE: posted winners message for {day_key} (message_id={new_message_id})")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import time
+import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -12,6 +13,12 @@ try:
     import instaloader
 except ImportError:
     instaloader = None
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import (
+    load_json_object,
+    prune_latest_iso_dates,
+    save_json_object_atomic,
+)
 
 WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
@@ -20,6 +27,7 @@ PAGE_STATE_FILE = "page_state.json"
 INSTAGRAM_STATE_FILE = "instagram_seen.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
+DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -786,50 +794,52 @@ def post_to_discord_with_metadata(message: str, capture_metadata: bool = False) 
 
 
 def load_discord_daily_posts() -> Dict[str, dict]:
-    if not os.path.exists(DISCORD_DAILY_POSTS_FILE):
-        return {}
-
-    try:
-        with open(DISCORD_DAILY_POSTS_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return data if isinstance(data, dict) else {}
-    except Exception as e:
-        print(f"LOAD DISCORD DAILY POSTS FAILED: error={e}")
-        return {}
+    return load_json_object(DISCORD_DAILY_POSTS_FILE, log=print)
 
 
 def save_discord_daily_posts(data: Dict[str, dict]) -> None:
     data = prune_discord_daily_posts(data)
-    with open(DISCORD_DAILY_POSTS_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, sort_keys=True)
+    save_json_object_atomic(DISCORD_DAILY_POSTS_FILE, data)
 
 
 def prune_discord_daily_posts(data: Dict[str, dict]) -> Dict[str, dict]:
-    if len(data) <= DISCORD_DAILY_POSTS_RETENTION_DAYS:
-        return data
-
-    retained_keys = sorted(data.keys())[-DISCORD_DAILY_POSTS_RETENTION_DAYS:]
-    retained_key_set = set(retained_keys)
-    return {key: value for key, value in data.items() if key in retained_key_set}
+    pruned = prune_latest_iso_dates(data, DISCORD_DAILY_POSTS_RETENTION_DAYS, log=print)
+    if len(pruned) < len(data):
+        print(f"RETENTION: pruned daily posts state from {len(data)} to {len(pruned)} day keys")
+    return pruned
 
 
-def add_thumbs_up_reaction(channel_id: str, message_id: str) -> None:
+def get_target_day_key() -> str:
+    manual_day = (os.getenv(DAILY_DATE_OVERRIDE_ENV, "") or "").strip()
+    if not manual_day:
+        return datetime.now(timezone.utc).date().isoformat()
+    try:
+        datetime.fromisoformat(manual_day)
+    except ValueError:
+        raise RuntimeError(f"{DAILY_DATE_OVERRIDE_ENV} must be YYYY-MM-DD")
+    return manual_day
+
+
+def add_thumbs_up_reaction(client: DiscordClient, channel_id: str, message_id: str) -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
+    client.put_reaction(
+        channel_id,
+        message_id,
+        "%F0%9F%91%8D",
+        context=f"add thumbs-up reaction channel={channel_id} message={message_id}",
+    )
 
-    reaction_url = (
-        f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}/"
-        "reactions/%F0%9F%91%8D/@me"
-    )
-    response = requests.put(
-        reaction_url,
-        headers={
-            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-            "Content-Type": "application/json",
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
+
+def message_exists(client: DiscordClient, channel_id: str, message_id: str, context: str) -> bool:
+    try:
+        client.get_message(channel_id, message_id, context=context)
+        return True
+    except DiscordMessageNotFoundError:
+        return False
+    except Exception as error:
+        print(f"WARN: failed to verify existing message ({context}): {error}")
+        return False
 
 
 def record_posted_item(
@@ -839,6 +849,7 @@ def record_posted_item(
     title: str,
     url: str,
     source_type: str,
+    item_key: str,
     message_id: str,
     channel_id: Optional[str],
 ) -> None:
@@ -850,6 +861,7 @@ def record_posted_item(
             items = day_entry["items"]
 
         item_record = {
+            "item_key": item_key,
             "section": section,
             "title": title,
             "url": url,
@@ -858,7 +870,14 @@ def record_posted_item(
             "source_type": source_type,
             "posted_at": utc_now_iso(),
         }
-        items.append(item_record)
+        existing_index = next(
+            (index for index, existing in enumerate(items) if isinstance(existing, dict) and existing.get("item_key") == item_key),
+            None,
+        )
+        if existing_index is None:
+            items.append(item_record)
+        else:
+            items[existing_index] = item_record
         save_discord_daily_posts(daily_posts)
     except Exception as e:
         print(f"RECORD DAILY DISCORD ITEM FAILED: title={title} | error={e}")
@@ -876,97 +895,149 @@ def post_daily_pick_messages(free_items: List[dict], paid_items: List[dict], ins
 
     token_available = bool(DISCORD_BOT_TOKEN)
     daily_posts = load_discord_daily_posts() if token_available else {}
-    day_key = datetime.now(timezone.utc).date().isoformat()
+    day_key = get_target_day_key()
+    day_entry = daily_posts.setdefault(day_key, {})
+    if not isinstance(day_entry, dict):
+        day_entry = {}
+        daily_posts[day_key] = day_entry
 
     if not token_available:
         print("DISCORD_BOT_TOKEN missing; skipping auto-reactions and message-ID tracking.")
+    else:
+        print(f"Daily picks target day={day_key}")
 
-    post_to_discord("🎯 Daily Picks — vote with 👍 on your favorites")
+    run_state = day_entry.get("run_state")
+    if not isinstance(run_state, dict):
+        run_state = {}
+        day_entry["run_state"] = run_state
+    run_state.setdefault("section_headers", {})
+    run_state["last_attempt_at_utc"] = utc_now_iso()
+
+    if bool(run_state.get("completed")):
+        print(f"SKIP: daily picks already completed for {day_key}; rerun protection active")
+        save_discord_daily_posts(daily_posts)
+        return
+
+    discord_client: Optional[DiscordClient] = None
+    if token_available:
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+                "Content-Type": "application/json",
+            }
+        )
+        discord_client = DiscordClient(session)
+
+    def post_or_reuse_simple(message: str, state_key: str, state_obj: dict) -> None:
+        existing_message_id = state_obj.get("message_id")
+        existing_channel_id = state_obj.get("channel_id")
+        if (
+            token_available
+            and discord_client
+            and isinstance(existing_message_id, str)
+            and isinstance(existing_channel_id, str)
+            and message_exists(
+                discord_client,
+                existing_channel_id,
+                existing_message_id,
+                context=f"verify {state_key} for {day_key}",
+            )
+        ):
+            print(f"REUSE: {state_key} for {day_key} (message_id={existing_message_id})")
+            return
+
+        metadata = post_to_discord_with_metadata(message, capture_metadata=token_available)
+        if metadata and metadata.get("message_id"):
+            state_obj["message_id"] = metadata["message_id"]
+            state_obj["channel_id"] = metadata.get("channel_id")
+            state_obj["posted_at_utc"] = utc_now_iso()
+            print(f"CREATE: posted {state_key} for {day_key} (message_id={metadata['message_id']})")
+        else:
+            print(f"WARN: missing metadata for {state_key} on {day_key}")
+        save_discord_daily_posts(daily_posts)
+
+    intro_state = run_state.setdefault("intro", {})
+    post_or_reuse_simple("🎯 Daily Picks — vote with 👍 on your favorites", "intro", intro_state)
     sleep_briefly()
 
-    if free_items:
-        post_to_discord("🎮 Free Picks")
+    section_inputs = [
+        ("free", "🎮 Free Picks", free_items, False, "steam_free"),
+        ("paid", "💸 Paid Under $20", paid_items, True, "paid_under_20"),
+        ("instagram", "📸 Instagram Creator Picks", instagram_posts, False, "instagram"),
+    ]
+
+    for section_key, header_message, section_items, is_paid, source_type in section_inputs:
+        if not section_items:
+            continue
+
+        section_headers = run_state.setdefault("section_headers", {})
+        section_state = section_headers.setdefault(section_key, {})
+        post_or_reuse_simple(header_message, f"{section_key}_header", section_state)
         sleep_briefly()
-        for idx, item in enumerate(free_items, start=1):
-            metadata = post_to_discord_with_metadata(
-                format_steam_item_message(item, idx, paid=False),
-                capture_metadata=token_available,
+
+        existing_items = day_entry.get("items")
+        if not isinstance(existing_items, list):
+            existing_items = []
+            day_entry["items"] = existing_items
+
+        for idx, item in enumerate(section_items, start=1):
+            title = item["title"] if section_key != "instagram" else f"@{item['username']}"
+            url = item["url"]
+            item_key = hashlib.sha256(f"{section_key}|{source_type}|{url}".encode("utf-8")).hexdigest()[:16]
+            existing_record = next(
+                (entry for entry in existing_items if isinstance(entry, dict) and entry.get("item_key") == item_key),
+                None,
             )
-            if token_available:
-                if metadata and metadata.get("message_id") and metadata.get("channel_id"):
-                    try:
-                        add_thumbs_up_reaction(metadata["channel_id"], metadata["message_id"])
-                    except Exception as e:
-                        print(f"ADD REACTION FAILED: title={item['title']} | error={e}")
-                    record_posted_item(
-                        daily_posts=daily_posts,
-                        day_key=day_key,
-                        section="free",
-                        title=item["title"],
-                        url=item["url"],
-                        source_type="steam_free",
-                        message_id=metadata["message_id"],
-                        channel_id=metadata["channel_id"],
-                    )
-                else:
-                    print(f"DISCORD MESSAGE METADATA MISSING: title={item['title']}")
+
+            if (
+                token_available
+                and discord_client
+                and isinstance(existing_record, dict)
+                and isinstance(existing_record.get("channel_id"), str)
+                and isinstance(existing_record.get("message_id"), str)
+                and message_exists(
+                    discord_client,
+                    existing_record["channel_id"],
+                    existing_record["message_id"],
+                    context=f"verify {section_key} item for {day_key}",
+                )
+            ):
+                print(f"REUSE: {section_key} item {title} for {day_key}")
+                continue
+
+            content = (
+                format_instagram_item_message(item, idx)
+                if section_key == "instagram"
+                else format_steam_item_message(item, idx, paid=is_paid)
+            )
+            metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
+            if token_available and metadata and metadata.get("message_id") and metadata.get("channel_id"):
+                try:
+                    if discord_client:
+                        add_thumbs_up_reaction(discord_client, metadata["channel_id"], metadata["message_id"])
+                except Exception as e:
+                    print(f"ADD REACTION FAILED: title={title} | error={e}")
+                record_posted_item(
+                    daily_posts=daily_posts,
+                    day_key=day_key,
+                    section=section_key,
+                    title=title,
+                    url=url,
+                    source_type=source_type,
+                    item_key=item_key,
+                    message_id=metadata["message_id"],
+                    channel_id=metadata["channel_id"],
+                )
+                print(f"CREATE: posted {section_key} item {title} for {day_key}")
+            else:
+                print(f"WARN: missing metadata for {section_key} item title={title}")
             sleep_briefly()
 
-    if paid_items:
-        post_to_discord("💸 Paid Under $20")
-        sleep_briefly()
-        for idx, item in enumerate(paid_items, start=1):
-            metadata = post_to_discord_with_metadata(
-                format_steam_item_message(item, idx, paid=True),
-                capture_metadata=token_available,
-            )
-            if token_available:
-                if metadata and metadata.get("message_id") and metadata.get("channel_id"):
-                    try:
-                        add_thumbs_up_reaction(metadata["channel_id"], metadata["message_id"])
-                    except Exception as e:
-                        print(f"ADD REACTION FAILED: title={item['title']} | error={e}")
-                    record_posted_item(
-                        daily_posts=daily_posts,
-                        day_key=day_key,
-                        section="paid",
-                        title=item["title"],
-                        url=item["url"],
-                        source_type="paid_under_20",
-                        message_id=metadata["message_id"],
-                        channel_id=metadata["channel_id"],
-                    )
-                else:
-                    print(f"DISCORD MESSAGE METADATA MISSING: title={item['title']}")
-            sleep_briefly()
-
-    if instagram_posts:
-        post_to_discord("📸 Instagram Creator Picks")
-        sleep_briefly()
-        for idx, post in enumerate(instagram_posts, start=1):
-            metadata = post_to_discord_with_metadata(
-                format_instagram_item_message(post, idx),
-                capture_metadata=token_available,
-            )
-            if token_available:
-                if metadata and metadata.get("message_id") and metadata.get("channel_id"):
-                    try:
-                        add_thumbs_up_reaction(metadata["channel_id"], metadata["message_id"])
-                    except Exception as e:
-                        print(f"ADD REACTION FAILED: username={post['username']} | error={e}")
-                    record_posted_item(
-                        daily_posts=daily_posts,
-                        day_key=day_key,
-                        section="instagram",
-                        title=f"@{post['username']}",
-                        url=post["url"],
-                        source_type="instagram",
-                        message_id=metadata["message_id"],
-                        channel_id=metadata["channel_id"],
-                    )
-                else:
-                    print(f"DISCORD MESSAGE METADATA MISSING: username={post['username']}")
-            sleep_briefly()
+    run_state["completed"] = True
+    run_state["completed_at_utc"] = utc_now_iso()
+    save_discord_daily_posts(daily_posts)
+    print(f"COMPLETE: daily picks state marked completed for {day_key}")
 
 
 def dedupe_by_app_id(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
@@ -1070,6 +1141,7 @@ def fetch_instagram_posts():
     
 def main():
     state = load_state()
+    print(f"Daily run target date (UTC): {get_target_day_key()}")
 
     start_page, end_page = get_page_window()
     print(f"Current rotating page window: {start_page}-{end_page}")

--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -1,17 +1,16 @@
 """Post weekly availability prompts to a Discord scheduling channel and add reactions."""
 
-import json
 import os
 import sys
-import time
 import urllib.parse
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import requests
 
-DISCORD_API_BASE = "https://discord.com/api/v10"
-REQUEST_TIMEOUT_SECONDS = 30
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
+
 USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
 WEEKLY_SCHEDULE_MESSAGES_FILE = "data/scheduling/weekly_schedule_messages.json"
 
@@ -49,222 +48,92 @@ AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "�
 
 
 def fail(message: str) -> None:
-    """Print an error and exit with a non-zero status."""
     print(f"ERROR: {message}", file=sys.stderr)
     sys.exit(1)
 
 
 def require_env(name: str) -> str:
-    """Return a required environment variable or exit if it is missing."""
     value = os.getenv(name)
     if not value:
         fail(f"Missing required environment variable: {name}")
     return value
 
 
-def check_response(response: requests.Response, context: str) -> None:
-    """Exit with details when a Discord API response is not successful."""
-    if not response.ok:
-        print(f"ERROR: {context}", file=sys.stderr)
-        print(f"HTTP status: {response.status_code}", file=sys.stderr)
-        print(f"Response body: {response.text}", file=sys.stderr)
-        sys.exit(1)
+def get_week_bounds(today: date | None = None, manual_week_start: str | None = None) -> tuple[date, date]:
+    if manual_week_start:
+        try:
+            monday = date.fromisoformat(manual_week_start)
+        except ValueError:
+            fail("SCHEDULE_WEEK_START must be in YYYY-MM-DD format")
+        if monday.weekday() != 0:
+            fail("SCHEDULE_WEEK_START must be a Monday")
+        return monday, monday + timedelta(days=6)
 
-
-def build_message_url(channel_id: str) -> str:
-    """Build the Discord API URL for creating a message in a channel."""
-    return f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
-
-
-def build_reaction_url(channel_id: str, message_id: str, emoji: str) -> str:
-    """Build the Discord API URL for adding a reaction to a message."""
-    encoded_emoji = urllib.parse.quote(emoji, safe="")
-    return (
-        f"{DISCORD_API_BASE}/channels/{channel_id}/messages/"
-        f"{message_id}/reactions/{encoded_emoji}/@me"
-    )
-
-
-def get_next_week_bounds(today: date | None = None) -> tuple[date, date]:
-    """Return next week's Monday and Sunday dates."""
     current_date = today or date.today()
-
     days_until_next_monday = (7 - current_date.weekday()) % 7
     if days_until_next_monday == 0:
         days_until_next_monday = 7
-
-    next_monday = current_date + timedelta(days=days_until_next_monday)
-    next_sunday = next_monday + timedelta(days=6)
-    return next_monday, next_sunday
-
-
-def get_next_week_date_range(today: date | None = None) -> str:
-    """Return next week's Monday-Sunday range, formatted for the intro message."""
-    next_monday, next_sunday = get_next_week_bounds(today=today)
-    return format_week_date_range(next_monday, next_sunday)
+    monday = current_date + timedelta(days=days_until_next_monday)
+    return monday, monday + timedelta(days=6)
 
 
 def format_week_date_range(start_date: date, end_date: date) -> str:
-    """Return a Monday-Sunday range formatted for the intro message."""
-    next_monday = start_date
-    next_sunday = end_date
-
-    if next_monday.year == next_sunday.year:
-        if next_monday.month == next_sunday.month:
-            return f"{next_monday:%b} {next_monday.day}–{next_sunday.day}, {next_monday.year}"
-        return f"{next_monday:%b} {next_monday.day}–{next_sunday:%b} {next_sunday.day}, {next_monday.year}"
-
-    return (
-        f"{next_monday:%b} {next_monday.day}, {next_monday.year}"
-        f"–{next_sunday:%b} {next_sunday.day}, {next_sunday.year}"
-    )
+    if start_date.year == end_date.year:
+        if start_date.month == end_date.month:
+            return f"{start_date:%b} {start_date.day}–{end_date.day}, {start_date.year}"
+        return f"{start_date:%b} {start_date.day}–{end_date:%b} {end_date.day}, {start_date.year}"
+    return f"{start_date:%b} {start_date.day}, {start_date.year}–{end_date:%b} {end_date.day}, {end_date.year}"
 
 
 def get_week_key(start_date: date, end_date: date) -> str:
-    """Return the stable week key for persisted message IDs."""
     return f"{start_date.isoformat()}_to_{end_date.isoformat()}"
 
 
-def ensure_parent_dir(path: str) -> None:
-    """Create the parent directory for a file path if needed."""
-    parent_dir = os.path.dirname(path)
-    if parent_dir:
-        try:
-            os.makedirs(parent_dir, exist_ok=True)
-        except OSError as error:
-            fail(f"Failed to create directory {parent_dir}: {error}")
-
-
-def get_current_utc_timestamp() -> str:
-    """Return the current UTC timestamp in ISO-like format with Z suffix."""
+def utc_timestamp() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
-    """Keep only the latest N week entries ordered by week key."""
-    week_keys = sorted(data.keys())
-    if len(week_keys) <= keep_last:
-        return data
-
-    keys_to_keep = set(week_keys[-keep_last:])
-    return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
-
-
-def load_json_file(path: str) -> dict[str, Any]:
-    """Load a JSON object from disk, creating an empty one if missing."""
-    if not os.path.exists(path):
-        save_json_file(path, {})
-        return {}
-
+def try_get_message(client: DiscordClient, channel_id: str, message_id: str, context: str) -> bool:
     try:
-        with open(path, "r", encoding="utf-8") as file:
-            loaded = json.load(file)
-    except json.JSONDecodeError:
-        fail(f"Invalid JSON in {path}")
-    except OSError as error:
-        fail(f"Failed to read {path}: {error}")
-
-    if not isinstance(loaded, dict):
-        fail(f"Expected top-level JSON object in {path}")
-
-    return loaded
+        client.get_message(channel_id, message_id, context=context)
+        return True
+    except DiscordMessageNotFoundError:
+        print(f"RECOVER: stale/deleted Discord message detected ({context}, message_id={message_id})")
+        return False
+    except Exception as error:
+        print(f"WARN: could not verify message ({context}, message_id={message_id}): {error}")
+        return False
 
 
-def save_json_file(path: str, data: dict[str, Any]) -> None:
-    """Write a JSON object to disk using UTF-8 and pretty indentation."""
-    ensure_parent_dir(path)
-
-    try:
-        with open(path, "w", encoding="utf-8") as file:
-            json.dump(data, file, indent=2, ensure_ascii=False)
-            file.write("\n")
-    except OSError as error:
-        fail(f"Failed to write {path}: {error}")
-
-
-def post_message(session: requests.Session, channel_id: str, content: str) -> str:
-    """Post a message and return the created Discord message ID."""
-    url = build_message_url(channel_id)
-    response = session.post(url, json={"content": content}, timeout=REQUEST_TIMEOUT_SECONDS)
-    check_response(response, "Failed to post Discord message")
-
-    try:
-        payload: dict[str, Any] = response.json()
-    except ValueError:
-        fail("Discord response was not valid JSON when posting message")
-
-    message_id = payload.get("id")
-    if not message_id:
-        fail("Discord response JSON did not include message id")
-
-    return str(message_id)
-
-
-def add_reaction(session: requests.Session, channel_id: str, message_id: str, emoji: str) -> None:
-    """Add a single emoji reaction to a posted Discord message."""
-    url = build_reaction_url(channel_id, message_id, emoji)
-    max_attempts = 5
-    transient_statuses = {500, 502, 503, 504}
-
-    for attempt in range(1, max_attempts + 1):
-        try:
-            response = session.put(url, timeout=REQUEST_TIMEOUT_SECONDS)
-        except requests.exceptions.RequestException as error:
-            if attempt < max_attempts:
-                print(
-                    f"Request exception adding reaction {emoji}: {error}. "
-                    "Retrying in 1 second..."
-                )
-                time.sleep(1.0)
-                continue
-            fail(f"Failed to add reaction {emoji} after {max_attempts} attempts: {error}")
-
-        if response.status_code == 429:
-            retry_after_seconds = 1.0
-            try:
-                payload: dict[str, Any] = response.json()
-                retry_after_value = payload.get("retry_after")
-                if isinstance(retry_after_value, (int, float)):
-                    retry_after_seconds = float(retry_after_value)
-                elif isinstance(retry_after_value, str):
-                    retry_after_seconds = float(retry_after_value)
-            except (ValueError, TypeError):
-                retry_after_seconds = 1.0
-
-            if retry_after_seconds < 0:
-                retry_after_seconds = 1.0
-
-            if attempt < max_attempts:
-                print(
-                    f"Rate limited adding reaction {emoji}, "
-                    f"sleeping {retry_after_seconds} seconds before retry"
-                )
-                time.sleep(retry_after_seconds)
-                continue
-            break
-
-        if response.status_code in transient_statuses:
-            if attempt < max_attempts:
-                print(
-                    f"Transient error adding reaction {emoji} "
-                    f"(HTTP {response.status_code}), retrying in 1 second..."
-                )
-                time.sleep(1.0)
-                continue
-            break
-
-        check_response(response, f"Failed to add reaction: {emoji}")
-        return
-
-    check_response(response, f"Failed to add reaction: {emoji}")
+def ensure_day_reactions(client: DiscordClient, channel_id: str, day_name: str, message_id: str) -> None:
+    for reaction in AVAILABILITY_REACTIONS:
+        encoded = urllib.parse.quote(reaction, safe="")
+        client.put_reaction(
+            channel_id,
+            message_id,
+            encoded,
+            context=f"seed reaction {reaction} for {day_name}",
+        )
 
 
 def main() -> None:
-    """Run the weekly availability post flow and seed day-specific reactions."""
     token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
     channel_id = require_env("DISCORD_SCHEDULING_CHANNEL_ID")
+    manual_week_start = os.getenv("SCHEDULE_WEEK_START", "").strip() or None
 
-    print(f"Starting weekly availability post (channel_id={channel_id})")
+    week_start, week_end = get_week_bounds(manual_week_start=manual_week_start)
+    week_key = get_week_key(week_start, week_end)
+    date_range = format_week_date_range(week_start, week_end)
+    intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
+
+    print(
+        f"Starting weekly availability post (channel_id={channel_id}, week_key={week_key}, manual={bool(manual_week_start)})"
+    )
+
+    weekly_messages = load_json_object(WEEKLY_SCHEDULE_MESSAGES_FILE, log=print)
+    existing_week_state = weekly_messages.get(week_key)
+    if not isinstance(existing_week_state, dict):
+        existing_week_state = {}
 
     with requests.Session() as session:
         session.headers.update(
@@ -274,44 +143,67 @@ def main() -> None:
                 "User-Agent": USER_AGENT,
             }
         )
+        client = DiscordClient(session)
 
-        week_start, week_end = get_next_week_bounds()
-        week_key = get_week_key(week_start, week_end)
-        date_range = format_week_date_range(week_start, week_end)
-        intro_message = INTRO_MESSAGE_TEMPLATE.format(date_range=date_range)
+        intro_message_id = existing_week_state.get("intro_message_id")
+        if isinstance(intro_message_id, str) and intro_message_id and try_get_message(
+            client, channel_id, intro_message_id, f"verify intro for {week_key}"
+        ):
+            print(f"REUSE: intro message for {week_key} (message_id={intro_message_id})")
+        else:
+            payload = client.post_message(channel_id, intro_message, context=f"post intro for {week_key}")
+            intro_message_id = str(payload.get("id", ""))
+            if not intro_message_id:
+                fail("Discord response JSON did not include intro message id")
+            print(f"CREATE: intro message for {week_key} (message_id={intro_message_id})")
 
-        intro_message_id = post_message(session, channel_id, intro_message)
-        print(f"Posted intro message (message_id={intro_message_id})")
+        existing_days = existing_week_state.get("days")
+        if not isinstance(existing_days, dict):
+            existing_days = {}
 
         day_message_ids: dict[str, str] = {}
+        created_days = 0
         for day_name, day_message in DAY_MESSAGES:
-            day_message_id = post_message(session, channel_id, day_message)
-            print(f"Posted day message: {day_name} (message_id={day_message_id})")
+            existing_day_id = existing_days.get(day_name)
+            if isinstance(existing_day_id, str) and existing_day_id and try_get_message(
+                client,
+                channel_id,
+                existing_day_id,
+                context=f"verify {day_name} for {week_key}",
+            ):
+                day_message_ids[day_name] = existing_day_id
+                print(f"REUSE: day message {day_name} (message_id={existing_day_id})")
+                continue
+
+            payload = client.post_message(channel_id, day_message, context=f"post {day_name} for {week_key}")
+            day_message_id = str(payload.get("id", ""))
+            if not day_message_id:
+                fail(f"Discord response JSON did not include {day_name} message id")
+
+            ensure_day_reactions(client, channel_id, day_name, day_message_id)
             day_message_ids[day_name] = day_message_id
+            created_days += 1
+            print(f"CREATE: day message {day_name} (message_id={day_message_id})")
 
-            for reaction in AVAILABILITY_REACTIONS:
-                add_reaction(session, channel_id, day_message_id, reaction)
-                print(f"Added reaction {reaction} to {day_name}")
+    weekly_messages[week_key] = {
+        "channel_id": channel_id,
+        "date_range": date_range,
+        "created_at_utc": existing_week_state.get("created_at_utc") or utc_timestamp(),
+        "updated_at_utc": utc_timestamp(),
+        "intro_message_id": intro_message_id,
+        "days": day_message_ids,
+        "post_completed": len(day_message_ids) == len(DAY_MESSAGES),
+    }
 
-        weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
-        weekly_messages[week_key] = {
-            "channel_id": channel_id,
-            "date_range": date_range,
-            "created_at_utc": get_current_utc_timestamp(),
-            "intro_message_id": intro_message_id,
-            "days": day_message_ids,
-        }
-        pruned_weekly_messages = prune_weeks(weekly_messages, keep_last=12)
-        if len(pruned_weekly_messages) < len(weekly_messages):
-            print("Pruned weekly schedule history to last 12 weeks")
+    pruned = prune_latest_keys(weekly_messages, keep_last=12)
+    if len(pruned) < len(weekly_messages):
+        print(f"RETENTION: pruned weekly schedule history from {len(weekly_messages)} to {len(pruned)} weeks")
 
-        save_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned_weekly_messages)
-        print(
-            f"Saved weekly schedule message IDs for {week_key} "
-            f"to {WEEKLY_SCHEDULE_MESSAGES_FILE}"
-        )
-
-    print("Finished successfully")
+    save_json_object_atomic(WEEKLY_SCHEDULE_MESSAGES_FILE, pruned)
+    if created_days == 0 and existing_week_state:
+        print(f"SKIP: week {week_key} already posted and reused")
+    else:
+        print(f"Saved weekly schedule message IDs for {week_key} (created_days={created_days})")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -9,6 +9,9 @@ from typing import Any
 
 import requests
 
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
+
 DISCORD_API_BASE = "https://discord.com/api/v10"
 REQUEST_TIMEOUT_SECONDS = 30
 USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
@@ -56,56 +59,22 @@ def check_response(response: requests.Response, context: str) -> None:
         sys.exit(1)
 
 
-def ensure_parent_dir(path: str) -> None:
-    """Create the parent directory for a file path if needed."""
-    parent_dir = os.path.dirname(path)
-    if parent_dir:
-        try:
-            os.makedirs(parent_dir, exist_ok=True)
-        except OSError as error:
-            fail(f"Failed to create directory {parent_dir}: {error}")
-
-
 def load_json_file(path: str) -> dict[str, Any]:
-    """Load a JSON object from disk, creating an empty one if missing."""
-    if not os.path.exists(path):
-        save_json_file(path, {})
-        return {}
-
-    try:
-        with open(path, "r", encoding="utf-8") as file:
-            loaded = json.load(file)
-    except json.JSONDecodeError:
-        fail(f"Invalid JSON in {path}")
-    except OSError as error:
-        fail(f"Failed to read {path}: {error}")
-
-    if not isinstance(loaded, dict):
-        fail(f"Expected top-level JSON object in {path}")
-
-    return loaded
+    """Load a JSON object from disk."""
+    return load_json_object(path, log=print)
 
 
 def save_json_file(path: str, data: dict[str, Any]) -> None:
-    """Write a JSON object to disk using UTF-8 and pretty indentation."""
-    ensure_parent_dir(path)
-
+    """Write a JSON object to disk using atomic persistence."""
     try:
-        with open(path, "w", encoding="utf-8") as file:
-            json.dump(data, file, indent=2, ensure_ascii=False)
-            file.write("\n")
+        save_json_object_atomic(path, data)
     except OSError as error:
         fail(f"Failed to write {path}: {error}")
 
 
 def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
     """Keep only the latest N week entries ordered by week key."""
-    week_keys = sorted(data.keys())
-    if len(week_keys) <= keep_last:
-        return data
-
-    keys_to_keep = set(week_keys[-keep_last:])
-    return {week_key: data[week_key] for week_key in week_keys if week_key in keys_to_keep}
+    return prune_latest_keys(data, keep_last=keep_last)
 
 
 def build_current_user_url() -> str:
@@ -698,6 +667,7 @@ def main() -> None:
                 "User-Agent": USER_AGENT,
             }
         )
+        discord_client = DiscordClient(posting_session)
 
         summary_message = format_summary_message(date_range, latest_week_summary)
         previous_summary_message_id = week_outputs.get("summary_message_id")
@@ -709,18 +679,48 @@ def main() -> None:
         previous_summary_message_content = week_outputs.get("summary_message_content")
 
         if summary_message_id is None:
-            summary_message_id = post_channel_message(posting_session, channel_id, summary_message)
+            payload = discord_client.post_message(
+                channel_id, summary_message, context=f"post summary for {latest_week_key}"
+            )
+            summary_message_id = str(payload.get("id", ""))
             week_outputs["summary_posted"] = True
             week_outputs["summary_message_id"] = summary_message_id
             week_outputs["summary_message_content"] = summary_message
-            print(f"Posted summary for week {latest_week_key} (message_id={summary_message_id})")
+            print(f"CREATE: posted summary for week {latest_week_key} (message_id={summary_message_id})")
         elif previous_summary_message_content != summary_message:
-            edit_channel_message(posting_session, channel_id, summary_message_id, summary_message)
-            week_outputs["summary_posted"] = True
-            week_outputs["summary_message_content"] = summary_message
-            print(f"Edited summary for week {latest_week_key} (message_id={summary_message_id})")
+            try:
+                discord_client.edit_message(
+                    channel_id,
+                    summary_message_id,
+                    summary_message,
+                    context=f"edit summary for {latest_week_key}",
+                )
+                week_outputs["summary_posted"] = True
+                week_outputs["summary_message_content"] = summary_message
+                print(
+                    f"EDIT: updated summary for week {latest_week_key} "
+                    f"(message_id={summary_message_id})"
+                )
+            except DiscordMessageNotFoundError:
+                print(
+                    f"RECOVER: stale/deleted summary message for week {latest_week_key} "
+                    f"(message_id={summary_message_id}); posting replacement"
+                )
+                payload = discord_client.post_message(
+                    channel_id,
+                    summary_message,
+                    context=f"recover summary for {latest_week_key}",
+                )
+                summary_message_id = str(payload.get("id", ""))
+                week_outputs["summary_posted"] = True
+                week_outputs["summary_message_id"] = summary_message_id
+                week_outputs["summary_message_content"] = summary_message
+                print(
+                    f"RECOVER: posted replacement summary for week {latest_week_key} "
+                    f"(message_id={summary_message_id})"
+                )
         else:
-            print(f"Summary unchanged for week {latest_week_key}; skipping summary edit")
+            print(f"SKIP: summary unchanged for week {latest_week_key}; skipping summary edit")
 
         previous_missing_users = week_outputs.get("reminder_missing_users")
         if not isinstance(previous_missing_users, list):
@@ -736,14 +736,14 @@ def main() -> None:
                 week_outputs["reminder_message_id"] = reminder_message_id
                 week_outputs["reminder_missing_users"] = missing_user_ids
                 print(
-                    f"Posted reminder for week {latest_week_key} "
+                    f"CREATE: posted reminder for week {latest_week_key} "
                     f"(message_id={reminder_message_id}, missing={len(missing_user_ids)})"
                 )
             else:
-                print(f"Reminder unchanged for week {latest_week_key}; skipping reminder post")
+                print(f"SKIP: reminder unchanged for week {latest_week_key}; skipping reminder post")
         else:
             week_outputs["reminder_missing_users"] = []
-            print(f"No missing users for week {latest_week_key}; skipping reminder post")
+            print(f"SKIP: no missing users for week {latest_week_key}; skipping reminder post")
 
     weekly_bot_outputs[latest_week_key] = week_outputs
     pruned_bot_outputs = prune_weeks(weekly_bot_outputs, keep_last=12)

--- a/state_utils.py
+++ b/state_utils.py
@@ -1,0 +1,85 @@
+"""Shared JSON state/retention helpers with atomic writes."""
+
+import json
+import os
+import tempfile
+from datetime import datetime
+from typing import Any, Callable
+
+
+LogFn = Callable[[str], None]
+
+
+def _default_log(message: str) -> None:
+    print(message)
+
+
+def ensure_parent_dir(path: str) -> None:
+    parent_dir = os.path.dirname(path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+
+def load_json_object(path: str, *, default: dict[str, Any] | None = None, log: LogFn | None = None) -> dict[str, Any]:
+    logger = log or _default_log
+    fallback = {} if default is None else default
+
+    if not os.path.exists(path):
+        return dict(fallback)
+
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+    except json.JSONDecodeError as error:
+        logger(f"STATE WARN: invalid JSON in {path}; using default object ({error})")
+        return dict(fallback)
+    except OSError as error:
+        logger(f"STATE WARN: failed to read {path}; using default object ({error})")
+        return dict(fallback)
+
+    if not isinstance(data, dict):
+        logger(f"STATE WARN: expected JSON object in {path}; using default object")
+        return dict(fallback)
+
+    return data
+
+
+def save_json_object_atomic(path: str, data: dict[str, Any]) -> None:
+    ensure_parent_dir(path)
+    directory = os.path.dirname(path) or "."
+
+    fd, temp_path = tempfile.mkstemp(prefix=".tmp-state-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+            json.dump(data, temp_file, indent=2, ensure_ascii=False)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def prune_latest_keys(data: dict[str, Any], keep_last: int) -> dict[str, Any]:
+    if len(data) <= keep_last:
+        return data
+    keys_to_keep = set(sorted(data.keys())[-keep_last:])
+    return {key: value for key, value in data.items() if key in keys_to_keep}
+
+
+def prune_latest_iso_dates(data: dict[str, Any], keep_last: int, *, log: LogFn | None = None) -> dict[str, Any]:
+    if len(data) <= keep_last:
+        return data
+
+    logger = log or _default_log
+
+    def sort_key(key: str) -> tuple[int, datetime | str]:
+        try:
+            return (1, datetime.fromisoformat(key))
+        except ValueError:
+            logger(f"STATE WARN: non-ISO date key encountered during prune: {key}")
+            return (0, key)
+
+    kept_keys = {key for key, _ in sorted(data.items(), key=lambda item: sort_key(item[0]))[-keep_last:]}
+    return {key: value for key, value in data.items() if key in kept_keys}


### PR DESCRIPTION
### Motivation

- Reduce duplicate Discord outputs on workflow reruns by adding idempotency checks and minimal recovery paths. 
- Consolidate repeated state/retention logic and make JSON persistence durable and backward-compatible. 
- Improve diagnostics and standardize Discord request behavior to make GH Actions runs easier to debug and safer to rerun.

### Description

- Added small shared helpers: `discord_api.py` (a `DiscordClient` with retry, typed errors including `DiscordMessageNotFoundError`) and `state_utils.py` (safe JSON load, atomic writes, and shared retention/prune helpers), and wired them into existing flows. (new files `discord_api.py`, `state_utils.py`) 
- Weekly scheduling (`scripts/post_weekly_availability.py`) now verifies/reuses stored `intro_message_id` and per-day message IDs, creates only missing messages, seeds reactions via the shared client, records `updated_at_utc`/`post_completed`, and prunes to the last 12 weeks via shared retention helper. `SCHEDULE_WEEK_START` input is supported for manual runs. 
- Weekly summary/respond sync (`scripts/sync_weekly_schedule_responses.py`) now uses `DiscordClient` for create/edit, skips edits when content is unchanged, and recovers by posting a replacement summary when the stored summary message is deleted/stale; persistence uses atomic writes and shared retention. 
- Morning daily picks (`main.py`) now keeps richer per-day `run_state` (intro/section header state, completion flag), produces stable `item_key` per posted item, verifies stored messages before reuse, posts only missing pieces for partial runs, and supports manual date override via `DAILY_DATE_UTC`; daily posts retention now uses the shared prune helper and atomic writes. 
- Evening winners (`evening_winners.py`) now validates item message IDs, computes winners the same way (human_votes = raw 👍 - 1), then skips if unchanged, edits if changed, or recovers by posting a replacement winners message and updates per-day `winners_state`; supports manual date override via `WINNERS_DATE_UTC`. 
- Minimal workflow additions: optional `workflow_dispatch` inputs added to workflows for manual reruns (`.github/workflows/weekly-scheduling-bot.yml`, `daily.yml`, `evening-winners.yml`). 
- Backward-compatible persistence: new fields are additive only (e.g., `updated_at_utc`, `post_completed`, per-day `run_state`, per-item `item_key`, `winners_state`), and legacy shapes are handled safely by `state_utils.load_json_object`.

### Testing

- Compiled modified and new Python modules to verify syntax: `python -m py_compile scripts/post_weekly_availability.py scripts/sync_weekly_schedule_responses.py main.py evening_winners.py state_utils.py discord_api.py`, which succeeded.
- No additional automated unit tests were added in this PR; recommended follow-ups include unit tests for malformed JSON load/prune, daily `run_state` rerun/partial recovery, winners edit/recovers with simulated 404s, and integration tests with a mocked Discord API to validate partial recovery and summary replacement logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68b5b8f148326957053cfa719e84d)