### PR TITLE
Follow-up: remove “Best overlap”, 8x/day sync, NY daily reminder cap, and concurrency

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -18,11 +18,14 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 23 * * *'
-    - cron: '0 3 * * *'
+    - cron: '0 */3 * * *'
 
 permissions:
   contents: write
+
+concurrency:
+  group: weekly-scheduling-responses-sync
+  cancel-in-progress: false
 
 jobs:
   sync-weekly-responses:

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -7,6 +7,7 @@ import time
 import urllib.parse
 from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import requests
 
@@ -36,6 +37,7 @@ AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "�
 SUMMARY_SLOT_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝"]
 SUMMARY_DISPLAY_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝", "❌"]
 MAX_SUMMARY_LINE_LENGTH = 185
+NEW_YORK_TIMEZONE = ZoneInfo("America/New_York")
 
 
 def fail(message: str) -> None:
@@ -515,22 +517,15 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
         fail("Missing or invalid summary object for current week")
 
     day_counts = summary.get("day_counts")
-    best_overlap = summary.get("best_overlap")
     slot_counts = summary.get("slot_counts")
     slot_voters = summary.get("slot_voters")
 
     if not isinstance(day_counts, dict):
         fail("Missing or invalid day_counts in current week summary")
-    if not isinstance(best_overlap, dict):
-        fail("Missing or invalid best_overlap in current week summary")
     if not isinstance(slot_counts, dict):
         fail("Missing or invalid slot_counts in current week summary")
     if not isinstance(slot_voters, dict):
         slot_voters = {}
-
-    best_day = best_overlap.get("day")
-    if not isinstance(best_day, str):
-        fail("Missing or invalid best_overlap fields in current week summary")
 
     week_dates = compute_week_dates_from_summary(week_summary)
 
@@ -608,8 +603,6 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
         ),
     )
 
-    best_day_lines = build_day_slot_lines(best_day) or ["No responses"]
-
     ranked_day_lines: list[str] = []
     for index, day_name in enumerate(ranked_days):
         ranked_day_lines.append(f"{index + 1}. **{day_with_date_label(day_name)}**")
@@ -624,10 +617,6 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
     lines = [
         f"📊 Availability Summary — {date_range}",
         "",
-        "Best overlap:",
-        f"**{day_with_date_label(best_day)}**",
-        *best_day_lines,
-        "",
         "All days ranked:",
         *ranked_day_lines,
     ]
