### PR TITLE
Evening winners: include voter names and post to daily-game-picks

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run evening winners script
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_DAILY_PICKS_CHANNEL_ID: ${{ secrets.DISCORD_DAILY_PICKS_CHANNEL_ID }}
           DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python evening_winners.py

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is now **channel-based** (no thread-based posting).
 
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)
 - Daily picks channel: `daily-game-picks` (`1491294533751799809`)
-- Winners destination channel: configured by `DISCORD_WINNERS_CHANNEL_ID`
+- Winners destination channel: `daily-game-picks` (uses `DISCORD_DAILY_PICKS_CHANNEL_ID` when set; otherwise falls back to daily item channel/state and then `DISCORD_WINNERS_CHANNEL_ID`)
 
 ---
 
@@ -128,12 +128,13 @@ Manual operator control:
 Behavior:
 - Reads same-day items from `discord_daily_posts.json`
 - Fetches 👍 counts from item messages
+- Fetches 👍 voter identities and displays human voter names per winner
 - Subtracts bot default 👍 to compute human votes
 - Inclusion rules:
   - raw 👍 = 1 → excluded (0 human votes)
   - raw 👍 = 2 → included (1 human vote)
   - raw 👍 = 3 → included (2 human votes)
-- Posts winners to `DISCORD_WINNERS_CHANNEL_ID` only (not back to daily picks channel)
+- Posts winners to `daily-game-picks` (`DISCORD_DAILY_PICKS_CHANNEL_ID` preferred; backward-compatible fallback to `DISCORD_WINNERS_CHANNEL_ID`)
 
 Rerun/idempotency behavior:
 - Same-day reruns do not duplicate winners posts
@@ -174,6 +175,7 @@ This shared layer is used by weekly + daily flows for consistency and safer reru
   - `INSTAGRAM_SESSION_B64`
 - Evening winners:
   - `DISCORD_BOT_TOKEN`
+  - `DISCORD_DAILY_PICKS_CHANNEL_ID` (recommended)
   - `DISCORD_WINNERS_CHANNEL_ID`
 
 ## Local Testing

--- a/discord_api.py
+++ b/discord_api.py
@@ -61,6 +61,31 @@ class DiscordClient:
         response = self.request("GET", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context)
         return self._parse_json_object(response, f"{context} JSON")
 
