### PR TITLE
Improve weekly summary readability and add sync observability logs

### DIFF
--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -44,6 +44,19 @@ jobs:
       - name: Install dependencies
         run: pip install requests
 
+      - name: Log sync context
+        env:
+          TARGET_WEEK_KEY: ${{ github.event.inputs.target_week_key || '' }}
+          REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          echo "Workflow trigger: ${{ github.event_name }}"
+          echo "Selected TARGET_WEEK_KEY: ${TARGET_WEEK_KEY:-'(default latest)'}"
+          echo "REBUILD_SUMMARY_ONLY: ${REBUILD_SUMMARY_ONLY}"
+          echo "DRY_RUN: ${DRY_RUN}"
+          echo "Current UTC time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          echo "Current New York time: $(TZ=America/New_York date '+%Y-%m-%d %I:%M:%S %p %Z')"
+
       - name: Sync weekly schedule responses
         env:
           PYTHONPATH: .
@@ -52,6 +65,12 @@ jobs:
           REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: python scripts/sync_weekly_schedule_responses.py
+
+      - name: Log sync completion
+        run: |
+          echo "Sync step completed"
+          echo "Post-sync UTC time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          echo "Post-sync New York time: $(TZ=America/New_York date '+%Y-%m-%d %I:%M:%S %p %Z')"
 
       - name: Commit weekly schedule responses
         run: |

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -501,7 +501,36 @@ def compute_week_dates_from_summary(week_summary: dict[str, Any]) -> dict[str, d
     return {}
 
 
-def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str:
+def count_active_roster_users(roster: dict[str, Any]) -> int:
+    """Return the number of active users from the expected roster."""
+    users = roster.get("users")
+    if not isinstance(users, dict):
+        fail(f"Missing or invalid users object in {EXPECTED_SCHEDULE_ROSTER_FILE}")
+    return sum(
+        1
+        for user in users.values()
+        if isinstance(user, dict) and user.get("is_active") is True
+    )
+
+
+def format_summary_last_updated_line(synced_at_utc: datetime) -> str:
+    """Format a compact New York last-updated line for summary output."""
+    ny_time = synced_at_utc.astimezone(NEW_YORK_TIMEZONE)
+    month_day = f"{ny_time.strftime('%b')} {ny_time.day}"
+    hour_12 = ((ny_time.hour - 1) % 12) + 1
+    minute = f"{ny_time.minute:02d}"
+    am_pm = ny_time.strftime("%p")
+    return f"*Last updated: {month_day}, {hour_12}:{minute} {am_pm} ET*"
+
+
+def format_summary_message(
+    date_range: str,
+    week_summary: dict[str, Any],
+    *,
+    responded_count: int,
+    active_user_count: int,
+    synced_at_utc: datetime,
+) -> str:
     """Build a richer deterministic summary message from weekly summary data."""
     summary = week_summary.get("summary")
     if not isinstance(summary, dict):
@@ -596,8 +625,17 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
         if index < len(DAY_NAMES) - 1:
             chronological_day_lines.append("")
 
+    missing_count = max(active_user_count - responded_count, 0)
+    response_status_line = (
+        f"*{responded_count} of {active_user_count} people responded • "
+        f"{missing_count} still missing*"
+    )
+    last_updated_line = format_summary_last_updated_line(synced_at_utc)
     lines = [
         f"📊 Availability Summary — {date_range}",
+        "",
+        response_status_line,
+        last_updated_line,
         "",
         *chronological_day_lines,
     ]
@@ -608,6 +646,9 @@ def format_summary_message(date_range: str, week_summary: dict[str, Any]) -> str
 
     fallback_lines = [
         f"📊 Availability Summary — {date_range}",
+        "",
+        response_status_line,
+        last_updated_line,
         "",
         *(f"**{day_with_date_label(day_name)}**" for day_name in DAY_NAMES),
         "",
@@ -818,6 +859,9 @@ def main() -> None:
         fail(f"Missing or invalid date_range for {posting_week_key}")
 
     missing_user_ids = compute_missing_user_ids_for_week(posting_week_responses, roster)
+    active_user_count = count_active_roster_users(roster)
+    responded_count = max(active_user_count - len(missing_user_ids), 0)
+    summary_synced_at_utc = datetime.now(ZoneInfo("UTC"))
     week_outputs = weekly_bot_outputs.get(posting_week_key)
     if not isinstance(week_outputs, dict):
         week_outputs = {}
@@ -832,7 +876,13 @@ def main() -> None:
         )
         discord_client = DiscordClient(posting_session)
 
-        summary_message = format_summary_message(date_range, posting_week_summary)
+        summary_message = format_summary_message(
+            date_range,
+            posting_week_summary,
+            responded_count=responded_count,
+            active_user_count=active_user_count,
+            synced_at_utc=summary_synced_at_utc,
+        )
         previous_summary_message_id = week_outputs.get("summary_message_id")
         summary_message_id = (
             str(previous_summary_message_id)

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -81,7 +81,13 @@ def test_summary_format_includes_dates_voter_names_and_truncation():
         },
     }
 