@@ -638,10 +627,6 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
 
     fallback_lines = [
         f"📊 Availability Summary — {date_range}",
-        "",
-        "Best overlap:",
-        f"**{day_with_date_label(best_day)}**",
-        f"{best_overlap.get('slot', '✅')} {best_overlap.get('count', 0)} — (details truncated)",
         "",
         "All days ranked:",
         *(
@@ -688,6 +673,11 @@ def edit_channel_message(
         response,
         f"Failed to edit channel message for channel_id={channel_id}, message_id={message_id}",
     )
+
+
+def current_new_york_local_date() -> str:
+    """Return the current New York calendar date in ISO format."""
+    return datetime.now(NEW_YORK_TIMEZONE).date().isoformat()
 
 
 def main() -> None:
@@ -927,19 +917,31 @@ def main() -> None:
             if not isinstance(previous_missing_users, list):
                 previous_missing_users = []
             previous_missing_users = [str(user_id) for user_id in previous_missing_users]
+            last_reminder_local_date = normalize_optional_text(
+                week_outputs.get("last_reminder_local_date")
+            )
+            reminder_local_date = current_new_york_local_date()
 
             if missing_user_ids:
                 if missing_user_ids != previous_missing_users:
-                    reminder_message = format_reminder_message(date_range, missing_user_ids)
-                    reminder_message_id = post_channel_message(
-                        posting_session, channel_id, reminder_message
-                    )
-                    week_outputs["reminder_message_id"] = reminder_message_id
-                    week_outputs["reminder_missing_users"] = missing_user_ids
-                    print(
-                        f"CREATE: posted reminder for week {posting_week_key} "
-                        f"(message_id={reminder_message_id}, missing={len(missing_user_ids)})"
-                    )
+                    if last_reminder_local_date == reminder_local_date:
+                        print(
+                            f"SKIP: reminder already posted on New York date "
+                            f"{reminder_local_date} for week {posting_week_key}; skipping reminder post"
+                        )
+                    else:
+                        reminder_message = format_reminder_message(date_range, missing_user_ids)
+                        reminder_message_id = post_channel_message(
+                            posting_session, channel_id, reminder_message
+                        )
+                        week_outputs["reminder_message_id"] = reminder_message_id
+                        week_outputs["reminder_missing_users"] = missing_user_ids
+                        week_outputs["last_reminder_local_date"] = reminder_local_date
+                        print(
+                            f"CREATE: posted reminder for week {posting_week_key} "
+                            f"(message_id={reminder_message_id}, missing={len(missing_user_ids)}, "
+                            f"ny_date={reminder_local_date})"
+                        )
                 else:
                     print(
                         f"SKIP: reminder unchanged for week {posting_week_key}; "

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -84,7 +84,8 @@ def test_summary_format_includes_dates_voter_names_and_truncation():
     msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
 
     assert "Monday 4/13" in msg
-    assert "Best overlap:" in msg
+    assert "Best overlap:" not in msg
+    assert "All days ranked:" in msg
     assert "✅" in msg
     assert "+" in msg and "more" in msg
     assert "User1, User1" not in msg
@@ -150,3 +151,115 @@ def test_main_dry_run_does_not_mutate_summary_message(monkeypatch, tmp_path, loa
 
     assert fake_client.posts == []
     assert fake_client.edits == []
+
+
+def test_main_posts_only_one_reminder_per_new_york_local_day(monkeypatch, tmp_path, load_fixture_json):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {},
+            }
+        },
+    )
+
+    reminder_posts = []
+
+    def fake_post_channel_message(session, channel_id, content):
+        reminder_posts.append((channel_id, content))
+        return f"rem-{len(reminder_posts)}"
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", fake_post_channel_message)
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(sync, "current_new_york_local_date", lambda: "2026-04-18")
+    sync.main()
+    sync.main()
+
+    outputs_after_same_day = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert len(reminder_posts) == 1
+    assert outputs_after_same_day[week_key]["last_reminder_local_date"] == "2026-04-18"
+
+    # New day + changed missing list should allow a new reminder.
+    _write(
+        responses_p,
+        {
+            week_key: {
+                "date_range": "Apr 13–19, 2026",
+                "users": {
+                    "100": {
+                        "username": "jan",
+                        "global_name": "Jan",
+                        "days": {
+                            day: {"reactions": ["✅"], "custom_reply": None}
+                            for day in sync.DAY_NAMES
+                        },
+                    }
+                },
+            }
+        },
+    )
+
+    monkeypatch.setattr(sync, "current_new_york_local_date", lambda: "2026-04-19")
+    sync.main()
+
+    outputs_after_next_day = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert len(reminder_posts) == 2
+    assert outputs_after_next_day[week_key]["last_reminder_local_date"] == "2026-04-19"
+
+
+def test_main_saturday_new_week_requires_change_and_allows_single_daily_reminder(
+    monkeypatch, tmp_path
+):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {},
+            }
+        },
+    )
+    reminder_posts = []
+
+    def fake_post_channel_message(session, channel_id, content):
+        reminder_posts.append((channel_id, content))
+        return f"rem-{len(reminder_posts)}"
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", fake_post_channel_message)
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setattr(sync, "current_new_york_local_date", lambda: "2026-04-18")
+
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    # First Saturday sync for newly created week posts summary + first reminder.
+    sync.main()
+    assert len(fake_client.posts) == 1
+    assert len(reminder_posts) == 1
+
+    # Later same-day Saturday syncs cannot post another reminder.
+    sync.main()
+    assert len(reminder_posts) == 1


### PR DESCRIPTION
### Motivation
- Reduce redundant summary noise by removing the separate “Best overlap” section and keep summaries concise while preserving existing formatting and truncation behavior.  
- Refresh summaries more frequently (≈every 3 hours) but avoid reminder spam by limiting reminders to one per New York local calendar day.  
- Prevent overlapping workflow runs from colliding on state commits or Discord edits.

### Description
- Removed rendering of the separate "Best overlap" section from both normal and fallback summary paths in `scripts/sync_weekly_schedule_responses.py` while keeping date labels, ranked-day blocks, voter lines, and truncation behavior intact.  
- Added New York local-date handling using `ZoneInfo("America/New_York")` and a helper `current_new_york_local_date()` and persisted `last_reminder_local_date` into `weekly_schedule_bot_outputs.json` to cap reminders per local day.  
- Updated reminder gating so a reminder is posted only when (a) there are missing users, (b) the missing-user list changed, and (c) `last_reminder_local_date != current_new_york_local_date()`; after posting the run saves `reminder_message_id`, `reminder_missing_users`, and `last_reminder_local_date`.  
- Increased scheduled cadence in `.github/workflows/weekly-scheduling-responses-sync.yml` to run every 3 hours with cron `0 */3 * * *` (≈8×/day) and added workflow-level concurrency protection: `concurrency: group: weekly-scheduling-responses-sync` with `cancel-in-progress: false` so runs queue sequentially.  
- Updated and added tests in `tests/test_weekly_sync_summary.py` to assert the summary no longer contains "Best overlap" and to validate reminder behavior (single reminder per NY local day, same-day suppression, next-day allowance, and Saturday/new-week behavior).

Files changed: `scripts/sync_weekly_schedule_responses.py`, `.github/workflows/weekly-scheduling-responses-sync.yml`, `tests/test_weekly_sync_summary.py`.

### Testing
- Ran the weekly summary tests with `pytest -q tests/test_weekly_sync_summary.py` and all tests passed: `5 passed`.  
- Verified the new schedule is `0 */3 * * *` and concurrency block is present in the workflow file.  
- Confirmed `last_reminder_local_date` is written to bot outputs when a reminder is created and that same-day duplicates are skipped by the code and exercised in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69d693fa88326891d93e9fd20ed98)