### PR TITLE
Follow-up: fix legacy summary backfill stale-content edge case

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -966,6 +966,10 @@ def main() -> None:
                 active_user_count=active_user_count,
                 synced_at_utc=legacy_compare_synced_at_utc,
             )
+            # Legacy records may have summary content but no signature yet.
+            # Compare normalized content before backfilling signature so we
+            # still edit when meaningful summary data changed since the
+            # pre-signature sync.
             summary_data_changed = (
                 normalize_summary_content_for_data_compare(previous_summary_message_content)
                 != normalize_summary_content_for_data_compare(regenerated_legacy_comparable_message)

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -598,7 +598,26 @@ def test_main_legacy_summary_with_changed_data_triggers_edit(monkeypatch, tmp_pa
             }
         },
     )
-    old_responses = json.loads(responses_p.read_text(encoding="utf-8"))
+    old_responses = {
+        week_key: {
+            "date_range": "Apr 13–19, 2026",
+            "users": {
+                "100": {
+                    "username": "jan",
+                    "global_name": "Jan",
+                    "days": {
+                        day: (
+                            {"reactions": ["✅"], "custom_reply": None}
+                            if day == "Monday"
+                            else {"reactions": [], "custom_reply": None}
+                        )
+                        for day in sync.DAY_NAMES
+                    },
+                }
+            },
+        }
+    }
+    _write(responses_p, old_responses)
     roster = json.loads(roster_p.read_text(encoding="utf-8"))
     old_summary = sync.build_weekly_summary(old_responses)[week_key]
     old_missing = sync.compute_missing_user_ids_for_week(old_responses[week_key], roster)
@@ -631,7 +650,11 @@ def test_main_legacy_summary_with_changed_data_triggers_edit(monkeypatch, tmp_pa
                         "username": "jan",
                         "global_name": "Jan",
                         "days": {
-                            day: {"reactions": ["✅"], "custom_reply": None}
+                            day: (
+                                {"reactions": ["🌅"], "custom_reply": None}
+                                if day == "Monday"
+                                else {"reactions": [], "custom_reply": None}
+                            )
                             for day in sync.DAY_NAMES
                         },
                     }
@@ -660,5 +683,6 @@ def test_main_legacy_summary_with_changed_data_triggers_edit(monkeypatch, tmp_pa
     assert fake_client.posts == []
     assert len(fake_client.edits) == 1
     assert outputs[week_key]["summary_message_content"] != legacy_content
+    assert "*1 of 2 people responded • 1 still missing*" in outputs[week_key]["summary_message_content"]
     assert isinstance(outputs[week_key].get("summary_data_signature"), str)
     assert "summary_last_synced_at_utc" in outputs[week_key]


### PR DESCRIPTION
### Motivation
- Fix a P1 bug where legacy outputs that had `summary_message_content` but no `summary_data_signature` could be backfilled without detecting meaningful summary-content changes, allowing stale Discord summaries to persist.

### Description
- In `scripts/sync_weekly_schedule_responses.py` compare the normalized `previous_summary_message_content` against a regenerated legacy-comparable summary before backfilling `summary_data_signature`, and add a clarifying inline comment explaining the behavior. 
- In `tests/test_weekly_sync_summary.py` strengthen the legacy-migration regression by simulating a reaction change that preserves response totals and assert that an edit occurs and that `summary_data_signature` and `summary_last_synced_at_utc` are set.

### Testing
- Ran `pytest -q tests/test_weekly_sync_summary.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d746a2f3548326aa0c1718f566143c)