### PR TITLE
Update Bot Health Report wording to Bot Data Health Check

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -26,7 +26,7 @@ jobs:
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
               { file: "daily.yml", name: "Daily Steam Picks", staleHours: 30 },
               { file: "evening-winners.yml", name: "Evening Winners", staleHours: 30 },
-              { file: "state-sanity-check.yml", name: "State Sanity Check", staleHours: 192 },
+              { file: "state-sanity-check.yml", name: "Bot Data Health Check", staleHours: 192 },
             ];
 
             function formatAge(hours) {


### PR DESCRIPTION
### Motivation

- The Bot Health Report list displayed the outdated label `State Sanity Check`, which is inconsistent with the workflow renamed elsewhere to `Bot Data Health Check`.

### Description

- Updated `.github/workflows/bot-health-report.yml` to change the displayed name in the `workflows` array from `State Sanity Check` to `Bot Data Health Check` while keeping the underlying workflow file reference `state-sanity-check.yml` and making no other changes.

### Testing

- Ran `git diff` and `rg -n "state-sanity-check.yml|State Sanity Check|Bot Data Health Check"` and `git status --short` to confirm the display name was updated and only `.github/workflows/bot-health-report.yml` was modified, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ef150e148326a4abbfd6e6d9522b)