### PR TITLE
chore: add workflow health docs, failure pings, and state sanity checks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -54,3 +54,35 @@ jobs:
 
           git diff --cached --quiet || git commit -m "Update bot state"
           git push
+
+      - name: Notify Discord on failure (optional)
+        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: run-script
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc || '' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          target = os.environ.get("DAILY_DATE_UTC")
+          details = f"daily_date_utc={target}" if target else "daily_date_utc=(default)"
+          payload = {
+              "content": (
+                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
+                  f"{details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }
+          request = urllib.request.Request(
+              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(request).read()
+          PY

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -38,3 +38,35 @@ jobs:
           DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python evening_winners.py
+
+      - name: Notify Discord on failure (optional)
+        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: run-evening-winners
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WINNERS_DATE_UTC: ${{ inputs.winners_date_utc || '' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          target = os.environ.get("WINNERS_DATE_UTC")
+          details = f"winners_date_utc={target}" if target else "winners_date_utc=(default)"
+          payload = {
+              "content": (
+                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
+                  f"{details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }
+          request = urllib.request.Request(
+              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(request).read()
+          PY

--- a/.github/workflows/state-sanity-check.yml
+++ b/.github/workflows/state-sanity-check.yml
@@ -1,0 +1,25 @@
+name: State Sanity Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  check-state:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run state sanity check
+        run: python scripts/check_state_sanity.py

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -49,3 +49,35 @@ jobs:
 
           git commit -m "chore: update weekly schedule message state"
           git push
+
+      - name: Notify Discord on failure (optional)
+        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: post-weekly-availability
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_DATE: ${{ inputs.schedule_week_start || '' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          target = os.environ.get("TARGET_DATE")
+          details = f"target_week_start={target}" if target else "target_week_start=(default)"
+          payload = {
+              "content": (
+                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
+                  f"{details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }
+          request = urllib.request.Request(
+              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(request).read()
+          PY

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -64,3 +64,37 @@ jobs:
 
           git commit -m "chore: update weekly schedule responses state"
           git push
+
+      - name: Notify Discord on failure (optional)
+        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: sync-weekly-responses
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_WEEK_KEY: ${{ github.event.inputs.target_week_key || '' }}
+          REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          payload = {
+              "content": (
+                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
+                  f"target_week_key={os.environ.get('TARGET_WEEK_KEY') or '(default)'}; "
+                  f"rebuild_summary_only={os.environ.get('REBUILD_SUMMARY_ONLY')}; "
+                  f"dry_run={os.environ.get('DRY_RUN')}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }
+          request = urllib.request.Request(
+              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(request).read()
+          PY

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # steam-discord-free-games
 
+[![Weekly Scheduling Bot](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-bot.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-bot.yml)
+[![Weekly Scheduling Responses Sync](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-responses-sync.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-responses-sync.yml)
+[![Steam Free Games](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/daily.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/daily.yml)
+[![Daily Game Picks Winners](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/evening-winners.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/evening-winners.yml)
+
 Discord automation for two production workflows:
 
 1. **Weekly scheduling** (availability prompts + ongoing sync/summary/reminders)
@@ -12,6 +17,65 @@ This repository is now **channel-based** (no thread-based posting).
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)
 - Daily picks channel: `daily-game-picks` (`1491294533751799809`)
 - Winners destination channel: `daily-game-picks` (uses `DISCORD_DAILY_PICKS_CHANNEL_ID` when set; otherwise falls back to daily item channel/state and then `DISCORD_WINNERS_CHANNEL_ID`)
+
+---
+
+## Operator Health / Status Quick Reference
+
+Healthy at a glance:
+- The four production workflows above show green badges.
+- Recent runs in **Actions** are succeeding on schedule (daily/3-hourly/weekly cadence).
+- New state commits continue landing for weekly and daily flows.
+
+If something fails:
+1. Open **GitHub Actions** → failed run → inspect the first failing step/log.
+2. Confirm required secrets are still set and non-empty.
+3. Re-run with `workflow_dispatch` and a specific date/week input when needed.
+4. If `DISCORD_FAILURE_WEBHOOK_URL` is configured, a concise failure ping is sent to Discord (failure only; no success spam).
+
+Manual rerun quick commands (GitHub CLI):
+
+### Weekly Scheduling Bot (`weekly-scheduling-bot.yml`)
+- **What it does:** posts/repairs weekly intro + weekday availability prompts.
+- **Manual input:** `schedule_week_start` (optional `YYYY-MM-DD`, Monday only).
+- **When to rerun:** missed Saturday post, stale/deleted scheduling messages, or a backfill week.
+- **Examples:**
+  - Default target logic: `gh workflow run weekly-scheduling-bot.yml`
+  - Specific week: `gh workflow run weekly-scheduling-bot.yml -f schedule_week_start=2026-04-13`
+
+### Weekly Scheduling Responses Sync (`weekly-scheduling-responses-sync.yml`)
+- **What it does:** pulls reactions, updates state, and posts/repairs weekly summary/reminders.
+- **Manual inputs:**
+  - `target_week_key` (optional, e.g. `2026-04-13_to_2026-04-19`)
+  - `rebuild_summary_only` (`true`/`false`)
+  - `dry_run` (`true`/`false`)
+- **When to rerun:** summary drift, missed reminder, or post-reaction sync repair.
+- **Examples:**
+  - Standard sync: `gh workflow run weekly-scheduling-responses-sync.yml`
+  - Rebuild only for one week: `gh workflow run weekly-scheduling-responses-sync.yml -f target_week_key=2026-04-13_to_2026-04-19 -f rebuild_summary_only=true`
+  - Preview only: `gh workflow run weekly-scheduling-responses-sync.yml -f dry_run=true`
+
+### Daily Picks (`daily.yml`)
+- **What it does:** posts daily free/paid/creator picks and updates `discord_daily_posts.json`.
+- **Manual input:** `daily_date_utc` (optional `YYYY-MM-DD`).
+- **When to rerun:** partial morning run, stale/deleted daily messages, or date-targeted state repair.
+- **Examples:**
+  - Default run date: `gh workflow run daily.yml`
+  - Target date: `gh workflow run daily.yml -f daily_date_utc=2026-04-08`
+
+### Evening Winners (`evening-winners.yml`)
+- **What it does:** computes winners from same-day 👍 reactions and posts/edits winners message.
+- **Manual input:** `winners_date_utc` (optional `YYYY-MM-DD`).
+- **When to rerun:** missed evening summary or reaction recount/state repair for a specific day.
+- **Examples:**
+  - Default run date: `gh workflow run evening-winners.yml`
+  - Target date: `gh workflow run evening-winners.yml -f winners_date_utc=2026-04-08`
+
+### State sanity check (`state-sanity-check.yml`)
+- **What it does:** read-only parse/shape checks for key JSON state files.
+- **Schedule:** Mondays at 12:00 UTC.
+- **Manual rerun:** `gh workflow run state-sanity-check.yml`
+- **Local run:** `python scripts/check_state_sanity.py`
 
 ---
 
@@ -177,6 +241,8 @@ This shared layer is used by weekly + daily flows for consistency and safer reru
   - `DISCORD_BOT_TOKEN`
   - `DISCORD_DAILY_PICKS_CHANNEL_ID` (recommended)
   - `DISCORD_WINNERS_CHANNEL_ID`
+- Optional failure notification (used by key workflows):
+  - `DISCORD_FAILURE_WEBHOOK_URL`
 
 ## Local Testing
 

--- a/scripts/check_state_sanity.py
+++ b/scripts/check_state_sanity.py
@@ -1,0 +1,134 @@
+"""Lightweight sanity checks for JSON state files used by automation workflows."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+WEEK_KEY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_to_\d{4}-\d{2}-\d{2}$")
+DATE_KEY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class SanityReport:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+
+def _load_json(path: Path, report: SanityReport, *, required: bool = True) -> Any | None:
+    if not path.exists():
+        message = f"missing file: {path.relative_to(ROOT)}"
+        if required:
+            report.error(message)
+        else:
+            report.warn(message)
+        return None
+
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            return json.load(file)
+    except json.JSONDecodeError as error:
+        report.error(f"invalid JSON in {path.relative_to(ROOT)}: {error}")
+    except OSError as error:
+        report.error(f"failed to read {path.relative_to(ROOT)}: {error}")
+    return None
+
+
+def _expect_dict(payload: Any, relative_path: str, report: SanityReport) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    report.error(f"expected top-level object in {relative_path}, got {type(payload).__name__}")
+    return {}
+
+
+def check_weekly_mapping(path: str, report: SanityReport) -> None:
+    payload = _load_json(ROOT / path, report)
+    if payload is None:
+        return
+
+    mapping = _expect_dict(payload, path, report)
+    for week_key, value in mapping.items():
+        if not isinstance(week_key, str) or not WEEK_KEY_RE.match(week_key):
+            report.warn(f"unexpected weekly key format in {path}: {week_key}")
+        if not isinstance(value, dict):
+            report.error(f"expected object for week {week_key} in {path}")
+
+
+def check_expected_schedule_roster(report: SanityReport) -> None:
+    path = "data/scheduling/expected_schedule_roster.json"
+    payload = _load_json(ROOT / path, report)
+    if payload is None:
+        return
+
+    mapping = _expect_dict(payload, path, report)
+    users = mapping.get("users")
+    if not isinstance(users, dict):
+        report.error(f"expected 'users' object in {path}")
+        return
+
+    for user_id, details in users.items():
+        if not isinstance(user_id, str):
+            report.warn(f"non-string user id in {path}: {user_id}")
+        if not isinstance(details, dict):
+            report.error(f"expected object for user {user_id} in {path}")
+            continue
+        if "is_active" in details and not isinstance(details["is_active"], bool):
+            report.error(f"expected boolean is_active for user {user_id} in {path}")
+
+
+def check_daily_posts(report: SanityReport) -> None:
+    path = "discord_daily_posts.json"
+    payload = _load_json(ROOT / path, report, required=False)
+    if payload is None:
+        return
+
+    mapping = _expect_dict(payload, path, report)
+    for date_key, entry in mapping.items():
+        if not isinstance(date_key, str) or not DATE_KEY_RE.match(date_key):
+            report.warn(f"unexpected date key format in {path}: {date_key}")
+        if not isinstance(entry, dict):
+            report.error(f"expected object for date {date_key} in {path}")
+            continue
+
+        items = entry.get("items")
+        if items is not None and not isinstance(items, list):
+            report.error(f"expected 'items' list for date {date_key} in {path}")
+
+
+def run_checks() -> int:
+    report = SanityReport()
+
+    check_weekly_mapping("data/scheduling/weekly_schedule_messages.json", report)
+    check_weekly_mapping("data/scheduling/weekly_schedule_responses.json", report)
+    check_weekly_mapping("data/scheduling/weekly_schedule_summary.json", report)
+    check_weekly_mapping("data/scheduling/weekly_schedule_bot_outputs.json", report)
+    check_expected_schedule_roster(report)
+    check_daily_posts(report)
+
+    if report.warnings:
+        print("STATE SANITY WARNINGS:")
+        for warning in report.warnings:
+            print(f"- {warning}")
+
+    if report.errors:
+        print("STATE SANITY ERRORS:")
+        for error in report.errors:
+            print(f"- {error}")
+        return 1
+
+    print("State sanity check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_checks())

--- a/tests/test_check_state_sanity.py
+++ b/tests/test_check_state_sanity.py
@@ -1,0 +1,35 @@
+import json
+
+from scripts import check_state_sanity as sanity
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_state_sanity_passes_for_minimal_valid_state(tmp_path, monkeypatch):
+    root = tmp_path
+    monkeypatch.setattr(sanity, "ROOT", root)
+
+    _write_json(root / "data/scheduling/weekly_schedule_messages.json", {"2026-04-13_to_2026-04-19": {"ok": True}})
+    _write_json(root / "data/scheduling/weekly_schedule_responses.json", {"2026-04-13_to_2026-04-19": {"ok": True}})
+    _write_json(root / "data/scheduling/weekly_schedule_summary.json", {"2026-04-13_to_2026-04-19": {"ok": True}})
+    _write_json(root / "data/scheduling/weekly_schedule_bot_outputs.json", {"2026-04-13_to_2026-04-19": {"ok": True}})
+    _write_json(root / "data/scheduling/expected_schedule_roster.json", {"users": {"1": {"is_active": True}}})
+    _write_json(root / "discord_daily_posts.json", {"2026-04-08": {"items": []}})
+
+    assert sanity.run_checks() == 0
+
+
+def test_state_sanity_fails_for_missing_required_or_wrong_shape(tmp_path, monkeypatch):
+    root = tmp_path
+    monkeypatch.setattr(sanity, "ROOT", root)
+
+    _write_json(root / "data/scheduling/weekly_schedule_messages.json", [])
+    _write_json(root / "data/scheduling/weekly_schedule_responses.json", {"bad": []})
+    _write_json(root / "data/scheduling/weekly_schedule_summary.json", {})
+    _write_json(root / "data/scheduling/weekly_schedule_bot_outputs.json", {})
+    _write_json(root / "data/scheduling/expected_schedule_roster.json", {"users": []})
+
+    assert sanity.run_checks() == 1


### PR DESCRIPTION
### Motivation
- Make workflow health and manual operator actions easier to discover at a glance. 
- Provide a lightweight, optional alerting path so failures are noticed quickly without adding heavy infra. 
- Catch obvious JSON/state drift early with a small, read-only sanity check to avoid silent corruption.

### Description
- Added GitHub Actions badges and an operator-focused health/status section to `README.md` that documents the key workflows and copy-paste `gh workflow run ...` manual rerun commands. 
- Added optional, failure-only Discord notifications to the four main workflows by checking `secrets.DISCORD_FAILURE_WEBHOOK_URL` and posting a concise message with workflow/job, run URL, and the relevant dispatch input when available in `weekly-scheduling-bot.yml`, `weekly-scheduling-responses-sync.yml`, `daily.yml`, and `evening-winners.yml`. 
- Added a lightweight, read-only state sanity checker at `scripts/check_state_sanity.py` that validates JSON parseability and basic top-level shapes for key files (weekly schedule messages/responses/summary/bot outputs, `data/scheduling/expected_schedule_roster.json` users structure, and `discord_daily_posts.json`). 
- Added a scheduled/manual workflow `state-sanity-check.yml` to run the sanity check and a focused test `tests/test_check_state_sanity.py` validating pass/fail behavior. 

### Testing
- Ran the sanity script locally with `python scripts/check_state_sanity.py` which printed `State sanity check passed.` and exited zero. 
- Ran unit tests with `pytest -q tests/test_check_state_sanity.py tests/test_state_utils.py` and all tests passed (7 passed). 
- No core weekly/daily/winners business logic was changed and existing tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a9fbe6ac8326b63b2f363ad5ae36)