+    def get_current_user(self, *, context: str) -> dict[str, Any]:
+        response = self.request("GET", f"{DISCORD_API_BASE}/users/@me", context=context)
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def get_reaction_users(
+        self,
+        channel_id: str,
+        message_id: str,
+        encoded_emoji: str,
+        *,
+        context: str,
+        limit: int = 100,
+        after: str | None = None,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if after:
+            params["after"] = after
+        response = self.request(
+            "GET",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{encoded_emoji}",
+            context=context,
+            params=params,
+        )
+        return self._parse_json_array(response, f"{context} JSON")
+
     def post_message(self, channel_id: str, content: str, *, context: str) -> dict[str, Any]:
         response = self.request("POST", f"{DISCORD_API_BASE}/channels/{channel_id}/messages", context=context, json_payload={"content": content})
         return self._parse_json_object(response, f"{context} JSON")
@@ -81,6 +106,20 @@ class DiscordClient:
         if not isinstance(payload, dict):
             raise DiscordApiError(f"{context} did not return an object")
         return payload
+
+    @staticmethod
+    def _parse_json_array(response: requests.Response, context: str) -> list[dict[str, Any]]:
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise DiscordApiError(f"{context} was not valid JSON") from error
+        if not isinstance(payload, list):
+            raise DiscordApiError(f"{context} did not return an array")
+        parsed: list[dict[str, Any]] = []
+        for item in payload:
+            if isinstance(item, dict):
+                parsed.append(item)
+        return parsed
 
     @staticmethod
     def _get_retry_after_seconds(response: requests.Response, attempt: int) -> float:

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
+from urllib.parse import quote
 
 import requests
 
@@ -10,10 +11,14 @@ from state_utils import load_json_object, save_json_object_atomic
 
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 THUMBS_UP_EMOJI = "👍"
+THUMBS_UP_EMOJI_ENCODED = quote(THUMBS_UP_EMOJI, safe="")
 
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
+DISCORD_DAILY_PICKS_CHANNEL_ID = os.getenv("DISCORD_DAILY_PICKS_CHANNEL_ID")
 WINNERS_DATE_OVERRIDE_ENV = "WINNERS_DATE_UTC"
+MAX_VOTERS_SHOWN_PER_GAME = 6
+DISCORD_MESSAGE_CHAR_LIMIT = 2000
 
 SECTION_CONFIG = {
     "free": "Free Picks",
@@ -63,12 +68,113 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
             lines.append(item["url"])
             vote_word = "vote" if item["human_votes"] == 1 else "votes"
             lines.append(f"👍 {item['human_votes']} {vote_word}")
+            lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
             lines.append("")
 
     if not has_any_winners:
         lines.append("_No votes yet today._")
 
     return "\n".join(lines).strip()
+
+
+def build_winners_message_compact(winners_by_section: Dict[str, List[dict]]) -> str:
+    lines = ["🏆 Daily Game Picks — Winners", ""]
+    has_any_winners = False
+
+    for section in SECTION_ORDER:
+        items = winners_by_section.get(section, [])
+        if not items:
+            continue
+
+        has_any_winners = True
+        lines.append(SECTION_CONFIG[section])
+        for item in items:
+            vote_word = "vote" if item["human_votes"] == 1 else "votes"
+            lines.append(f"- {item['title']} ({item['human_votes']} {vote_word})")
+            lines.append(f"  {item['url']}")
+        lines.append("")
+
+    if not has_any_winners:
+        lines.append("_No votes yet today._")
+
+    return "\n".join(lines).strip()
+
+
+def resolve_display_name(user: dict) -> str:
+    if not isinstance(user, dict):
+        return "Unknown User"
+    global_name = (user.get("global_name") or "").strip()
+    if global_name:
+        return global_name
+    username = (user.get("username") or "").strip()
+    if username:
+        return username
+    user_id = str(user.get("id") or "").strip()
+    if user_id:
+        return f"User {user_id}"
+    return "Unknown User"
+
+
+def format_voter_names_for_message(names: List[str]) -> str:
+    if not names:
+        return "Unknown voters"
+    visible = names[:MAX_VOTERS_SHOWN_PER_GAME]
+    hidden_count = len(names) - len(visible)
+    joined = ", ".join(visible)
+    if hidden_count > 0:
+        return f"{joined}, +{hidden_count} more"
+    return joined
+
+
+def pick_winners_channel_id(items: List[dict]) -> Optional[str]:
+    if DISCORD_DAILY_PICKS_CHANNEL_ID:
+        return DISCORD_DAILY_PICKS_CHANNEL_ID
+    for item in items:
+        channel_id = item.get("channel_id")
+        if isinstance(channel_id, str) and channel_id.strip():
+            return channel_id
+    return DISCORD_WINNERS_CHANNEL_ID
+
+
+def fetch_human_voter_names(
+    client: DiscordClient,
+    *,
+    channel_id: str,
+    message_id: str,
+    bot_user_id: Optional[str],
+    context: str,
+) -> List[str]:
+    names: List[str] = []
+    seen_user_ids: set[str] = set()
+    after: Optional[str] = None
+
+    while True:
+        users = client.get_reaction_users(
+            channel_id,
+            message_id,
+            THUMBS_UP_EMOJI_ENCODED,
+            context=context,
+            limit=100,
+            after=after,
+        )
+        if not users:
+            break
+        for user in users:
+            user_id = str(user.get("id") or "").strip()
+            if not user_id or user_id in seen_user_ids:
+                continue
+            seen_user_ids.add(user_id)
+            if bot_user_id and user_id == bot_user_id:
+                continue
+            names.append(resolve_display_name(user))
+        if len(users) < 100:
+            break
+        last_user_id = str(users[-1].get("id") or "").strip()
+        if not last_user_id:
+            break
+        after = last_user_id
+
+    return names
 
 
 def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
@@ -82,9 +188,6 @@ def post_winners_message(client: DiscordClient, channel_id: str, message: str) -
 def main() -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
-    if not DISCORD_WINNERS_CHANNEL_ID:
-        raise RuntimeError("DISCORD_WINNERS_CHANNEL_ID is not set.")
-
     day_key = get_target_day_key()
     print(f"Starting evening winners for day={day_key}")
 
@@ -96,6 +199,12 @@ def main() -> None:
     items = today_entry.get("items", []) if isinstance(today_entry, dict) else []
 
     winners_by_section: Dict[str, List[dict]] = {key: [] for key in SECTION_ORDER}
+    winners_channel_id = pick_winners_channel_id(items)
+    if not winners_channel_id:
+        raise RuntimeError(
+            "Winners destination channel id is not set. "
+            "Set DISCORD_DAILY_PICKS_CHANNEL_ID or DISCORD_WINNERS_CHANNEL_ID."
+        )
 
     with requests.Session() as session:
         session.headers.update(
@@ -105,6 +214,8 @@ def main() -> None:
             }
         )
         client = DiscordClient(session)
+        bot_user = client.get_current_user(context="fetch bot user for winners vote filtering")
+        bot_user_id = str(bot_user.get("id") or "").strip() or None
 
         for item in items:
             section = item.get("section")
@@ -131,16 +242,26 @@ def main() -> None:
 
             if human_votes < 1:
                 continue
+            voter_names = fetch_human_voter_names(
+                client,
+                channel_id=str(channel_id),
+                message_id=str(message_id),
+                bot_user_id=bot_user_id,
+                context=f"fetch voters for {item.get('title', 'item')}",
+            )
 
             winners_by_section[section].append(
                 {
                     "title": item.get("title", "Untitled"),
                     "url": item.get("url", ""),
                     "human_votes": human_votes,
+                    "voter_names": voter_names,
                 }
             )
 
         message = build_winners_message(winners_by_section)
+        if len(message) > DISCORD_MESSAGE_CHAR_LIMIT:
+            message = build_winners_message_compact(winners_by_section)
         winners_state = today_entry.get("winners_state")
         if not isinstance(winners_state, dict):
             winners_state = {}
@@ -153,7 +274,7 @@ def main() -> None:
         if isinstance(previous_message_id, str) and previous_message_id:
             try:
                 client.get_message(
-                    DISCORD_WINNERS_CHANNEL_ID,
+                    winners_channel_id,
                     previous_message_id,
                     context=f"verify winners message for {day_key}",
                 )
@@ -161,7 +282,7 @@ def main() -> None:
                     print(f"SKIP: winners already posted and unchanged for {day_key}")
                     return
                 client.edit_message(
-                    DISCORD_WINNERS_CHANNEL_ID,
+                    winners_channel_id,
                     previous_message_id,
                     message,
                     context=f"edit winners message for {day_key}",
@@ -178,7 +299,7 @@ def main() -> None:
                     f"(message_id={previous_message_id}); posting replacement"
                 )
 
-        new_message_id = post_winners_message(client, DISCORD_WINNERS_CHANNEL_ID, message)
+        new_message_id = post_winners_message(client, winners_channel_id, message)
         winners_state["message_id"] = new_message_id
         winners_state["content_hash"] = content_hash
         winners_state["last_action"] = "create"

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -15,12 +15,13 @@ class FakeSession:
 
 
 class FakeDiscordClient:
-    def __init__(self, message_payloads, *, stale_winner_id=None, unchanged_hash=None):
+    def __init__(self, message_payloads, reaction_users=None, *, stale_winner_id=None):
         self.message_payloads = message_payloads
+        self.reaction_users = reaction_users or {}
         self.stale_winner_id = stale_winner_id
-        self.unchanged_hash = unchanged_hash
         self.posts = []
         self.edits = []
+        self.reaction_calls = []
 
     def get_message(self, channel_id, message_id, *, context):
         if self.stale_winner_id and message_id == self.stale_winner_id:
@@ -28,6 +29,13 @@ class FakeDiscordClient:
         if message_id in self.message_payloads:
             return self.message_payloads[message_id]
         return {"id": message_id}
+
+    def get_current_user(self, *, context):
+        return {"id": "bot-1", "username": "bot-user"}
+
+    def get_reaction_users(self, channel_id, message_id, encoded_emoji, *, context, limit=100, after=None):
+        self.reaction_calls.append((channel_id, message_id, encoded_emoji, limit, after))
+        return self.reaction_users.get(message_id, [])
 
     def edit_message(self, channel_id, message_id, content, *, context):
         self.edits.append((channel_id, message_id, content))
@@ -62,22 +70,40 @@ def test_winner_vote_rules_and_message_content(monkeypatch, tmp_path):
         "m2": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
         "m3": {"reactions": [{"emoji": {"name": "👍"}, "count": 3}]},
     }
