### PR TITLE
fix(workflows): use env in if checks for health-monitor webhook

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -94,7 +94,7 @@ jobs:
             core.setOutput("content", lines.join("\n").trim());
 
       - name: Post health report to Discord
-        if: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        if: ${{ env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           HEALTH_REPORT_CONTENT: ${{ steps.build-report.outputs.content }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -56,7 +56,7 @@ jobs:
           git push
 
       - name: Notify Discord health monitor on failure
-        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -40,7 +40,7 @@ jobs:
         run: python evening_winners.py
 
       - name: Notify Discord health monitor on failure
-        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -51,7 +51,7 @@ jobs:
           git push
 
       - name: Notify Discord health monitor on failure
-        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -66,7 +66,7 @@ jobs:
           git push
 
       - name: Notify Discord health monitor on failure
-        if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
         env:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}


### PR DESCRIPTION
### Motivation
- Manual workflow dispatches were rejected because `secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL` was used directly inside `if:` expressions, which GitHub Actions does not allow. 
- The change is to expose the secret via `env` and reference `env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL` in `if:` expressions so manual runs can queue again. 
- Preserve existing behavior: failure-only notifications and the daily health report should remain unchanged when the webhook secret is configured.

### Description
- Replaced `if: ${{ failure() && secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` with `if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` in failure-notification steps. 
- Replaced `if: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` with `if: ${{ env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` for the bot health report posting step. 
- Kept the secret exposed at the step level via `env: DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}` so runtime behavior is preserved. 
- Files changed: `.github/workflows/weekly-scheduling-bot.yml`, `.github/workflows/weekly-scheduling-responses-sync.yml`, `.github/workflows/daily.yml`, `.github/workflows/evening-winners.yml`, and `.github/workflows/bot-health-report.yml`.

### Testing
- Searched workflows for remaining broken patterns with `rg` and verified no matches remain for `if: ${{ ... secrets.` or the two exact broken patterns; this check passed. 
- Inspected the five modified workflow files and confirmed each `if:` now references `env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL` while the step-level `env` still maps the secret; this validation passed. 
- Attempted a YAML parse check via `yaml.safe_load(...)` but the environment is missing `PyYAML`, so automated parsing could not be run here (reported as a skipped validation). 
- The patch is intentionally minimal and limited to the targeted `if:` expressions to restore manual run queuing without altering schedules or bot logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b966bbec8326916945a17e65f040)