### PR TITLE
Refactor: share scheduling day labels and show chronological summary order

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -18,6 +18,7 @@ on:
         type: boolean
         default: false
   schedule:
+    # No-op touch: keep cron unchanged while forcing workflow re-evaluation.
     - cron: '0 */3 * * *'
 
 permissions:

--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -9,6 +9,7 @@ from typing import Any
 import requests
 
 from discord_api import DiscordClient, DiscordMessageNotFoundError
+from scripts.scheduling_labels import DAY_MESSAGE_TEMPLATES, format_day_label
 from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
 
 USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
@@ -33,16 +34,6 @@ If needed, reply under a day message for custom availability, for example:
 Tue 7–9 PM
 Wed after 6
 Sat 1–4 PM"""
-
-DAY_MESSAGE_TEMPLATES: list[tuple[str, str, int]] = [
-    ("Monday", "🇲", 0),
-    ("Tuesday", "🇹", 1),
-    ("Wednesday", "🇼", 2),
-    ("Thursday", "🇷", 3),
-    ("Friday", "🇫", 4),
-    ("Saturday", "🇸", 5),
-    ("Sunday", "🇺", 6),
-]
 
 AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
 
@@ -106,7 +97,8 @@ def try_get_message(client: DiscordClient, channel_id: str, message_id: str, con
 
 
 def format_day_message(day_name: str, emoji: str, day_date: date) -> str:
-    return f"{emoji} {day_name} — {day_date.month}/{day_date.day}"
+    _ = emoji
+    return format_day_label(day_name, day_date, include_emoji=True)
 
 
 def ensure_day_reactions(client: DiscordClient, channel_id: str, day_name: str, message_id: str) -> None:

--- a/scripts/scheduling_labels.py
+++ b/scripts/scheduling_labels.py
@@ -1,0 +1,29 @@
+"""Shared day label helpers for weekly scheduling scripts."""
+
+from datetime import date
+
+DAY_MESSAGE_TEMPLATES: list[tuple[str, str, int]] = [
+    ("Monday", "🇲", 0),
+    ("Tuesday", "🇹", 1),
+    ("Wednesday", "🇼", 2),
+    ("Thursday", "🇷", 3),
+    ("Friday", "🇫", 4),
+    ("Saturday", "🇸", 5),
+    ("Sunday", "🇺", 6),
+]
+
+DAY_NAMES: list[str] = [day_name for day_name, _, _ in DAY_MESSAGE_TEMPLATES]
+DAY_EMOJIS: dict[str, str] = {day_name: emoji for day_name, emoji, _ in DAY_MESSAGE_TEMPLATES}
+
+
+def format_day_label(day_name: str, day_date: date, *, include_emoji: bool = False) -> str:
+    """Format a scheduling day label with a compact no-leading-zero date."""
+    base_label = f"{day_name} {day_date.month}/{day_date.day}"
+    if not include_emoji:
+        return base_label
+
+    emoji = DAY_EMOJIS.get(day_name)
+    if not emoji:
+        return base_label
+
+    return f"{emoji} {day_name} — {day_date.month}/{day_date.day}"

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 import requests
 
 from discord_api import DiscordClient, DiscordMessageNotFoundError
+from scripts.scheduling_labels import DAY_NAMES, format_day_label
 from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
@@ -22,16 +23,6 @@ WEEKLY_SCHEDULE_RESPONSES_FILE = "data/scheduling/weekly_schedule_responses.json
 WEEKLY_SCHEDULE_SUMMARY_FILE = "data/scheduling/weekly_schedule_summary.json"
 EXPECTED_SCHEDULE_ROSTER_FILE = "data/scheduling/expected_schedule_roster.json"
 WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE = "data/scheduling/weekly_schedule_bot_outputs.json"
-
-DAY_NAMES: list[str] = [
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-    "Sunday",
-]
 
 AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
 SUMMARY_SLOT_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝"]
@@ -533,7 +524,7 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
         day_date = week_dates.get(day_name)
         if day_date is None:
             return day_name
-        return f"{day_name} {day_date.month}/{day_date.day}"
+        return format_day_label(day_name, day_date)
 
     def format_voter_line(day_name: str, slot: str, slot_count: int) -> str:
         raw_day_slot_voters = slot_voters.get(day_name)
@@ -594,31 +585,21 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
                 ordered_lines.append(format_voter_line(day_name, slot, slot_count))
         return ordered_lines
 
-    ranked_days = sorted(
-        DAY_NAMES,
-        key=lambda day_name: (
-            -max(int(slot_counts.get(day_name, {}).get(slot, 0)) for slot in SUMMARY_SLOT_ORDER),
-            -int(day_counts.get(day_name, 0)),
-            DAY_NAMES.index(day_name),
-        ),
-    )
-
-    ranked_day_lines: list[str] = []
-    for index, day_name in enumerate(ranked_days):
-        ranked_day_lines.append(f"{index + 1}. **{day_with_date_label(day_name)}**")
+    chronological_day_lines: list[str] = []
+    for index, day_name in enumerate(DAY_NAMES):
+        chronological_day_lines.append(f"**{day_with_date_label(day_name)}**")
         day_slot_lines = build_day_slot_lines(day_name)
         if day_slot_lines:
-            ranked_day_lines.extend(day_slot_lines)
+            chronological_day_lines.extend(day_slot_lines)
         else:
-            ranked_day_lines.append("No responses")
-        if index < len(ranked_days) - 1:
-            ranked_day_lines.append("")
+            chronological_day_lines.append("No responses")
+        if index < len(DAY_NAMES) - 1:
+            chronological_day_lines.append("")
 
     lines = [
         f"📊 Availability Summary — {date_range}",
         "",
-        "All days ranked:",
-        *ranked_day_lines,
+        *chronological_day_lines,
     ]
 
     message = "\n".join(lines)
@@ -628,11 +609,7 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
     fallback_lines = [
         f"📊 Availability Summary — {date_range}",
         "",
-        "All days ranked:",
-        *(
-            f"{index + 1}. **{day_with_date_label(day_name)}**"
-            for index, day_name in enumerate(ranked_days)
-        ),
+        *(f"**{day_with_date_label(day_name)}**" for day_name in DAY_NAMES),
         "",
         "_Detailed voter names were truncated to fit Discord message limits._",
     ]

--- a/tests/test_scheduling_labels.py
+++ b/tests/test_scheduling_labels.py
@@ -1,0 +1,16 @@
+from datetime import date
+
+from scripts import post_weekly_availability as weekly
+from scripts import scheduling_labels
+
+
+def test_format_day_label_no_leading_zeros():
+    assert scheduling_labels.format_day_label("Monday", date(2026, 4, 3)) == "Monday 4/3"
+    assert scheduling_labels.format_day_label("Monday", date(2026, 4, 3), include_emoji=True) == "🇲 Monday — 4/3"
+
+
+def test_post_script_uses_shared_day_label_helper():
+    assert (
+        weekly.format_day_message("Tuesday", "🇹", date(2026, 4, 14))
+        == scheduling_labels.format_day_label("Tuesday", date(2026, 4, 14), include_emoji=True)
+    )

--- a/tests/test_weekly_post_availability.py
+++ b/tests/test_weekly_post_availability.py
@@ -1,6 +1,7 @@
 import json
 
 from scripts import post_weekly_availability as weekly
+from scripts import scheduling_labels
 
 
 class FakeSession:
@@ -118,7 +119,11 @@ def test_day_message_includes_week_dates_and_compact_format(monkeypatch, tmp_pat
 
 
 def test_format_day_message_uses_no_leading_zeros():
-    assert weekly.format_day_message("Monday", "🇲", weekly.date(2026, 4, 3)) == "🇲 Monday — 4/3"
+    assert (
+        weekly.format_day_message("Monday", "🇲", weekly.date(2026, 4, 3))
+        == scheduling_labels.format_day_label("Monday", weekly.date(2026, 4, 3), include_emoji=True)
+        == "🇲 Monday — 4/3"
+    )
 
 
 def test_legacy_state_shape_loads_and_upgrades(monkeypatch, tmp_path, load_fixture_json):

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -85,10 +85,56 @@ def test_summary_format_includes_dates_voter_names_and_truncation():
 
     assert "Monday 4/13" in msg
     assert "Best overlap:" not in msg
-    assert "All days ranked:" in msg
+    assert "All days ranked:" not in msg
     assert "✅" in msg
     assert "+" in msg and "more" in msg
     assert "User1, User1" not in msg
+
+
+def test_summary_format_is_monday_to_sunday_chronological():
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {d: 0 for d in sync.DAY_NAMES},
+            "slot_counts": {
+                d: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "slot_voters": {
+                d: {slot: [] for slot in sync.SUMMARY_SLOT_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": 0},
+        },
+    }
+
+    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+
+    day_positions = [msg.index(f"**{day} 4/{13 + index}**") for index, day in enumerate(sync.DAY_NAMES)]
+    assert day_positions == sorted(day_positions)
+
+
+def test_shared_date_label_helper_matches_summary_and_day_posts():
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {d: 0 for d in sync.DAY_NAMES},
+            "slot_counts": {
+                d: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "slot_voters": {
+                d: {slot: [] for slot in sync.SUMMARY_SLOT_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": 0},
+        },
+    }
+
+    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+    assert "**Monday 4/13**" in msg
 
 
 def test_main_rebuild_only_edits_or_recovers_summary(monkeypatch, tmp_path, load_fixture_json):


### PR DESCRIPTION
### Motivation

- Ensure the Saturday scheduling posts and the availability summary display dates identically by centralizing date-label formatting. 
- Make the availability summary deterministic and easier to scan by always listing Monday→Sunday chronologically.
- Force a harmless workflow YAML touch so GitHub re-evaluates the scheduled workflow without changing its behavior.

### Description

- Add a small shared helper module `scripts/scheduling_labels.py` that centralizes the Monday→Sunday ordering, emoji mapping, and a compact no-leading-zero date-label formatter `format_day_label` used by both scripts.
- Refactor `scripts/post_weekly_availability.py` to import `DAY_MESSAGE_TEMPLATES` and use `format_day_label(..., include_emoji=True)` for day post labels, preserving existing emoji mappings and formatting (e.g. `🇲 Monday — 4/13`).
- Refactor `scripts/sync_weekly_schedule_responses.py` to import `DAY_NAMES` and `format_day_label`, remove the ranked/sorted "All days ranked:" block, and render the availability summary in chronological Monday→Sunday order while preserving all per-slot detail lines, voter-name dedup/truncation logic, and the Discord-length fallback behavior.
- Make a no-op comment addition near the cron block in `.github/workflows/weekly-scheduling-responses-sync.yml` to trigger workflow re-evaluation without changing the cron schedule.
- Add and update tests: new `tests/test_scheduling_labels.py`, and updates to `tests/test_weekly_post_availability.py` and `tests/test_weekly_sync_summary.py` to assert shared label usage, no-leading-zero formatting, removal of the "All days ranked" heading, and chronological ordering.

### Testing

- Ran `pytest -q tests/test_weekly_post_availability.py tests/test_weekly_sync_summary.py tests/test_scheduling_labels.py` and all tests passed.

- Test output: `14 passed in 0.39s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73ea8cb348326905d98b90cce1d15)