### PR TITLE
Follow-up: fix legacy summary backfill stale-data detection

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -541,6 +541,20 @@ def normalize_summary_content_for_data_compare(content: Any) -> str | None:
     return "\n".join(normalized_lines).strip()
 
 
+def legacy_summary_data_matches_current(
+    previous_summary_message_content: Any,
+    regenerated_legacy_comparable_message: str,
+) -> bool:
+    """Return whether legacy summary content matches current meaningful summary data."""
+    previous_normalized = normalize_summary_content_for_data_compare(
+        previous_summary_message_content
+    )
+    current_normalized = normalize_summary_content_for_data_compare(
+        regenerated_legacy_comparable_message
+    )
+    return previous_normalized is not None and previous_normalized == current_normalized
+
+
 def format_summary_message(
     date_range: str,
     week_summary: dict[str, Any],
@@ -966,9 +980,9 @@ def main() -> None:
                 active_user_count=active_user_count,
                 synced_at_utc=legacy_compare_synced_at_utc,
             )
-            summary_data_changed = (
-                normalize_summary_content_for_data_compare(previous_summary_message_content)
-                != normalize_summary_content_for_data_compare(regenerated_legacy_comparable_message)
+            summary_data_changed = not legacy_summary_data_matches_current(
+                previous_summary_message_content,
+                regenerated_legacy_comparable_message,
             )
         else:
             summary_data_changed = True

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -155,6 +155,41 @@ def test_shared_date_label_helper_matches_summary_and_day_posts():
     assert "**Monday 4/13**" in msg
 
 
+def test_legacy_summary_data_compare_ignores_last_updated_line():
+    week_summary = {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13–19, 2026",
+        "summary": {
+            "day_counts": {d: 0 for d in sync.DAY_NAMES},
+            "slot_counts": {
+                d: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "slot_voters": {
+                d: {slot: [] for slot in sync.SUMMARY_SLOT_ORDER}
+                for d in sync.DAY_NAMES
+            },
+            "best_overlap": {"day": "Monday", "slot": "✅", "count": 0},
+        },
+    }
+    old_message = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=0,
+        active_user_count=2,
+        synced_at_utc=sync.datetime(2026, 4, 1, 0, 0, tzinfo=sync.timezone.utc),
+    )
+    regenerated = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        week_summary,
+        responded_count=0,
+        active_user_count=2,
+        synced_at_utc=sync.datetime(2026, 4, 9, 0, 0, tzinfo=sync.timezone.utc),
+    )
+
+    assert sync.legacy_summary_data_matches_current(old_message, regenerated) is True
+
+
 def test_summary_includes_status_timestamp_spacing_and_slot_order():
     week_summary = {
         "week_key": "2026-04-13_to_2026-04-19",


### PR DESCRIPTION
### Motivation
- Legacy weekly outputs that lacked the new `summary_data_signature` could be preserved even when meaningful summary data (e.g., reactions) changed because the migration path ignored timestamp churn and sometimes treated data as unchanged.
- Ensure migration/backfill updates stale legacy summaries when underlying summary data changed while still ignoring only the volatile `Last updated` timestamp line.

### Description
- Add `legacy_summary_data_matches_current(previous_summary_message_content, regenerated_legacy_comparable_message)` to encapsulate legacy-vs-current summary comparison while dropping the volatile `Last updated` line. (modified `scripts/sync_weekly_schedule_responses.py`)
- Use the new helper in the legacy/no-signature branch to compute `summary_data_changed` so meaningful differences trigger edits/backfills and only timestamp changes are ignored. (modified `scripts/sync_weekly_schedule_responses.py`)
- Add `test_legacy_summary_data_compare_ignores_last_updated_line` to verify the legacy comparison ignores only the timestamp line and treats otherwise-equal summary content as matching. (modified `tests/test_weekly_sync_summary.py`)

### Testing
- Ran the focused test suite: `pytest -q tests/test_weekly_sync_summary.py` and all tests passed. (Result: `13 passed`)
- The tests cover unchanged-summary/no-edit, changed-summary/edit+timestamp update, legacy-output backfill behavior, and the new legacy comparison regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d746d651148326a24ff86e1f4c00eb)