### PR TITLE
PR 3 — Automated Tests + Validation + Hardening

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 instaloader
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def fixture_dir() -> Path:
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture_json(fixture_dir):
+    def _load(name: str):
+        return json.loads((fixture_dir / name).read_text(encoding="utf-8"))
+
+    return _load

--- a/tests/fixtures/discord_daily_posts_legacy.json
+++ b/tests/fixtures/discord_daily_posts_legacy.json
@@ -1,0 +1,15 @@
+{
+  "2026-04-08": {
+    "items": [
+      {
+        "item_key": "abc123",
+        "section": "free",
+        "title": "Game A",
+        "url": "https://store.steampowered.com/app/1",
+        "message_id": "10",
+        "channel_id": "20",
+        "source_type": "steam_free"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/weekly_messages_legacy.json
+++ b/tests/fixtures/weekly_messages_legacy.json
@@ -1,0 +1,16 @@
+{
+  "2026-04-13_to_2026-04-19": {
+    "thread_id": "chan-1",
+    "date_range": "Apr 13–19, 2026",
+    "intro_message_id": "intro-old",
+    "days": {
+      "Monday": "m-1",
+      "Tuesday": "t-1",
+      "Wednesday": "w-1",
+      "Thursday": "r-1",
+      "Friday": "f-1",
+      "Saturday": "s-1",
+      "Sunday": "u-1"
+    }
+  }
+}

--- a/tests/fixtures/weekly_responses_named_users.json
+++ b/tests/fixtures/weekly_responses_named_users.json
@@ -1,0 +1,33 @@
+{
+  "2026-04-13_to_2026-04-19": {
+    "date_range": "Apr 13–19, 2026",
+    "users": {
+      "100": {
+        "username": "alpha",
+        "global_name": "Alpha",
+        "days": {
+          "Monday": {"reactions": ["✅", "🌙"], "custom_reply": null},
+          "Tuesday": {"reactions": ["🌅"], "custom_reply": null},
+          "Wednesday": {"reactions": ["📝"], "custom_reply": "after 6"},
+          "Thursday": {"reactions": [], "custom_reply": null},
+          "Friday": {"reactions": [], "custom_reply": null},
+          "Saturday": {"reactions": [], "custom_reply": null},
+          "Sunday": {"reactions": [], "custom_reply": null}
+        }
+      },
+      "200": {
+        "username": "beta",
+        "global_name": null,
+        "days": {
+          "Monday": {"reactions": ["✅"], "custom_reply": null},
+          "Tuesday": {"reactions": ["🌅", "☀️"], "custom_reply": null},
+          "Wednesday": {"reactions": ["📝"], "custom_reply": "late"},
+          "Thursday": {"reactions": ["❌"], "custom_reply": null},
+          "Friday": {"reactions": [], "custom_reply": null},
+          "Saturday": {"reactions": [], "custom_reply": null},
+          "Sunday": {"reactions": [], "custom_reply": null}
+        }
+      }
+    }
+  }
+}

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -1,0 +1,137 @@
+import json
+
+import evening_winners as winners
+
+
+class FakeSession:
+    def __init__(self):
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeDiscordClient:
+    def __init__(self, message_payloads, *, stale_winner_id=None, unchanged_hash=None):
+        self.message_payloads = message_payloads
+        self.stale_winner_id = stale_winner_id
+        self.unchanged_hash = unchanged_hash
+        self.posts = []
+        self.edits = []
+
+    def get_message(self, channel_id, message_id, *, context):
+        if self.stale_winner_id and message_id == self.stale_winner_id:
+            raise winners.DiscordMessageNotFoundError("missing")
+        if message_id in self.message_payloads:
+            return self.message_payloads[message_id]
+        return {"id": message_id}
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        self.edits.append((channel_id, message_id, content))
+        return {"id": message_id}
+
+    def post_message(self, channel_id, content, *, context):
+        mid = f"w-{len(self.posts)+1}"
+        self.posts.append((channel_id, content, mid))
+        return {"id": mid}
+
+
+def _setup_daily(tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        day_key: {
+            "items": [
+                {"section": "free", "title": "One", "url": "u1", "channel_id": "c", "message_id": "m1"},
+                {"section": "free", "title": "Two", "url": "u2", "channel_id": "c", "message_id": "m2"},
+                {"section": "paid", "title": "Three", "url": "u3", "channel_id": "c", "message_id": "m3"},
+            ]
+        }
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return day_key, path
+
+
+def test_winner_vote_rules_and_message_content(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    payloads = {
+        "m1": {"reactions": [{"emoji": {"name": "👍"}, "count": 1}]},
+        "m2": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m3": {"reactions": [{"emoji": {"name": "👍"}, "count": 3}]},
+    }
+    fake = FakeDiscordClient(payloads)
+
+    monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
+    monkeypatch.setattr(winners.requests, "Session", FakeSession)
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake)
+    monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
+    monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) == 1
+    content = fake.posts[0][1]
+    assert "One" not in content
+    assert "Two" in content and "👍 1 vote" in content
+    assert "Three" in content and "👍 2 votes" in content
+
+
+def test_winners_rerun_skip_edit_and_recovery(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    same_message = winners.build_winners_message({"free": [], "paid": [], "instagram": []})
+    same_hash = winners.hashlib.sha256(same_message.encode("utf-8")).hexdigest()
+    data[day_key]["winners_state"] = {"message_id": "w-old", "content_hash": same_hash}
+    data[day_key]["items"] = []
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    fake_skip = FakeDiscordClient({}, unchanged_hash=same_hash)
+    monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
+    monkeypatch.setattr(winners.requests, "Session", FakeSession)
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_skip)
+    monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
+    monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
+    winners.main()
+    assert fake_skip.posts == [] and fake_skip.edits == []
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"]["content_hash"] = "different"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    fake_edit = FakeDiscordClient({})
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_edit)
+    winners.main()
+    assert len(fake_edit.edits) == 1
+
+    fake_recover = FakeDiscordClient({}, stale_winner_id="w-old")
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_recover)
+    winners.main()
+    assert len(fake_recover.posts) == 1
+
+
+def test_stale_daily_item_message_is_skipped(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    payloads = {"m2": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]}}
+
+    class ItemStaleClient(FakeDiscordClient):
+        def get_message(self, channel_id, message_id, *, context):
+            if message_id == "m1":
+                raise winners.DiscordMessageNotFoundError("missing item")
+            return super().get_message(channel_id, message_id, context=context)
+
+    fake = ItemStaleClient(payloads)
+    monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
+    monkeypatch.setattr(winners.requests, "Session", FakeSession)
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake)
+    monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
+    monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) == 1
+    assert "Two" in fake.posts[0][1]

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -1,0 +1,86 @@
+import json
+
+import main
+
+
+class FakeDiscordClient:
+    def __init__(self, existing_ids=None, stale_ids=None):
+        self.existing_ids = set(existing_ids or [])
+        self.stale_ids = set(stale_ids or [])
+        self.reactions = []
+
+    def get_message(self, channel_id, message_id, *, context):
+        if message_id in self.stale_ids:
+            raise main.DiscordMessageNotFoundError("gone")
+        if message_id in self.existing_ids:
+            return {"id": message_id}
+        raise RuntimeError("missing")
+
+    def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
+        self.reactions.append((channel_id, message_id, encoded_emoji))
+
+
+def test_prune_daily_posts_retains_latest_30():
+    data = {f"2026-03-{day:02d}": {"items": []} for day in range(1, 32)}
+    pruned = main.prune_discord_daily_posts(data)
+
+    assert len(pruned) == 30
+    assert "2026-03-01" not in pruned
+    assert "2026-03-31" in pruned
+
+
+def test_daily_pick_rerun_and_partial_recovery(monkeypatch, tmp_path, load_fixture_json):
+    daily_path = tmp_path / "daily.json"
+    initial = load_fixture_json("discord_daily_posts_legacy.json")
+    day_key = "2026-04-08"
+    initial[day_key]["items"][0]["title"] = "Game A"
+    initial[day_key]["items"][0]["url"] = "https://store.steampowered.com/app/1"
+    initial[day_key]["items"][0]["item_key"] = main.hashlib.sha256(
+        "free|steam_free|https://store.steampowered.com/app/1".encode("utf-8")
+    ).hexdigest()[:16]
+    initial[day_key]["run_state"] = {
+        "intro": {"message_id": "intro-1", "channel_id": "chan-1"},
+        "section_headers": {"free": {"message_id": "header-1", "channel_id": "chan-1"}},
+        "completed": False,
+    }
+    daily_path.write_text(json.dumps(initial), encoding="utf-8")
+
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        counter["i"] += 1
+        posted.append(message)
+        return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient(existing_ids={"intro-1", "header-1", "10"})
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [
+        {"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9},
+        {"title": "Game B", "url": "https://store.steampowered.com/app/2", "price": "Free", "score": 8},
+    ]
+    main.post_daily_pick_messages(free_items, [], [])
+
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert any("Game B" in msg for msg in posted)
+    assert saved[day_key]["run_state"]["completed"] is True
+    assert len(fake_client.reactions) == 1  # only new item gets default 👍
+
+    posted_before = len(posted)
+    main.post_daily_pick_messages(free_items, [], [])
+    assert len(posted) == posted_before
+
+
+def test_load_discord_daily_posts_handles_old_shapes(monkeypatch, tmp_path):
+    path = tmp_path / "daily.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(path))
+
+    assert main.load_discord_daily_posts() == {}

--- a/tests/test_state_utils.py
+++ b/tests/test_state_utils.py
@@ -1,0 +1,46 @@
+import json
+
+from state_utils import load_json_object, prune_latest_iso_dates, prune_latest_keys, save_json_object_atomic
+
+
+def test_load_json_object_returns_default_for_invalid_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{oops", encoding="utf-8")
+
+    assert load_json_object(str(path), default={"ok": 1}) == {"ok": 1}
+
+
+def test_load_json_object_returns_default_for_non_dict(tmp_path):
+    path = tmp_path / "arr.json"
+    path.write_text("[1,2,3]", encoding="utf-8")
+
+    assert load_json_object(str(path), default={"ok": True}) == {"ok": True}
+
+
+def test_save_json_object_atomic_writes_expected_json(tmp_path):
+    path = tmp_path / "state" / "x.json"
+    save_json_object_atomic(str(path), {"b": 2, "a": 1})
+
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved == {"b": 2, "a": 1}
+
+
+def test_prune_latest_keys_keeps_newest_keys():
+    data = {f"week-{i:02d}": i for i in range(1, 16)}
+    pruned = prune_latest_keys(data, keep_last=12)
+
+    assert len(pruned) == 12
+    assert "week-01" not in pruned
+    assert "week-15" in pruned
+
+
+def test_prune_latest_iso_dates_handles_mixed_keys_safely():
+    data = {
+        "2026-01-01": 1,
+        "not-a-date": 2,
+        "2026-03-01": 3,
+        "2026-02-01": 4,
+    }
+    pruned = prune_latest_iso_dates(data, keep_last=2, log=lambda _: None)
+
+    assert set(pruned.keys()) == {"2026-02-01", "2026-03-01"}

--- a/tests/test_weekly_post_availability.py
+++ b/tests/test_weekly_post_availability.py
@@ -1,0 +1,108 @@
+import json
+
+from scripts import post_weekly_availability as weekly
+
+
+class FakeSession:
+    def __init__(self):
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeClient:
+    def __init__(self, existing_message_ids=None, stale_ids=None):
+        self.existing = set(existing_message_ids or [])
+        self.stale = set(stale_ids or [])
+        self.created_messages = []
+        self.reaction_calls = []
+
+    def get_message(self, channel_id, message_id, *, context):
+        if message_id in self.stale:
+            raise weekly.DiscordMessageNotFoundError("gone")
+        if message_id in self.existing:
+            return {"id": message_id}
+        raise RuntimeError("not verifiable")
+
+    def post_message(self, channel_id, content, *, context):
+        new_id = f"new-{len(self.created_messages) + 1}"
+        self.created_messages.append((context, content, new_id))
+        return {"id": new_id}
+
+    def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
+        self.reaction_calls.append((message_id, encoded_emoji))
+
+
+def _run_main(monkeypatch, tmp_path, *, existing_state, fake_client):
+    path = tmp_path / "weekly_messages.json"
+    path.write_text(json.dumps(existing_state), encoding="utf-8")
+
+    monkeypatch.setattr(weekly, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(path))
+    monkeypatch.setattr(weekly.requests, "Session", FakeSession)
+    monkeypatch.setattr(weekly, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("DISCORD_SCHEDULING_CHANNEL_ID", "chan-1")
+    monkeypatch.setenv("SCHEDULE_WEEK_START", "2026-04-13")
+
+    weekly.main()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_rerun_reuses_intro_and_days_without_duplicates(monkeypatch, tmp_path):
+    week_key = "2026-04-13_to_2026-04-19"
+    existing = {
+        week_key: {
+            "channel_id": "chan-1",
+            "date_range": "Apr 13–19, 2026",
+            "created_at_utc": "2026-04-01T00:00:00Z",
+            "intro_message_id": "intro-1",
+            "days": {day: f"id-{day}" for day, _ in weekly.DAY_MESSAGES},
+        }
+    }
+    fake = FakeClient(existing_message_ids={"intro-1", *[f"id-{day}" for day, _ in weekly.DAY_MESSAGES]})
+
+    saved = _run_main(monkeypatch, tmp_path, existing_state=existing, fake_client=fake)
+
+    assert fake.created_messages == []
+    assert saved[week_key]["intro_message_id"] == "intro-1"
+    assert saved[week_key]["post_completed"] is True
+
+
+def test_partial_recovery_only_creates_missing_or_stale_posts(monkeypatch, tmp_path):
+    week_key = "2026-04-13_to_2026-04-19"
+    existing = {
+        week_key: {
+            "channel_id": "chan-1",
+            "date_range": "Apr 13–19, 2026",
+            "intro_message_id": "intro-1",
+            "days": {day: f"id-{day}" for day, _ in weekly.DAY_MESSAGES},
+        }
+    }
+    fake = FakeClient(
+        existing_message_ids={"id-Monday", "id-Tuesday", "id-Thursday", "id-Friday", "id-Saturday", "id-Sunday"},
+        stale_ids={"intro-1", "id-Wednesday"},
+    )
+
+    saved = _run_main(monkeypatch, tmp_path, existing_state=existing, fake_client=fake)
+
+    assert len(fake.created_messages) == 2  # intro + Wednesday only
+    assert saved[week_key]["intro_message_id"].startswith("new-")
+    assert saved[week_key]["days"]["Wednesday"].startswith("new-")
+    assert saved[week_key]["days"]["Monday"] == "id-Monday"
+    assert len(fake.reaction_calls) == len(weekly.AVAILABILITY_REACTIONS)
+
+
+def test_legacy_state_shape_loads_and_upgrades(monkeypatch, tmp_path, load_fixture_json):
+    existing = load_fixture_json("weekly_messages_legacy.json")
+    fake = FakeClient(existing_message_ids={"intro-old", "m-1", "t-1", "w-1", "r-1", "f-1", "s-1", "u-1"})
+
+    saved = _run_main(monkeypatch, tmp_path, existing_state=existing, fake_client=fake)
+    week_key = "2026-04-13_to_2026-04-19"
+
+    assert saved[week_key]["channel_id"] == "chan-1"
+    assert "updated_at_utc" in saved[week_key]
+    assert saved[week_key]["post_completed"] is True

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -1,0 +1,152 @@
+import json
+
+from scripts import sync_weekly_schedule_responses as sync
+
+
+class FakeSession:
+    def __init__(self):
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeDiscordClient:
+    def __init__(self, *, stale_summary_id=None):
+        self.posts = []
+        self.edits = []
+        self.stale_summary_id = stale_summary_id
+
+    def post_message(self, channel_id, content, *, context):
+        mid = f"summary-{len(self.posts)+1}"
+        self.posts.append((channel_id, content, context, mid))
+        return {"id": mid}
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        if self.stale_summary_id and message_id == self.stale_summary_id:
+            raise sync.DiscordMessageNotFoundError("missing")
+        self.edits.append((channel_id, message_id, content, context))
+        return {"id": message_id}
+
+
+def _write(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _setup_files(tmp_path, weekly_responses):
+    week_key = "2026-04-13_to_2026-04-19"
+    messages = {
+        week_key: {
+            "channel_id": "chan-1",
+            "date_range": "Apr 13–19, 2026",
+            "days": {d: f"id-{d}" for d in sync.DAY_NAMES},
+        }
+    }
+    roster = {"users": {"100": {"is_active": True}, "200": {"is_active": True}}}
+
+    messages_p = tmp_path / "messages.json"
+    responses_p = tmp_path / "responses.json"
+    summary_p = tmp_path / "summary.json"
+    roster_p = tmp_path / "roster.json"
+    outputs_p = tmp_path / "outputs.json"
+
+    _write(messages_p, messages)
+    _write(responses_p, weekly_responses)
+    _write(summary_p, {})
+    _write(roster_p, roster)
+    _write(outputs_p, {})
+
+    return week_key, messages_p, responses_p, summary_p, roster_p, outputs_p
+
+
+def test_summary_format_includes_dates_voter_names_and_truncation():
+    voters = [{"display_name": f"User{i}"} for i in range(1, 30)]
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {d: (2 if d == "Monday" else 0) for d in sync.DAY_NAMES},
+            "slot_counts": {
+                d: {slot: (len(voters) if d == "Monday" and slot == "✅" else 0) for slot in sync.SUMMARY_DISPLAY_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "slot_voters": {
+                d: {slot: (voters + [{"display_name": "User1"}] if d == "Monday" and slot == "✅" else []) for slot in sync.SUMMARY_SLOT_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": len(voters)},
+        },
+    }
+
+    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+
+    assert "Monday 4/13" in msg
+    assert "Best overlap:" in msg
+    assert "✅" in msg
+    assert "+" in msg and "more" in msg
+    assert "User1, User1" not in msg
+
+
+def test_main_rebuild_only_edits_or_recovers_summary(monkeypatch, tmp_path, load_fixture_json):
+    weekly_responses = load_fixture_json("weekly_responses_named_users.json")
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(tmp_path, weekly_responses)
+
+    existing_output = {
+        week_key: {
+            "summary_message_id": "sum-old",
+            "summary_message_content": "old-content",
+        },
+        "2026-04-06_to_2026-04-12": {"summary_message_id": "preserve-me"},
+    }
+    _write(outputs_p, existing_output)
+
+    fake_client = FakeDiscordClient(stale_summary_id="sum-old")
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert fake_client.posts, "stale summary should trigger replacement post"
+    assert outputs[week_key]["summary_message_id"].startswith("summary-")
+    assert outputs["2026-04-06_to_2026-04-12"]["summary_message_id"] == "preserve-me"
+
+
+def test_main_dry_run_does_not_mutate_summary_message(monkeypatch, tmp_path, load_fixture_json):
+    weekly_responses = load_fixture_json("weekly_responses_named_users.json")
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(tmp_path, weekly_responses)
+
+    _write(outputs_p, {week_key: {"summary_message_id": "sum-old", "summary_message_content": "unchanged"}})
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.setenv("DRY_RUN", "true")
+
+    sync.main()
+
+    assert fake_client.posts == []
+    assert fake_client.edits == []


### PR DESCRIPTION
### Motivation
- Provide a lightweight, maintainable automated test suite to protect the core idempotency, recovery and formatting business rules introduced in previous PRs. 
- Hardening around shared state loading, retention pruning and summary formatting to catch regressions early and keep tests fast and local. 
- Keep production code changes minimal and low-risk while enabling tests to import and exercise existing modules. 

### Description
- Added a focused pytest test suite and fixtures under `tests/` to cover weekly scheduling, summary generation, daily picks, evening winners, and shared state helpers (`tests/*.py`, `tests/fixtures/*`, `tests/conftest.py`).
- Added `scripts/__init__.py` to allow importing script modules from tests without changing runtime behavior. 
- Added `pytest` to `requirements.txt` so tests run in-repo with the minimal dependency set. 
- Tests exercise and protect key business rules: weekly/daily idempotent rerun behavior and partial recovery, summary formatting (dates, voter names, truncation and ordering), winners vote-counting (`human_votes = raw 👍 - 1`) and rerun/edit/recover behavior, and retention/prune and JSON-loading hardening. 

### Testing
- Ran the test suite with `pytest -q` and observed: `17 passed`.
- The added tests include unit and lightweight integration-style tests that mock Discord interactions and use realistic JSON fixtures to validate legacy and current state shapes. 
- No production behavior changes were introduced beyond `scripts/__init__.py`; all tests run locally and are deterministic (no live Discord/network calls).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6971914f4832694b0f17e20d3df7c)