### PR TITLE
Add 3 new active members to scheduling roster

### DIFF
--- a/data/scheduling/expected_schedule_roster.json
+++ b/data/scheduling/expected_schedule_roster.json
@@ -54,6 +54,21 @@
       "username": "thomasgoh",
       "global_name": "Thomas",
       "is_active": true
+    },
+    "321367835525775381": {
+      "username": "cangnguyen",
+      "global_name": "CountCrapula",
+      "is_active": true
+    },
+    "204517030395641856": {
+      "username": "datvnguyen",
+      "global_name": "Nguyen Vu Tat Dat",
+      "is_active": true
+    },
+    "239951450082377740": {
+      "username": "cvang24",
+      "global_name": "Christian",
+      "is_active": true
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Add three Discord users to the expected weekly scheduling roster so they are included in scheduling reminders, missing-user checks, and weekly summary participation.

### Description
- Updated `data/scheduling/expected_schedule_roster.json` to include three new active users. 
- Added the following entries under the top-level `"users"` object with `"is_active": true`:
  - `321367835525775381`: `username`: `cangnguyen`, `global_name`: `CountCrapula`.
  - `204517030395641856`: `username`: `datvnguyen`, `global_name`: `Nguyen Vu Tat Dat`.
  - `239951450082377740`: `username`: `cvang24`, `global_name`: `Christian`.
- Preserved the existing JSON structure, formatting, and all other users, and made no changes to scheduling, reminder, or health-monitoring logic.

### Testing
- Validated JSON syntax with `python -m json.tool data/scheduling/expected_schedule_roster.json` which succeeded.
- Verified the three new user IDs appear in `data/scheduling/expected_schedule_roster.json` via a content search.
- Confirmed no unrelated files were modified and only `data/scheduling/expected_schedule_roster.json` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e008be148326a170149476956285)