### PR TITLE
Add calendar dates to weekly scheduling day posts

### DIFF
--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -34,14 +34,14 @@ Tue 7–9 PM
 Wed after 6
 Sat 1–4 PM"""
 
-DAY_MESSAGES: list[tuple[str, str]] = [
-    ("Monday", "🇲 Monday"),
-    ("Tuesday", "🇹 Tuesday"),
-    ("Wednesday", "🇼 Wednesday"),
-    ("Thursday", "🇷 Thursday"),
-    ("Friday", "🇫 Friday"),
-    ("Saturday", "🇸 Saturday"),
-    ("Sunday", "🇺 Sunday"),
+DAY_MESSAGE_TEMPLATES: list[tuple[str, str, int]] = [
+    ("Monday", "🇲", 0),
+    ("Tuesday", "🇹", 1),
+    ("Wednesday", "🇼", 2),
+    ("Thursday", "🇷", 3),
+    ("Friday", "🇫", 4),
+    ("Saturday", "🇸", 5),
+    ("Sunday", "🇺", 6),
 ]
 
 AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
@@ -105,6 +105,10 @@ def try_get_message(client: DiscordClient, channel_id: str, message_id: str, con
         return False
 
 
+def format_day_message(day_name: str, emoji: str, day_date: date) -> str:
+    return f"{emoji} {day_name} — {day_date.month}/{day_date.day}"
+
+
 def ensure_day_reactions(client: DiscordClient, channel_id: str, day_name: str, message_id: str) -> None:
     for reaction in AVAILABILITY_REACTIONS:
         encoded = urllib.parse.quote(reaction, safe="")
@@ -163,7 +167,9 @@ def main() -> None:
 
         day_message_ids: dict[str, str] = {}
         created_days = 0
-        for day_name, day_message in DAY_MESSAGES:
+        for day_name, emoji, day_offset in DAY_MESSAGE_TEMPLATES:
+            day_date = week_start + timedelta(days=day_offset)
+            day_message = format_day_message(day_name, emoji, day_date)
             existing_day_id = existing_days.get(day_name)
             if isinstance(existing_day_id, str) and existing_day_id and try_get_message(
                 client,
@@ -192,7 +198,7 @@ def main() -> None:
         "updated_at_utc": utc_timestamp(),
         "intro_message_id": intro_message_id,
         "days": day_message_ids,
-        "post_completed": len(day_message_ids) == len(DAY_MESSAGES),
+        "post_completed": len(day_message_ids) == len(DAY_MESSAGE_TEMPLATES),
     }
 
     pruned = prune_latest_keys(weekly_messages, keep_last=12)

--- a/tests/test_weekly_post_availability.py
+++ b/tests/test_weekly_post_availability.py
@@ -60,10 +60,10 @@ def test_rerun_reuses_intro_and_days_without_duplicates(monkeypatch, tmp_path):
             "date_range": "Apr 13–19, 2026",
             "created_at_utc": "2026-04-01T00:00:00Z",
             "intro_message_id": "intro-1",
-            "days": {day: f"id-{day}" for day, _ in weekly.DAY_MESSAGES},
+            "days": {day: f"id-{day}" for day, _, _ in weekly.DAY_MESSAGE_TEMPLATES},
         }
     }
-    fake = FakeClient(existing_message_ids={"intro-1", *[f"id-{day}" for day, _ in weekly.DAY_MESSAGES]})
+    fake = FakeClient(existing_message_ids={"intro-1", *[f"id-{day}" for day, _, _ in weekly.DAY_MESSAGE_TEMPLATES]})
 
     saved = _run_main(monkeypatch, tmp_path, existing_state=existing, fake_client=fake)
 
@@ -79,7 +79,7 @@ def test_partial_recovery_only_creates_missing_or_stale_posts(monkeypatch, tmp_p
             "channel_id": "chan-1",
             "date_range": "Apr 13–19, 2026",
             "intro_message_id": "intro-1",
-            "days": {day: f"id-{day}" for day, _ in weekly.DAY_MESSAGES},
+            "days": {day: f"id-{day}" for day, _, _ in weekly.DAY_MESSAGE_TEMPLATES},
         }
     }
     fake = FakeClient(
@@ -94,6 +94,31 @@ def test_partial_recovery_only_creates_missing_or_stale_posts(monkeypatch, tmp_p
     assert saved[week_key]["days"]["Wednesday"].startswith("new-")
     assert saved[week_key]["days"]["Monday"] == "id-Monday"
     assert len(fake.reaction_calls) == len(weekly.AVAILABILITY_REACTIONS)
+
+
+def test_day_message_includes_week_dates_and_compact_format(monkeypatch, tmp_path):
+    fake = FakeClient()
+
+    _run_main(monkeypatch, tmp_path, existing_state={}, fake_client=fake)
+
+    day_contents = [
+        content
+        for context, content, _ in fake.created_messages
+        if context.startswith("post ") and "intro" not in context
+    ]
+    assert day_contents == [
+        "🇲 Monday — 4/13",
+        "🇹 Tuesday — 4/14",
+        "🇼 Wednesday — 4/15",
+        "🇷 Thursday — 4/16",
+        "🇫 Friday — 4/17",
+        "🇸 Saturday — 4/18",
+        "🇺 Sunday — 4/19",
+    ]
+
+
+def test_format_day_message_uses_no_leading_zeros():
+    assert weekly.format_day_message("Monday", "🇲", weekly.date(2026, 4, 3)) == "🇲 Monday — 4/3"
 
 
 def test_legacy_state_shape_loads_and_upgrades(monkeypatch, tmp_path, load_fixture_json):


### PR DESCRIPTION
### Motivation
- The weekly scheduling post did not include calendar dates next to each day while other availability flows had dates, so users lacked quick context for which calendar day each emoji/day referred to.
- The change should use the computed `week_start` to generate each day’s date dynamically while preserving all existing posting, reaction seeding, and reuse behavior.

### Description
- Replace the hardcoded `DAY_MESSAGES` strings with `DAY_MESSAGE_TEMPLATES` tuples that store `(day_name, emoji, monday_offset)` so ordering and emoji mapping remain unchanged.
- Add `format_day_message(day_name, emoji, day_date)` and build each day message as `emoji day_name — M/D` using `week_start + offset` to compute the date with no leading zeros.
- Update the posting loop to render day messages dynamically from the templates and adjust the `post_completed` check to use `DAY_MESSAGE_TEMPLATES` length.
- Update tests in `tests/test_weekly_post_availability.py` to use the new template shape and add assertions that verify the Monday–Sunday dated output and no-leading-zero formatting while preserving reaction seeding and reuse/recovery checks.

### Testing
- Ran `pytest -q tests/test_weekly_post_availability.py` and it completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73610a10c8326808a9849076cbf12)