### PR TITLE
Restrict winners posts to DISCORD_WINNERS_CHANNEL_ID only

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -127,12 +127,6 @@ def format_voter_names_for_message(names: List[str]) -> str:
 
 
 def pick_winners_channel_id(items: List[dict]) -> Optional[str]:
-    if DISCORD_DAILY_PICKS_CHANNEL_ID:
-        return DISCORD_DAILY_PICKS_CHANNEL_ID
-    for item in items:
-        channel_id = item.get("channel_id")
-        if isinstance(channel_id, str) and channel_id.strip():
-            return channel_id
     return DISCORD_WINNERS_CHANNEL_ID
 
 
@@ -203,7 +197,7 @@ def main() -> None:
     if not winners_channel_id:
         raise RuntimeError(
             "Winners destination channel id is not set. "
-            "Set DISCORD_DAILY_PICKS_CHANNEL_ID or DISCORD_WINNERS_CHANNEL_ID."
+            "Set DISCORD_WINNERS_CHANNEL_ID."
         )
 
     with requests.Session() as session:


### PR DESCRIPTION
### Motivation

* Ensure Daily Game Picks winners are never routed to the daily vote channel and must go only to the dedicated winners channel by default, failing fast if that channel is not configured.

### Description

* Updated `pick_winners_channel_id(items)` in `evening_winners.py` to return only `DISCORD_WINNERS_CHANNEL_ID` and removed the previous fallbacks to `DISCORD_DAILY_PICKS_CHANNEL_ID` and per-item `channel_id`, and updated the runtime error to explicitly require `DISCORD_WINNERS_CHANNEL_ID`.

### Testing

* Ran `python -m py_compile evening_winners.py` to verify the file compiles successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d474dff48326963574c7d4ea44c3)