### PR TITLE
Normalize weekly summary signature missing-user ordering

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -665,11 +665,12 @@ def compute_summary_data_signature(
     missing_user_ids: list[str],
 ) -> str:
     """Hash meaningful summary inputs to detect real summary-data changes."""
+    normalized_missing_user_ids = sorted(missing_user_ids)
     signature_payload = {
         "week_summary": week_summary,
         "responded_count": responded_count,
         "active_user_count": active_user_count,
-        "missing_user_ids": missing_user_ids,
+        "missing_user_ids": normalized_missing_user_ids,
     }
     stable_payload = json.dumps(signature_payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(stable_payload.encode("utf-8")).hexdigest()

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -204,6 +204,41 @@ def test_summary_includes_status_timestamp_spacing_and_slot_order():
     assert "\n**Monday 4/13**\n✅ 3 — Alice, Bob, Charlie\n🌅 1 — Dawn\n☀️ 2 — Sun1, Sun2\n🌙 1 — Moon\n📝 1 — Note\n❌ 4 — (names unavailable)\n\n**Tuesday 4/14**\n☀️ 1 — Erin\n\n**Wednesday 4/15**\nNo responses" in msg
 
 
+def test_summary_signature_normalizes_missing_user_order():
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {day: 0 for day in sync.DAY_NAMES},
+            "slot_counts": {day: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER} for day in sync.DAY_NAMES},
+            "slot_voters": {day: {slot: [] for slot in sync.SUMMARY_SLOT_ORDER} for day in sync.DAY_NAMES},
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": 0},
+        },
+    }
+
+    signature_ab = sync.compute_summary_data_signature(
+        week_summary=week_summary,
+        responded_count=0,
+        active_user_count=2,
+        missing_user_ids=["100", "200"],
+    )
+    signature_ba = sync.compute_summary_data_signature(
+        week_summary=week_summary,
+        responded_count=0,
+        active_user_count=2,
+        missing_user_ids=["200", "100"],
+    )
+    signature_different_set = sync.compute_summary_data_signature(
+        week_summary=week_summary,
+        responded_count=0,
+        active_user_count=2,
+        missing_user_ids=["100", "300"],
+    )
+
+    assert signature_ab == signature_ba
+    assert signature_ab != signature_different_set
+
+
 def test_main_rebuild_only_edits_or_recovers_summary(monkeypatch, tmp_path, load_fixture_json):
     weekly_responses = load_fixture_json("weekly_responses_named_users.json")
     week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(tmp_path, weekly_responses)


### PR DESCRIPTION
### Motivation
- Prevent spurious summary signature changes when `missing_user_ids` is the same logical set but in a different order so that identical summaries do not trigger unnecessary Discord edits.

### Description
- Normalize `missing_user_ids` inside `compute_summary_data_signature(...)` by sorting the list before including it in the JSON payload, leaving all summary formatting and reminder behavior unchanged.
- Add a focused unit test `test_summary_signature_normalizes_missing_user_order` to assert the signature is stable across reordered `missing_user_ids` and differs for a truly different set.

### Testing
- Ran the focused test with `pytest -q tests/test_weekly_sync_summary.py -k summary_signature_normalizes_missing_user_order` and it passed.
- Ran the whole weekly-sync test file with `pytest -q tests/test_weekly_sync_summary.py` and all tests passed (12 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d744e14c108326ac57fe06d0dd09f2)