### PR TITLE
Rename State Sanity Check to Bot Data Health Check and post summary to Discord

### DIFF
--- a/.github/workflows/state-sanity-check.yml
+++ b/.github/workflows/state-sanity-check.yml
@@ -1,4 +1,4 @@
-name: State Sanity Check
+name: Bot Data Health Check
 
 on:
   workflow_dispatch:
@@ -21,5 +21,104 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Run state sanity check
-        run: python scripts/check_state_sanity.py
+      - name: Run bot data health check
+        id: sanity-check
+        continue-on-error: true
+        run: python scripts/check_state_sanity.py --json > state-sanity-summary.json
+
+      - name: Build Discord summary
+        if: ${{ always() }}
+        id: discord-summary
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import datetime
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path("state-sanity-summary.json")
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          warnings = summary.get("warnings", [])
+          errors = summary.get("errors", [])
+          cap = 5
+
+          date_text = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+          lines = [f"🧪 XiannGPT Bot Data Health Check — {date_text}"]
+
+          if errors:
+            lines.append("Status: 🔴 failed")
+          elif warnings:
+            lines.append("Status: 🟡 passed with warnings")
+          else:
+            lines.append("Status: ✅ passed")
+
+          if warnings:
+            lines.append("Warnings:")
+            for warning in warnings[:cap]:
+              lines.append(f"- {warning}")
+            if len(warnings) > cap:
+              lines.append(f"...and {len(warnings) - cap} more warnings in GitHub run logs")
+          else:
+            lines.append("Warnings: 0")
+
+          if errors:
+            lines.append("Errors:")
+            for error in errors[:cap]:
+              lines.append(f"- {error}")
+            if len(errors) > cap:
+              lines.append(f"...and {len(errors) - cap} more errors in GitHub run logs")
+          else:
+            lines.append("Errors: 0")
+
+          lines.append(f"Run: {os.environ['RUN_URL']}")
+          content = "\n".join(lines)
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as file:
+            file.write("content<<EOF\n")
+            file.write(content)
+            file.write("\nEOF\n")
+          PY
+
+      - name: Post health summary to Discord
+        if: ${{ always() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          HEALTH_REPORT_CONTENT: ${{ steps.discord-summary.outputs.content }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+          print(json.dumps({"content": os.environ["HEALTH_REPORT_CONTENT"]}))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"
+
+      - name: Fail workflow on bot data health check errors
+        if: ${{ always() && steps.sanity-check.outcome == 'failure' }}
+        run: |
+          echo "Bot data health check found errors." >&2
+          exit 1

--- a/scripts/check_state_sanity.py
+++ b/scripts/check_state_sanity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -105,7 +106,21 @@ def check_daily_posts(report: SanityReport) -> None:
             report.error(f"expected 'items' list for date {date_key} in {path}")
 
 
-def run_checks() -> int:
+def build_summary(report: SanityReport) -> dict[str, Any]:
+    if report.errors:
+        status = "failed"
+    elif report.warnings:
+        status = "passed_with_warnings"
+    else:
+        status = "passed"
+    return {
+        "status": status,
+        "warnings": report.warnings,
+        "errors": report.errors,
+    }
+
+
+def run_checks(*, json_output: bool = False) -> int:
     report = SanityReport()
 
     check_weekly_mapping("data/scheduling/weekly_schedule_messages.json", report)
@@ -114,6 +129,12 @@ def run_checks() -> int:
     check_weekly_mapping("data/scheduling/weekly_schedule_bot_outputs.json", report)
     check_expected_schedule_roster(report)
     check_daily_posts(report)
+
+    summary = build_summary(report)
+
+    if json_output:
+        print(json.dumps(summary))
+        return 1 if report.errors else 0
 
     if report.warnings:
         print("STATE SANITY WARNINGS:")
@@ -131,4 +152,7 @@ def run_checks() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(run_checks())
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON summary")
+    args = parser.parse_args()
+    sys.exit(run_checks(json_output=args.json))


### PR DESCRIPTION
### Motivation

* Make the existing state sanity check easier to understand and surface results directly to the repo's Discord health-monitor channel. 
* Keep the validation behavior unchanged while adding a compact, human-readable summary that operators can scan quickly. 

### Description

* Rename the workflow from `State Sanity Check` to `Bot Data Health Check` and keep the same triggers and `contents: read` permission. 
* Run the existing checker in machine-readable mode by calling `python scripts/check_state_sanity.py --json` and save the JSON summary to `state-sanity-summary.json`. 
* Add a workflow step that builds a concise Discord message (status near the top, separate Warnings/Errors sections, inline cap of 5 items, overflow note, and the GitHub Actions run URL) and expose it via `GITHUB_OUTPUT`. 
* Post the summary to the `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` using the repo's existing `curl` webhook pattern and preserve failure semantics by allowing the check step to continue for notification and then failing the job if the sanity check reported errors. 
* Keep `scripts/check_state_sanity.py` backward compatible and add an optional `--json` flag that emits a structured summary with `status`, `warnings`, and `errors` without changing the underlying validation logic. 

### Testing

* Ran `python scripts/check_state_sanity.py` and confirmed the original human-readable output reports success. 
* Ran `python scripts/check_state_sanity.py --json` and confirmed it prints a JSON object with `status`, `warnings`, and `errors`. 
* Compiled the script with `python -m compileall scripts/check_state_sanity.py` to verify there are no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d9bfc8bc8326b4c63f18228d8459)