### PR TITLE
Route ops alerts to Discord health monitor and add daily health report

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -1,0 +1,115 @@
+name: Bot Health Report
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub Actions cron uses UTC only (no timezone/DST support).
+    # 03:10 UTC is ~11:10 PM New York during EDT, ~10:10 PM during EST.
+    - cron: "10 3 * * *"
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  post-health-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build daily health report
+        id: build-report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflows = [
+              { file: "weekly-scheduling-bot.yml", name: "Weekly Scheduling Bot", staleHours: 192 },
+              { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
+              { file: "daily.yml", name: "Daily Steam Picks", staleHours: 30 },
+              { file: "evening-winners.yml", name: "Evening Winners", staleHours: 30 },
+              { file: "state-sanity-check.yml", name: "State Sanity Check", staleHours: 192 },
+            ];
+
+            function formatAge(hours) {
+              if (hours < 1) return "<1h ago";
+              if (hours < 48) return `${Math.round(hours)}h ago`;
+              return `${Math.round(hours / 24)}d ago`;
+            }
+
+            function evaluateStatus(run, staleHours) {
+              if (!run) return { icon: "🟡", statusText: "no recent run found", includeRun: false };
+
+              const updatedAt = new Date(run.updated_at || run.created_at);
+              const ageHours = (Date.now() - updatedAt.getTime()) / 3_600_000;
+              const recency = formatAge(ageHours);
+              const conclusion = run.conclusion || run.status || "unknown";
+
+              if (ageHours > staleHours) {
+                return {
+                  icon: "🟡",
+                  statusText: `${conclusion} (${recency}) — stale`,
+                  includeRun: true,
+                };
+              }
+
+              if (["success"].includes(conclusion)) {
+                return { icon: "🟢", statusText: `${conclusion} (${recency})`, includeRun: false };
+              }
+
+              if (["failure", "timed_out", "startup_failure", "action_required"].includes(conclusion)) {
+                return { icon: "🔴", statusText: `${conclusion} (${recency})`, includeRun: true };
+              }
+
+              return { icon: "🟡", statusText: `${conclusion} (${recency})`, includeRun: true };
+            }
+
+            const nyDate = new Intl.DateTimeFormat("en-US", {
+              timeZone: "America/New_York",
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            }).format(new Date());
+
+            const lines = [`🚦 XiannGPT Bot Daily Health — ${nyDate}`, ""];
+
+            for (const workflow of workflows) {
+              const response = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow.file,
+                per_page: 1,
+                exclude_pull_requests: true,
+              });
+
+              const run = response.data.workflow_runs[0] || null;
+              const status = evaluateStatus(run, workflow.staleHours);
+
+              lines.push(`${status.icon} ${workflow.name}`);
+              lines.push(`Last run: ${status.statusText}`);
+              if (status.includeRun && run?.html_url) {
+                lines.push(`Run: ${run.html_url}`);
+              }
+              lines.push("");
+            }
+
+            core.setOutput("content", lines.join("\n").trim());
+
+      - name: Post health report to Discord
+        if: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          HEALTH_REPORT_CONTENT: ${{ steps.build-report.outputs.content }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          payload = {"content": os.environ["HEALTH_REPORT_CONTENT"]}
+          request = urllib.request.Request(
+              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(request).read()
+          PY

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -55,10 +55,10 @@ jobs:
           git diff --cached --quiet || git commit -m "Update bot state"
           git push
 
-      - name: Notify Discord on failure (optional)
-        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
-          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
           JOB_NAME: run-script
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -73,13 +73,16 @@ jobs:
           details = f"daily_date_utc={target}" if target else "daily_date_utc=(default)"
           payload = {
               "content": (
-                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
-                  f"{details}\n"
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
           }
           request = urllib.request.Request(
-              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
               method="POST",

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -39,10 +39,10 @@ jobs:
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python evening_winners.py
 
-      - name: Notify Discord on failure (optional)
-        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
-          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
           JOB_NAME: run-evening-winners
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -57,13 +57,16 @@ jobs:
           details = f"winners_date_utc={target}" if target else "winners_date_utc=(default)"
           payload = {
               "content": (
-                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
-                  f"{details}\n"
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
           }
           request = urllib.request.Request(
-              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
               method="POST",

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -50,10 +50,10 @@ jobs:
           git commit -m "chore: update weekly schedule message state"
           git push
 
-      - name: Notify Discord on failure (optional)
-        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
-          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
           JOB_NAME: post-weekly-availability
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -68,13 +68,16 @@ jobs:
           details = f"target_week_start={target}" if target else "target_week_start=(default)"
           payload = {
               "content": (
-                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
-                  f"{details}\n"
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
           }
           request = urllib.request.Request(
-              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
               method="POST",

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -65,10 +65,10 @@ jobs:
           git commit -m "chore: update weekly schedule responses state"
           git push
 
-      - name: Notify Discord on failure (optional)
-        if: ${{ failure() && secrets.DISCORD_FAILURE_WEBHOOK_URL != '' }}
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
-          DISCORD_FAILURE_WEBHOOK_URL: ${{ secrets.DISCORD_FAILURE_WEBHOOK_URL }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
           JOB_NAME: sync-weekly-responses
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -83,15 +83,19 @@ jobs:
 
           payload = {
               "content": (
-                  f"⚠️ Workflow failed: {os.environ['WORKFLOW_NAME']} / {os.environ['JOB_NAME']}\n"
-                  f"target_week_key={os.environ.get('TARGET_WEEK_KEY') or '(default)'}; "
-                  f"rebuild_summary_only={os.environ.get('REBUILD_SUMMARY_ONLY')}; "
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  "Context: "
+                  f"target_week_key={os.environ.get('TARGET_WEEK_KEY') or '(default)'}, "
+                  f"rebuild_summary_only={os.environ.get('REBUILD_SUMMARY_ONLY')}, "
                   f"dry_run={os.environ.get('DRY_RUN')}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
           }
           request = urllib.request.Request(
-              os.environ["DISCORD_FAILURE_WEBHOOK_URL"],
+              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
               method="POST",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is now **channel-based** (no thread-based posting).
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)
 - Daily picks channel: `daily-game-picks` (`1491294533751799809`)
 - Winners destination channel: `daily-game-picks` (uses `DISCORD_DAILY_PICKS_CHANNEL_ID` when set; otherwise falls back to daily item channel/state and then `DISCORD_WINNERS_CHANNEL_ID`)
+- Health monitor channel: `xiann-gpt-bot-health-monitor` (`1491520649917628536`)
 
 ---
 
@@ -31,7 +32,18 @@ If something fails:
 1. Open **GitHub Actions** → failed run → inspect the first failing step/log.
 2. Confirm required secrets are still set and non-empty.
 3. Re-run with `workflow_dispatch` and a specific date/week input when needed.
-4. If `DISCORD_FAILURE_WEBHOOK_URL` is configured, a concise failure ping is sent to Discord (failure only; no success spam).
+4. If `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` is configured, a concise failure ping is sent to the health monitor Discord channel (failure only; no success spam).
+
+### Health monitor operator dashboard
+
+Operational alerts are now centralized in `xiann-gpt-bot-health-monitor`.
+
+- **Immediate failure pings:** key production workflows send a compact `🔴 XiannGPT Bot Failure` message with workflow, job, context, and run URL.
+- **Daily health report:** `bot-health-report.yml` posts one summary per day with signal lights:
+  - 🟢 healthy (latest run succeeded)
+  - 🟡 warning (stale, skipped, cancelled, or otherwise non-success)
+  - 🔴 failed (latest run failed)
+- **Operator default path:** this channel is now the primary dashboard for bot operations; email is no longer the preferred alerting path.
 
 Manual rerun quick commands (GitHub CLI):
 
@@ -76,6 +88,11 @@ Manual rerun quick commands (GitHub CLI):
 - **Schedule:** Mondays at 12:00 UTC.
 - **Manual rerun:** `gh workflow run state-sanity-check.yml`
 - **Local run:** `python scripts/check_state_sanity.py`
+
+### Bot health report (`bot-health-report.yml`)
+- **What it does:** posts a once-daily Discord health summary across core workflows.
+- **Schedule:** `10 3 * * *` (03:10 UTC daily; ~11:10 PM New York during EDT).
+- **Manual rerun:** `gh workflow run bot-health-report.yml`
 
 ---
 
@@ -241,8 +258,8 @@ This shared layer is used by weekly + daily flows for consistency and safer reru
   - `DISCORD_BOT_TOKEN`
   - `DISCORD_DAILY_PICKS_CHANNEL_ID` (recommended)
   - `DISCORD_WINNERS_CHANNEL_ID`
-- Optional failure notification (used by key workflows):
-  - `DISCORD_FAILURE_WEBHOOK_URL`
+- Health monitor notifications (failure pings + daily report):
+  - `DISCORD_HEALTH_MONITOR_WEBHOOK_URL`
 
 ## Local Testing
 


### PR DESCRIPTION
### Motivation
- Consolidate immediate failure alerts and daily health visibility into a single Discord operator dashboard channel for clearer, centralized observability.
- Replace the obsolete failure-only webhook secret with a single health-monitor webhook that serves both on-failure pings and the daily signal-light summary.

### Description
- Updated all production workflows (`weekly-scheduling-bot.yml`, `weekly-scheduling-responses-sync.yml`, `daily.yml`, `evening-winners.yml`) to use `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` for failure-only notifications and removed references to `DISCORD_FAILURE_WEBHOOK_URL` from those workflows.
- Standardized failure message payload to a compact format beginning with `🔴 XiannGPT Bot Failure` and including `Workflow`, `Job`, `Status: failed`, `Context` (workflow-specific inputs), and `Run` URL.
- Added a new daily workflow ` .github/workflows/bot-health-report.yml` that runs at `10 3 * * *` UTC, inspects the latest runs for the core workflows, renders signal-light indicators (🟢/🟡/🔴) plus recency and run URLs for warnings/failures, and posts a compact `🚦 XiannGPT Bot Daily Health — <NY date>` report to the health-monitor webhook.
- Updated `README.md` to document the `xiann-gpt-bot-health-monitor` channel (ID `1491520649917628536`), the new `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` secret, the daily report schedule/meaning, and that alerts now use the health monitor channel.

### Testing
- Ran `pytest -q` which passed: `23 passed`.
- Verified there are no remaining references to `DISCORD_FAILURE_WEBHOOK_URL` via a repository search (`rg -n "DISCORD_FAILURE_WEBHOOK_URL" || true`) which returned no matches.
- Exercised the updated workflows locally by static inspection of the modified files ` .github/workflows/weekly-scheduling-bot.yml`, ` .github/workflows/weekly-scheduling-responses-sync.yml`, ` .github/workflows/daily.yml`, ` .github/workflows/evening-winners.yml`, ` .github/workflows/bot-health-report.yml`, and `README.md` to confirm formats and env usage.
- Automated tests and repository searches succeeded with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b2f2ca548326a2c2583f33a08831)