-    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+    msg = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=1,
+        active_user_count=2,
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+    )
 
     assert "Monday 4/13" in msg
     assert "Best overlap:" not in msg
@@ -109,7 +115,13 @@ def test_summary_format_is_monday_to_sunday_chronological():
         },
     }
 
-    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+    msg = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=1,
+        active_user_count=2,
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+    )
 
     day_positions = [msg.index(f"**{day} 4/{13 + index}**") for index, day in enumerate(sync.DAY_NAMES)]
     assert day_positions == sorted(day_positions)
@@ -133,8 +145,63 @@ def test_shared_date_label_helper_matches_summary_and_day_posts():
         },
     }
 
-    msg = sync.format_summary_message("Apr 13–19, 2026", week_summary)
+    msg = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=1,
+        active_user_count=2,
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+    )
     assert "**Monday 4/13**" in msg
+
+
+def test_summary_includes_status_timestamp_spacing_and_slot_order():
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {d: 0 for d in sync.DAY_NAMES},
+            "slot_counts": {
+                "Monday": {"✅": 3, "🌅": 1, "☀️": 2, "🌙": 1, "📝": 1, "❌": 4},
+                "Tuesday": {"✅": 0, "🌅": 0, "☀️": 1, "🌙": 0, "📝": 0, "❌": 0},
+                **{
+                    day: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER}
+                    for day in sync.DAY_NAMES
+                    if day not in {"Monday", "Tuesday"}
+                },
+            },
+            "slot_voters": {
+                "Monday": {
+                    "✅": [{"display_name": "Alice"}, {"display_name": "Bob"}, {"display_name": "Charlie"}],
+                    "🌅": [{"display_name": "Dawn"}],
+                    "☀️": [{"display_name": "Sun1"}, {"display_name": "Sun2"}],
+                    "🌙": [{"display_name": "Moon"}],
+                    "📝": [{"display_name": "Note"}],
+                },
+                "Tuesday": {"✅": [], "🌅": [], "☀️": [{"display_name": "Erin"}], "🌙": [], "📝": []},
+                **{
+                    day: {slot: [] for slot in sync.SUMMARY_SLOT_ORDER}
+                    for day in sync.DAY_NAMES
+                    if day not in {"Monday", "Tuesday"}
+                },
+            },
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": 3},
+        },
+    }
+
+    msg = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=12,
+        active_user_count=14,
+        synced_at_utc=sync.datetime(2026, 4, 10, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+    )
+
+    assert "*12 of 14 people responded • 2 still missing*" in msg
+    assert "*Last updated: Apr 9, 8:00 PM ET*" in msg
+    assert "\n\n**Tuesday 4/14**" in msg
+    assert "\n\n\n**Tuesday 4/14**" not in msg
+    assert "\n**Monday 4/13**\n✅ 3 — Alice, Bob, Charlie\n🌅 1 — Dawn\n☀️ 2 — Sun1, Sun2\n🌙 1 — Moon\n📝 1 — Note\n❌ 4 — (names unavailable)\n\n**Tuesday 4/14**\n☀️ 1 — Erin\n\n**Wednesday 4/15**\nNo responses" in msg
 
 
 def test_main_rebuild_only_edits_or_recovers_summary(monkeypatch, tmp_path, load_fixture_json):


### PR DESCRIPTION
### Motivation
- Make the weekly availability summary easier to scan day-by-day while preserving all existing vote/slot logic and truncation behavior.
- Surface lightweight status metadata (response counts and last-sync timestamp) to help debug missed scheduled runs without changing scheduling or reminder logic.
- Add harmless workflow logging around the sync step to improve observability of scheduled runs.

### Description
- Reworked `format_summary_message` to include a top status line and compact New York last-updated timestamp, keeping Monday→Sunday order, the existing slot display order (`✅`, `🌅`, `☀️`, `🌙`, `📝`, `❌`), voter-name truncation, and Discord-length fallback behavior (file: `scripts/sync_weekly_schedule_responses.py`).
- Added `count_active_roster_users` and `format_summary_last_updated_line`, computed `responded_count` from the active roster + existing missing-user logic, and pass `synced_at_utc` into the formatter so the message contains `*X of Y people responded • Z still missing*` and `*Last updated: ... ET*` lines (NY timezone).
- Instrumented the GitHub Actions job `weekly-scheduling-responses-sync.yml` with pre/post sync logging that prints workflow trigger type, selected `TARGET_WEEK_KEY`, mode flags, and UTC/New York timestamps without altering cron or scheduling behavior.
- Updated tests to exercise the new summary lines and spacing and adjusted existing calls to `format_summary_message` to supply the new parameters; added `test_summary_includes_status_timestamp_spacing_and_slot_order` (file: `tests/test_weekly_sync_summary.py`).

### Testing
- Ran `pytest -q tests/test_weekly_sync_summary.py`, which passed: `8 passed in 0.63s`.
- Ran `pytest -q tests/test_weekly_sync_summary.py tests/test_scheduling_labels.py`, which passed: `10 passed in 0.48s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7404c9db08326bb46b28530b2796d)