### PR TITLE
Use curl for Discord failure notifications in remaining workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -64,14 +64,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc || '' }}
         run: |
-          python - <<'PY'
+          payload="$(python - <<'PY'
           import json
           import os
-          import urllib.request
 
           target = os.environ.get("DAILY_DATE_UTC")
           details = f"daily_date_utc={target}" if target else "daily_date_utc=(default)"
-          payload = {
+          print(json.dumps({
               "content": (
                   "🔴 XiannGPT Bot Failure\n\n"
                   f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
@@ -80,12 +79,29 @@ jobs:
                   f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
-          }
-          request = urllib.request.Request(
-              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          urllib.request.urlopen(request).read()
+          }))
           PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -48,14 +48,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc || '' }}
         run: |
-          python - <<'PY'
+          payload="$(python - <<'PY'
           import json
           import os
-          import urllib.request
 
           target = os.environ.get("WINNERS_DATE_UTC")
           details = f"winners_date_utc={target}" if target else "winners_date_utc=(default)"
-          payload = {
+          print(json.dumps({
               "content": (
                   "🔴 XiannGPT Bot Failure\n\n"
                   f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
@@ -64,12 +63,29 @@ jobs:
                   f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
-          }
-          request = urllib.request.Request(
-              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          urllib.request.urlopen(request).read()
+          }))
           PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -59,14 +59,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TARGET_DATE: ${{ inputs.schedule_week_start || '' }}
         run: |
-          python - <<'PY'
+          payload="$(python - <<'PY'
           import json
           import os
-          import urllib.request
 
           target = os.environ.get("TARGET_DATE")
           details = f"target_week_start={target}" if target else "target_week_start=(default)"
-          payload = {
+          print(json.dumps({
               "content": (
                   "🔴 XiannGPT Bot Failure\n\n"
                   f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
@@ -75,12 +74,29 @@ jobs:
                   f"Context: {details}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
-          }
-          request = urllib.request.Request(
-              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          urllib.request.urlopen(request).read()
+          }))
           PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -76,12 +76,11 @@ jobs:
           REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
-          python - <<'PY'
+          payload="$(python - <<'PY'
           import json
           import os
-          import urllib.request
 
-          payload = {
+          print(json.dumps({
               "content": (
                   "🔴 XiannGPT Bot Failure\n\n"
                   f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
@@ -93,12 +92,29 @@ jobs:
                   f"dry_run={os.environ.get('DRY_RUN')}\n"
                   f"Run: {os.environ['RUN_URL']}"
               )
-          }
-          request = urllib.request.Request(
-              os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          urllib.request.urlopen(request).read()
+          }))
           PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"


### PR DESCRIPTION
### Motivation

- Standardize the Discord webhook POST used by failure-notification steps across workflows to the proven `curl` pattern used in `bot-health-report.yml` to avoid the older `urllib.request` issues that caused notification steps to fail. 
- Keep the existing health-monitor design, environment wiring, schedules, and message semantics unchanged so notifications remain consistent and minimal-risk.

### Description

- Replaced the embedded Python `urllib.request` POST with a `curl`-based POST (using a short Python snippet only to JSON-encode the payload) in the failure-notification step of `.github/workflows/daily.yml`, `.github/workflows/evening-winners.yml`, `.github/workflows/weekly-scheduling-bot.yml`, and `.github/workflows/weekly-scheduling-responses-sync.yml`.
- Preserved the existing `if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}` guard, all env wiring, and each workflow’s message fields and context (workflow, job, status, context fields, and run URL).
- Implemented the same HTTP handling used by `bot-health-report.yml`: `curl --silent --show-error --write-out "%{http_code}"`, write response to a temp file, treat any 2xx as success, print success on 2xx, print `Discord webhook POST failed: HTTP <status>` and the response body on non-2xx, remove temp files, and exit non-zero on failure.
- Committed changes on branch `chore/curl-discord-failure-notifications` with the message `Use curl for Discord failure notifications in remaining workflows`.

### Testing

- Reviewed the modified workflow YAML for syntax and consistency and ran `git diff --check`, which reported no whitespace or syntax Diff errors.
- Verified via search that `urllib.request` was removed from the updated failure-notification steps and that the `failure()` guard remains present in all four workflows.
- Committed the changes successfully; `git push` failed in this environment because `origin` is not configured, but a PR record was created via the repo tooling with the PR title/body provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ccbdb8f48326a00941410e72e639)