### PR TITLE
Improve Discord health report webhook error logging

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -102,6 +102,8 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import sys
+          import urllib.error
           import urllib.request
 
           payload = {"content": os.environ["HEALTH_REPORT_CONTENT"]}
@@ -111,5 +113,18 @@ jobs:
               headers={"Content-Type": "application/json"},
               method="POST",
           )
-          urllib.request.urlopen(request).read()
+
+          try:
+              with urllib.request.urlopen(request) as response:
+                  print(f"Discord webhook POST succeeded: HTTP {response.getcode()}")
+          except urllib.error.HTTPError as error:
+              body_bytes = error.read() if error.fp else b""
+              body_text = body_bytes.decode("utf-8", errors="replace") if body_bytes else ""
+              print(f"Discord webhook POST failed: HTTP {error.code}", file=sys.stderr)
+              if body_text:
+                  print(body_text, file=sys.stderr)
+              sys.exit(1)
+          except Exception as error:
+              print(f"Discord webhook POST failed: {error}", file=sys.stderr)
+              sys.exit(1)
           PY


### PR DESCRIPTION
### Motivation

- Make Discord webhook failures in the daily health-report workflow easier to diagnose by adding explicit, safe logging around the POST request.
- Preserve the existing health-monitor design and the `if: ${{ env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` guard while avoiding any exposure of the webhook URL.

### Description

- Wrap the Python `urllib.request.urlopen(...)` POST in a `try/except` block and add imports for `sys` and `urllib.error` to support error handling.
- On success print a short confirmation with the HTTP status code (e.g., `Discord webhook POST succeeded: HTTP 204`).
- Catch `urllib.error.HTTPError`, safely read and decode the response body (with error-tolerant decoding), print the HTTP status and body to `stderr`, and exit with a non-zero code.
- Catch other exceptions, print a concise failure message to `stderr`, and exit non-zero, and do not log the webhook URL or other secrets.

### Testing

- Validated YAML syntax by loading the workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bot-health-report.yml')"` which succeeded.
- Attempted `python` `yaml.safe_load` check which failed due to missing `PyYAML` in the environment (test environment issue, not a workflow syntax problem).
- Confirmed the `env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL` guard remains present in the workflow file via text search, and performed a local smoke-check of the modified Python block for correct structure and imports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c20cedc08326977dd99f6fb305a2)