### PR TITLE
fix: set PYTHONPATH for Weekly Scheduling Responses Sync

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Sync weekly schedule responses
         env:
+          PYTHONPATH: .
           DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
           TARGET_WEEK_KEY: ${{ github.event.inputs.target_week_key || '' }}
           REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}


### PR DESCRIPTION
### Motivation
- The workflow failed with `ModuleNotFoundError` because running `python scripts/sync_weekly_schedule_responses.py` in GitHub Actions did not reliably include the repository root on Python's import path, preventing import of the root-level `discord_api.py`.

### Description
- Add `PYTHONPATH: .` to the `Sync weekly schedule responses` step in `.github/workflows/weekly-scheduling-responses-sync.yml` so the script can import root-level shared modules.

### Testing
- Ran a local automated assertion that `.github/workflows/weekly-scheduling-responses-sync.yml` contains `PYTHONPATH: .`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e38997948326a4ca52dcaee42ed9)