-    fake = FakeDiscordClient(payloads)
+    reaction_users = {
+        "m2": [
+            {"id": "bot-1", "global_name": "Bot Name", "username": "bot-user"},
+            {"id": "u1", "global_name": "Jan", "username": "jan123"},
+        ],
+        "m3": [
+            {"id": "bot-1", "global_name": "Bot Name", "username": "bot-user"},
+            {"id": "u2", "global_name": "Jerry", "username": "jerry1"},
+            {"id": "u3", "global_name": None, "username": "akhil_user"},
+            {"id": "u3", "global_name": None, "username": "akhil_user"},
+            {"id": "u4"},
+        ],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
 
     monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
     monkeypatch.setattr(winners.requests, "Session", FakeSession)
     monkeypatch.setattr(winners, "DiscordClient", lambda session: fake)
     monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
-    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
+    monkeypatch.setattr(winners, "DISCORD_DAILY_PICKS_CHANNEL_ID", None)
+    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", None)
     monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
 
     winners.main()
 
     assert len(fake.posts) == 1
+    assert fake.posts[0][0] == "c"
     content = fake.posts[0][1]
     assert "One" not in content
     assert "Two" in content and "👍 1 vote" in content
     assert "Three" in content and "👍 2 votes" in content
+    assert "Voters — Jan" in content
+    assert "Voters — Jerry, akhil_user, User u4" in content
+    assert "Bot Name" not in content
 
 
 def test_winners_rerun_skip_edit_and_recovery(monkeypatch, tmp_path):
@@ -89,11 +115,12 @@ def test_winners_rerun_skip_edit_and_recovery(monkeypatch, tmp_path):
     data[day_key]["items"] = []
     path.write_text(json.dumps(data), encoding="utf-8")
 
-    fake_skip = FakeDiscordClient({}, unchanged_hash=same_hash)
+    fake_skip = FakeDiscordClient({})
     monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
     monkeypatch.setattr(winners.requests, "Session", FakeSession)
     monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_skip)
     monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_DAILY_PICKS_CHANNEL_ID", "daily-picks")
     monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
     monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
     winners.main()
