### PR TITLE
Recover stale winners message when winner keys are unchanged

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -306,9 +306,26 @@ def main() -> None:
             print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
             return
 
-        if sorted(str(key) for key in previous_winner_keys) == current_winner_keys:
-            print(f"SKIP: no newly eligible winners for {day_key}")
-            return
+        winner_keys_unchanged = sorted(str(key) for key in previous_winner_keys) == current_winner_keys
+        if winner_keys_unchanged:
+            if isinstance(previous_message_id, str) and previous_message_id:
+                try:
+                    client.get_message(
+                        winners_channel_id,
+                        previous_message_id,
+                        context=f"verify unchanged winners message for {day_key}",
+                    )
+                    print(f"SKIP: no newly eligible winners for {day_key}")
+                    return
+                except DiscordMessageNotFoundError:
+                    print(
+                        f"RECOVER: stale/deleted winners message for {day_key} "
+                        f"(message_id={previous_message_id}); posting replacement"
+                    )
+                    previous_message_id = None
+            elif not current_winner_keys:
+                print(f"SKIP: no newly eligible winners for {day_key}")
+                return
 
         if isinstance(previous_message_id, str) and previous_message_id:
             try:

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -178,6 +178,33 @@ def test_no_eligible_winners_and_no_existing_message_is_noop(monkeypatch, tmp_pa
     assert fake.edits == []
 
 
+def test_unchanged_winner_keys_with_stale_message_posts_replacement(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"] = {"message_id": "w-stale", "winner_keys": ["paid-win", "shared-dupe"]}
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    payloads = {
+        "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-dupe": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-paid": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-old-in": {"reactions": [{"emoji": {"name": "👍"}, "count": 1}]},
+    }
+    reaction_users = {
+        "m-late": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}],
+        "m-paid": [{"id": "bot-1"}, {"id": "u2", "username": "u2"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users, stale_winner_id="w-stale")
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) == 1
+    assert fake.edits == []
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert updated[day_key]["winners_state"]["message_id"] == "w-1"
+
+
 def test_stale_daily_item_message_is_skipped(monkeypatch, tmp_path):
     day_key, path = _setup_daily(tmp_path)
     payloads = {"m-paid": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]}}


### PR DESCRIPTION
### Motivation
- A recent change to a 10-day lookback with rolling dedupe introduced a regression where runs would return early if `winner_keys` were unchanged, skipping recovery when the stored `winners_state["message_id"]` pointed to a deleted/stale Discord message. 
- The intent is to preserve the no-op/dedupe behavior while ensuring a replacement winners message is posted if the previous message is missing. 
- This follow-up restores correct recovery behavior without creating redundant reposts when the existing winners message is valid.

### Description
- Update `evening_winners.py` so the unchanged-keys early-skip path verifies the stored `message_id` exists via `client.get_message(...)` before returning. 
- If `client.get_message(...)` raises `DiscordMessageNotFoundError`, the code now clears `previous_message_id` and falls through to post a replacement winners message. 
- Preserve existing edit-in-place behavior and the no-winners/no-existing-message no-op case. 
- Files changed: `evening_winners.py` and `tests/test_evening_winners.py`.

### Testing
- Added `test_unchanged_winner_keys_with_stale_message_posts_replacement` to `tests/test_evening_winners.py` to reproduce the regression and assert a replacement post is created and persisted when the stored winners message is stale. 
- Ran `pytest -q tests/test_evening_winners.py`, and all tests passed (`8 passed`). 
- Existing tests covering the 10-day lookback, rolling dedupe, voter rules, edit/no-op behavior remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74546fb208326b62c0018e5cd33dd)