### PR TITLE
Reduce weekly summary churn by hashing meaningful summary data

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -1,11 +1,12 @@
 """Sync weekly scheduling reactions from Discord into durable JSON state."""
 
 import json
+import hashlib
 import os
 import sys
 import time
 import urllib.parse
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -657,6 +658,42 @@ def format_summary_message(
     return "\n".join(fallback_lines)
 
 
+def compute_summary_data_signature(
+    week_summary: dict[str, Any],
+    responded_count: int,
+    active_user_count: int,
+    missing_user_ids: list[str],
+) -> str:
+    """Hash meaningful summary inputs to detect real summary-data changes."""
+    signature_payload = {
+        "week_summary": week_summary,
+        "responded_count": responded_count,
+        "active_user_count": active_user_count,
+        "missing_user_ids": missing_user_ids,
+    }
+    stable_payload = json.dumps(signature_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(stable_payload.encode("utf-8")).hexdigest()
+
+
+def parse_iso_utc_datetime(value: Any) -> datetime | None:
+    """Parse an ISO timestamp into an aware UTC datetime."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def post_channel_message(session: requests.Session, channel_id: str, content: str) -> str:
     """Post a message to a Discord channel and return the new message id."""
     response = session.post(
@@ -860,8 +897,9 @@ def main() -> None:
 
     missing_user_ids = compute_missing_user_ids_for_week(posting_week_responses, roster)
     active_user_count = count_active_roster_users(roster)
-    responded_count = max(active_user_count - len(missing_user_ids), 0)
-    summary_synced_at_utc = datetime.now(ZoneInfo("UTC"))
+    # "Responded" means active roster users minus users still missing per reminder logic.
+    responded_active_user_count = max(active_user_count - len(missing_user_ids), 0)
+    summary_synced_at_utc = datetime.now(timezone.utc)
     week_outputs = weekly_bot_outputs.get(posting_week_key)
     if not isinstance(week_outputs, dict):
         week_outputs = {}
@@ -876,13 +914,6 @@ def main() -> None:
         )
         discord_client = DiscordClient(posting_session)
 
-        summary_message = format_summary_message(
-            date_range,
-            posting_week_summary,
-            responded_count=responded_count,
-            active_user_count=active_user_count,
-            synced_at_utc=summary_synced_at_utc,
-        )
         previous_summary_message_id = week_outputs.get("summary_message_id")
         summary_message_id = (
             str(previous_summary_message_id)
@@ -890,6 +921,55 @@ def main() -> None:
             else None
         )
         previous_summary_message_content = week_outputs.get("summary_message_content")
+        previous_summary_data_signature = normalize_optional_text(
+            week_outputs.get("summary_data_signature")
+        )
+        previous_summary_last_synced_at_utc = parse_iso_utc_datetime(
+            week_outputs.get("summary_last_synced_at_utc")
+        )
+        current_summary_data_signature = compute_summary_data_signature(
+            posting_week_summary,
+            responded_count=responded_active_user_count,
+            active_user_count=active_user_count,
+            missing_user_ids=missing_user_ids,
+        )
+        is_legacy_summary_without_signature = (
+            previous_summary_data_signature is None
+            and isinstance(previous_summary_message_content, str)
+            and bool(previous_summary_message_content)
+        )
+        summary_data_changed = (
+            previous_summary_data_signature != current_summary_data_signature
+            if previous_summary_data_signature is not None
+            else not is_legacy_summary_without_signature
+        )
+
+        if summary_data_changed:
+            effective_summary_synced_at_utc = summary_synced_at_utc
+            week_outputs["summary_last_synced_at_utc"] = (
+                effective_summary_synced_at_utc.isoformat()
+            )
+        else:
+            effective_summary_synced_at_utc = previous_summary_last_synced_at_utc
+
+        if (
+            not summary_data_changed
+            and isinstance(previous_summary_message_content, str)
+            and previous_summary_message_content
+        ):
+            summary_message = previous_summary_message_content
+        else:
+            if effective_summary_synced_at_utc is None:
+                effective_summary_synced_at_utc = summary_synced_at_utc
+            summary_message = format_summary_message(
+                date_range,
+                posting_week_summary,
+                responded_count=responded_active_user_count,
+                active_user_count=active_user_count,
+                synced_at_utc=effective_summary_synced_at_utc,
+            )
+
+        week_outputs["summary_data_signature"] = current_summary_data_signature
 
         if dry_run:
             print(f"DRY_RUN: summary preview for {posting_week_key}")

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -86,7 +86,7 @@ def test_summary_format_includes_dates_voter_names_and_truncation():
         week_summary,
         responded_count=1,
         active_user_count=2,
-        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.timezone.utc),
     )
 
     assert "Monday 4/13" in msg
@@ -120,7 +120,7 @@ def test_summary_format_is_monday_to_sunday_chronological():
         week_summary,
         responded_count=1,
         active_user_count=2,
-        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.timezone.utc),
     )
 
     day_positions = [msg.index(f"**{day} 4/{13 + index}**") for index, day in enumerate(sync.DAY_NAMES)]
@@ -150,7 +150,7 @@ def test_shared_date_label_helper_matches_summary_and_day_posts():
         week_summary,
         responded_count=1,
         active_user_count=2,
-        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.timezone.utc),
     )
     assert "**Monday 4/13**" in msg
 
@@ -194,7 +194,7 @@ def test_summary_includes_status_timestamp_spacing_and_slot_order():
         week_summary,
         responded_count=12,
         active_user_count=14,
-        synced_at_utc=sync.datetime(2026, 4, 10, 0, 0, tzinfo=sync.ZoneInfo("UTC")),
+        synced_at_utc=sync.datetime(2026, 4, 10, 0, 0, tzinfo=sync.timezone.utc),
     )
 
     assert "*12 of 14 people responded • 2 still missing*" in msg
@@ -212,6 +212,8 @@ def test_main_rebuild_only_edits_or_recovers_summary(monkeypatch, tmp_path, load
         week_key: {
             "summary_message_id": "sum-old",
             "summary_message_content": "old-content",
+            "summary_data_signature": "stale-signature",
+            "summary_last_synced_at_utc": "2026-04-01T00:00:00+00:00",
         },
         "2026-04-06_to_2026-04-12": {"summary_message_id": "preserve-me"},
     }
@@ -249,6 +251,7 @@ def test_main_dry_run_does_not_mutate_summary_message(monkeypatch, tmp_path, loa
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -376,3 +379,197 @@ def test_main_saturday_new_week_requires_change_and_allows_single_daily_reminder
     # Later same-day Saturday syncs cannot post another reminder.
     sync.main()
     assert len(reminder_posts) == 1
+
+
+def test_main_unchanged_summary_signature_skips_edit_and_keeps_timestamp(
+    monkeypatch, tmp_path
+):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {},
+            }
+        },
+    )
+
+    weekly_responses = json.loads(responses_p.read_text(encoding="utf-8"))
+    roster = json.loads(roster_p.read_text(encoding="utf-8"))
+    weekly_summary = sync.build_weekly_summary(weekly_responses)
+    posting_week_summary = weekly_summary[week_key]
+    missing_user_ids = sync.compute_missing_user_ids_for_week(weekly_responses[week_key], roster)
+    active_user_count = sync.count_active_roster_users(roster)
+    responded_count = max(active_user_count - len(missing_user_ids), 0)
+    old_synced_at = sync.datetime(2026, 4, 1, 0, 0, tzinfo=sync.timezone.utc)
+    prior_summary_message = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        posting_week_summary,
+        responded_count=responded_count,
+        active_user_count=active_user_count,
+        synced_at_utc=old_synced_at,
+    )
+    prior_signature = sync.compute_summary_data_signature(
+        posting_week_summary, responded_count, active_user_count, missing_user_ids
+    )
+    _write(
+        outputs_p,
+        {
+            week_key: {
+                "summary_message_id": "sum-old",
+                "summary_message_content": prior_summary_message,
+                "summary_data_signature": prior_signature,
+                "summary_last_synced_at_utc": old_synced_at.isoformat(),
+            }
+        },
+    )
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert fake_client.posts == []
+    assert fake_client.edits == []
+    assert outputs[week_key]["summary_last_synced_at_utc"] == old_synced_at.isoformat()
+    assert outputs[week_key]["summary_message_content"] == prior_summary_message
+
+
+def test_main_changed_summary_data_updates_timestamp_and_edits_message(monkeypatch, tmp_path):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {},
+            }
+        },
+    )
+    baseline_weekly_responses = json.loads(responses_p.read_text(encoding="utf-8"))
+    roster = json.loads(roster_p.read_text(encoding="utf-8"))
+    baseline_summary = sync.build_weekly_summary(baseline_weekly_responses)[week_key]
+    baseline_missing = sync.compute_missing_user_ids_for_week(
+        baseline_weekly_responses[week_key], roster
+    )
+    active_user_count = sync.count_active_roster_users(roster)
+    baseline_responded = max(active_user_count - len(baseline_missing), 0)
+    old_synced_at = sync.datetime(2026, 4, 1, 0, 0, tzinfo=sync.timezone.utc)
+    baseline_content = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        baseline_summary,
+        responded_count=baseline_responded,
+        active_user_count=active_user_count,
+        synced_at_utc=old_synced_at,
+    )
+    baseline_signature = sync.compute_summary_data_signature(
+        baseline_summary, baseline_responded, active_user_count, baseline_missing
+    )
+    _write(
+        outputs_p,
+        {
+            week_key: {
+                "summary_message_id": "sum-old",
+                "summary_message_content": baseline_content,
+                "summary_data_signature": baseline_signature,
+                "summary_last_synced_at_utc": old_synced_at.isoformat(),
+            }
+        },
+    )
+
+    _write(
+        responses_p,
+        {
+            week_key: {
+                "date_range": "Apr 13–19, 2026",
+                "users": {
+                    "100": {
+                        "username": "jan",
+                        "global_name": "Jan",
+                        "days": {
+                            day: {"reactions": ["✅"], "custom_reply": None}
+                            for day in sync.DAY_NAMES
+                        },
+                    }
+                },
+            }
+        },
+    )
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert fake_client.posts == []
+    assert len(fake_client.edits) == 1
+    assert outputs[week_key]["summary_message_content"] != baseline_content
+    assert outputs[week_key]["summary_data_signature"] != baseline_signature
+    assert outputs[week_key]["summary_last_synced_at_utc"] != old_synced_at.isoformat()
+
+
+def test_main_legacy_summary_backfills_signature_without_noisy_edit(monkeypatch, tmp_path):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {},
+            }
+        },
+    )
+    _write(
+        outputs_p,
+        {
+            week_key: {
+                "summary_message_id": "sum-old",
+                "summary_message_content": "legacy-summary-content",
+            }
+        },
+    )
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert fake_client.posts == []
+    assert fake_client.edits == []
+    assert outputs[week_key]["summary_message_content"] == "legacy-summary-content"
+    assert isinstance(outputs[week_key].get("summary_data_signature"), str)
+    assert "summary_last_synced_at_utc" not in outputs[week_key]


### PR DESCRIPTION
### Motivation
- Avoid frequent Discord summary message edits caused solely by the regenerated `Last updated` timestamp while preserving that timestamp feature.
- Keep all summary formatting, reminder behavior, and vote/overlap logic unchanged while adding a low-risk mechanism to detect meaningful summary changes.

### Description
- Add `compute_summary_data_signature` to hash meaningful summary inputs (`week_summary`, `responded_count`, `active_user_count`, `missing_user_ids`) and `parse_iso_utc_datetime` helper to read ISO UTC timestamps. (modified `scripts/sync_weekly_schedule_responses.py`)
- Store `summary_data_signature` and `summary_last_synced_at_utc` in `data/scheduling/weekly_schedule_bot_outputs.json` and only refresh the stored `summary_last_synced_at_utc` when the signature shows the summary data actually changed. (modified `scripts/sync_weekly_schedule_responses.py`)
- Preserve prior summary content/timestamp when the signature shows no meaningful change and quietly backfill legacy outputs that lack the new fields without forcing an edit. (modified `scripts/sync_weekly_schedule_responses.py`)
- Small UTC cleanup: replace `datetime.now(ZoneInfo("UTC"))` with `datetime.now(timezone.utc)` in the summary sync path and add a comment clarifying that `responded` is derived as `active roster - missing users`. (modified `scripts/sync_weekly_schedule_responses.py`)
- Add tests for unchanged-summary/no-edit, changed-summary/edit+timestamp update, and legacy-output backfill behavior; adjust a few existing tests to use `timezone.utc` where appropriate. (modified `tests/test_weekly_sync_summary.py`)

### Testing
- Ran the focused test file: `pytest -q tests/test_weekly_sync_summary.py` and all tests passed.

```
...........                                                              [100%]
11 passed in 0.34s
```
- The new tests verify: unchanged summary data does not update timestamp or edit the message, changed summary data updates signature/timestamp and triggers an edit, and legacy `weekly_schedule_bot_outputs.json` entries without the new fields are backfilled without noisy edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d742b66aa88326aa0e991b85ea5caf)