### PR TITLE
Refresh winners updates when deduped vote counts change

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -297,16 +297,39 @@ def main() -> None:
             today_entry["winners_state"] = winners_state
 
         current_winner_keys = sorted(deduped_winners.keys())
+        current_winner_vote_counts = {
+            key: int(deduped_winners[key]["human_votes"])
+            for key in current_winner_keys
+        }
         previous_message_id = winners_state.get("message_id")
         previous_winner_keys = winners_state.get("winner_keys")
         if not isinstance(previous_winner_keys, list):
             previous_winner_keys = []
+        previous_winner_vote_counts = winners_state.get("winner_vote_counts")
+        had_previous_vote_snapshot = isinstance(previous_winner_vote_counts, dict)
+        if not had_previous_vote_snapshot:
+            previous_winner_vote_counts = {}
+        normalized_previous_vote_counts = {
+            str(key): int(value)
+            for key, value in previous_winner_vote_counts.items()
+            if str(key)
+        }
 
         if not current_winner_keys and not (isinstance(previous_message_id, str) and previous_message_id):
             print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
             return
 
-        if sorted(str(key) for key in previous_winner_keys) == current_winner_keys:
+        keys_unchanged = sorted(str(key) for key in previous_winner_keys) == current_winner_keys
+        vote_counts_unchanged = normalized_previous_vote_counts == current_winner_vote_counts
+
+        if keys_unchanged and not had_previous_vote_snapshot:
+            winners_state["winner_vote_counts"] = current_winner_vote_counts
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no newly eligible winners for {day_key} (backfilled vote snapshot)")
+            return
+
+        if keys_unchanged and vote_counts_unchanged:
             print(f"SKIP: no newly eligible winners for {day_key}")
             return
 
@@ -324,6 +347,7 @@ def main() -> None:
                     context=f"edit winners message for {day_key}",
                 )
                 winners_state["winner_keys"] = current_winner_keys
+                winners_state["winner_vote_counts"] = current_winner_vote_counts
                 winners_state["last_action"] = "edit"
                 winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
                 save_discord_daily_posts(daily_posts)
@@ -338,6 +362,7 @@ def main() -> None:
         new_message_id = post_winners_message(client, winners_channel_id, message)
         winners_state["message_id"] = new_message_id
         winners_state["winner_keys"] = current_winner_keys
+        winners_state["winner_vote_counts"] = current_winner_vote_counts
         winners_state["last_action"] = "create"
         winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
         save_discord_daily_posts(daily_posts)

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -167,6 +167,63 @@ def test_winners_rerun_skip_then_edit_for_newly_eligible_winner(monkeypatch, tmp
     assert "Brand New" in fake_edit.edits[0][2]
 
 
+def test_winners_rerun_same_keys_with_higher_votes_triggers_edit(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"] = {
+        "message_id": "w-old",
+        "winner_keys": ["paid-win", "shared-dupe"],
+        "winner_vote_counts": {"paid-win": 1, "shared-dupe": 1},
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    payloads = {
+        "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 4}]},  # 3 human votes
+        "m-dupe": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-paid": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+    }
+    reaction_users = {
+        "m-late": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}, {"id": "u5", "username": "u5"}, {"id": "u8", "username": "u8"}],
+        "m-paid": [{"id": "bot-1"}, {"id": "u2", "username": "u2"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+    winners.main()
+
+    assert len(fake.edits) == 1
+    assert fake.edits[0][0] == "wchan"
+    assert "Late Voted Earlier Day" in fake.edits[0][2]
+    assert "👍 3 votes" in fake.edits[0][2]
+    assert fake.posts == []
+
+
+def test_winners_rerun_same_keys_same_vote_counts_is_noop(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"] = {
+        "message_id": "w-old",
+        "winner_keys": ["paid-win", "shared-dupe"],
+        "winner_vote_counts": {"paid-win": 1, "shared-dupe": 2},
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    payloads = {
+        "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 3}]},  # 2 human votes
+        "m-dupe": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-paid": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+    }
+    reaction_users = {
+        "m-late": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}, {"id": "u5", "username": "u5"}],
+        "m-paid": [{"id": "bot-1"}, {"id": "u2", "username": "u2"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+    winners.main()
+
+    assert fake.posts == []
+    assert fake.edits == []
+
+
 def test_no_eligible_winners_and_no_existing_message_is_noop(monkeypatch, tmp_path):
     day_key = "2026-04-08"
     path = tmp_path / "daily.json"


### PR DESCRIPTION
### Motivation
- The existing winners workflow only compared `winner_keys`, which prevented updating an existing winners message when human vote totals changed for deduped winners.
- We want the winners message to reflect live-ish vote totals while preserving the 10-day lookback and dedupe behavior and keeping low channel churn.
- The change must be minimal-risk and backward-compatible with existing `winners_state` entries.

### Description
- Persist a per-winner snapshot `winner_vote_counts` (`{winner_key: human_votes}`) in `winners_state` alongside `winner_keys` in `evening_winners.py`.
- Update the skip logic to no-op only when both deduped keys and the vote-count snapshot are unchanged, and trigger an edit/create when keys change or vote counts change.
- Add a quiet backfill path that stores the current vote snapshot when legacy `winners_state` lacks `winner_vote_counts` to avoid unnecessary edits during upgrade.
- Add tests and update `tests/test_evening_winners.py` to cover same-keys+increased-votes => edit, same-keys+same-votes => skip, new winner flows, in-window dedupe, bot-only exclusion, and no-op when no winners and no prior message.

### Testing
- Ran the updated unit tests with `pytest -q tests/test_evening_winners.py` and observed `9 passed`.
- New tests verify that increased human votes for an already-deduped winner triggers an edit and that unchanged snapshots remain a no-op.
- Existing winner/dedupe behaviors, message creation, and voter-name display truncation remain covered by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d732ef9a8083269e59d44d8d92a20a)