### PR TITLE
Use curl for Discord health report webhook POST

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -99,32 +99,32 @@ jobs:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           HEALTH_REPORT_CONTENT: ${{ steps.build-report.outputs.content }}
         run: |
-          python - <<'PY'
+          payload="$(python - <<'PY'
           import json
           import os
-          import sys
-          import urllib.error
-          import urllib.request
-
-          payload = {"content": os.environ["HEALTH_REPORT_CONTENT"]}
-          request = urllib.request.Request(
-              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-
-          try:
-              with urllib.request.urlopen(request) as response:
-                  print(f"Discord webhook POST succeeded: HTTP {response.getcode()}")
-          except urllib.error.HTTPError as error:
-              body_bytes = error.read() if error.fp else b""
-              body_text = body_bytes.decode("utf-8", errors="replace") if body_bytes else ""
-              print(f"Discord webhook POST failed: HTTP {error.code}", file=sys.stderr)
-              if body_text:
-                  print(body_text, file=sys.stderr)
-              sys.exit(1)
-          except Exception as error:
-              print(f"Discord webhook POST failed: {error}", file=sys.stderr)
-              sys.exit(1)
+          print(json.dumps({"content": os.environ["HEALTH_REPORT_CONTENT"]}))
           PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"


### PR DESCRIPTION
### Motivation

- The existing Python `urllib.request` POST to the Discord webhook was failing in GitHub Actions with HTTP 403 (`error code: 1010`), indicating runner-side request/header differences rather than a bad webhook or secret. 
- A minimal change to use `curl` enables explicit `Content-Type` and `User-Agent` headers and straightforward HTTP status and body capture without changing the health-report generation logic.

### Description

- Replaced the embedded Python `urllib.request` POST in `.github/workflows/bot-health-report.yml` with a `curl`-based POST while keeping the `if: ${{ env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` guard and existing env/secret wiring. 
- The workflow still builds the same JSON payload (`content` from `HEALTH_REPORT_CONTENT`) by emitting it via a short Python snippet and storing it in `payload`. 
- The `curl` invocation writes the response body to a temp file (via `mktemp`), captures the HTTP status code with `--write-out`, sends `Content-Type: application/json` and a normal `User-Agent`, treats any `2xx` as success, and on failure prints the HTTP status and the response body and exits non-zero.

### Testing

- Ran `git diff --check` which returned no whitespace or diff-check issues and therefore succeeded. 
- Attempted to parse the workflow YAML with `python` + `yaml.safe_load`, but this automated check failed due to the environment lacking the `yaml` module (`ModuleNotFoundError`). 
- The change is intentionally minimal and scoped only to `.github/workflows/bot-health-report.yml` so the report generation logic and guards remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ca3c39d483269111bb9667a744ab)