@@ -106,11 +133,13 @@ def test_winners_rerun_skip_edit_and_recovery(monkeypatch, tmp_path):
     monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_edit)
     winners.main()
     assert len(fake_edit.edits) == 1
+    assert fake_edit.edits[0][0] == "daily-picks"
 
     fake_recover = FakeDiscordClient({}, stale_winner_id="w-old")
     monkeypatch.setattr(winners, "DiscordClient", lambda session: fake_recover)
     winners.main()
     assert len(fake_recover.posts) == 1
+    assert fake_recover.posts[0][0] == "daily-picks"
 
 
 def test_stale_daily_item_message_is_skipped(monkeypatch, tmp_path):
@@ -123,11 +152,18 @@ def test_stale_daily_item_message_is_skipped(monkeypatch, tmp_path):
                 raise winners.DiscordMessageNotFoundError("missing item")
             return super().get_message(channel_id, message_id, context=context)
 
-    fake = ItemStaleClient(payloads)
+    reaction_users = {
+        "m2": [
+            {"id": "bot-1", "username": "bot"},
+            {"id": "u9", "global_name": "Thomas", "username": "thomas"},
+        ]
+    }
+    fake = ItemStaleClient(payloads, reaction_users)
     monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
     monkeypatch.setattr(winners.requests, "Session", FakeSession)
     monkeypatch.setattr(winners, "DiscordClient", lambda session: fake)
     monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_DAILY_PICKS_CHANNEL_ID", "daily-picks")
     monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
     monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
 
@@ -135,3 +171,42 @@ def test_stale_daily_item_message_is_skipped(monkeypatch, tmp_path):
 
     assert len(fake.posts) == 1
     assert "Two" in fake.posts[0][1]
+    assert "Voters — Thomas" in fake.posts[0][1]
+
+
+def test_build_winners_message_voter_truncation():
+    winners_by_section = {
+        "free": [
+            {
+                "title": "Game A",
+                "url": "u-a",
+                "human_votes": 9,
+                "voter_names": ["Jan", "Jerry", "Akhil", "Thomas", "Charlie", "Kevin", "Raymond", "Rishabh", "Malphax"],
+            }
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert "Voters — Jan, Jerry, Akhil, Thomas, Charlie, Kevin, +3 more" in content
+
+
+def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
+    winners_by_section = {
+        "free": [
+            {
+                "title": f"Game {idx}",
+                "url": f"https://example.com/{idx}",
+                "human_votes": 2,
+                "voter_names": [f"User {i}" for i in range(10)],
+            }
+            for idx in range(50)
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+    message = winners.build_winners_message(winners_by_section)
+    assert len(message) > winners.DISCORD_MESSAGE_CHAR_LIMIT
+    compact = winners.build_winners_message_compact(winners_by_section)
+    assert "Voters —" not in compact
+    assert "- Game 0 (2 votes)" in compact


### PR DESCRIPTION
### Motivation
- Make evening winners more useful by showing which human users voted for each winning game while keeping existing inclusion logic unchanged.  
- Support multiple voters per game and keep winners messages readable when many people vote.  
- Ensure winners are posted to the intended `daily-game-picks` destination while preserving rerun/idempotency and recovery behavior.

### Description
- Added Discord helper methods to `discord_api.py` to fetch the bot user (`/users/@me`) and paginated reaction users (`/reactions/{emoji}`) and to parse JSON arrays.  
- Enhanced `evening_winners.py` to collect and include human voter display names per winning item while excluding the bot’s seeded 👍 by matching the bot user id; name selection prefers `global_name` → `username` → `User <id>` fallback.  
- Implemented voter list dedupe, per-game truncation (show up to `6` names then `+N more`), and a compact fallback message format when full content exceeds Discord limits.  
- Updated winners destination resolution to prefer `DISCORD_DAILY_PICKS_CHANNEL_ID`, fall back to the daily item `channel_id`, and then to `DISCORD_WINNERS_CHANNEL_ID`, and wired the new env var in `.github/workflows/evening-winners.yml` and documented the change in `README.md`.

### Testing
- Ran the focused test file with `pytest -q tests/test_evening_winners.py` and observed `5 passed`.  
- Ran the whole test suite with `pytest -q` and observed `21 passed`.  
- Tests cover inclusion rules unchanged, voter-name inclusion and bot exclusion, multiple voters, display-name preference/fallback, voter-list truncation, compact fallback format, and rerun/edit/recovery behavior with the resolved daily-picks destination.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a62049288326905bc80ac4187c24)