### PR TITLE
Fix legacy weekly summary backfill comparison to avoid silently preserving stale summaries

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -958,17 +958,24 @@ def main() -> None:
         if previous_summary_data_signature is not None:
             summary_data_changed = previous_summary_data_signature != current_summary_data_signature
         elif is_legacy_summary_without_signature:
-            legacy_compare_synced_at_utc = previous_summary_last_synced_at_utc or summary_synced_at_utc
+            # Legacy rows may have pre-signature content; compare normalized content
+            # before backfilling a signature so changed summaries still trigger edits.
             regenerated_legacy_comparable_message = format_summary_message(
                 date_range,
                 posting_week_summary,
                 responded_count=responded_active_user_count,
                 active_user_count=active_user_count,
-                synced_at_utc=legacy_compare_synced_at_utc,
+                synced_at_utc=summary_synced_at_utc,
+            )
+            previous_legacy_normalized_content = normalize_summary_content_for_data_compare(
+                previous_summary_message_content
+            )
+            regenerated_legacy_normalized_content = normalize_summary_content_for_data_compare(
+                regenerated_legacy_comparable_message
             )
             summary_data_changed = (
-                normalize_summary_content_for_data_compare(previous_summary_message_content)
-                != normalize_summary_content_for_data_compare(regenerated_legacy_comparable_message)
+                previous_legacy_normalized_content
+                != regenerated_legacy_normalized_content
             )
         else:
             summary_data_changed = True

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -662,3 +662,81 @@ def test_main_legacy_summary_with_changed_data_triggers_edit(monkeypatch, tmp_pa
     assert outputs[week_key]["summary_message_content"] != legacy_content
     assert isinstance(outputs[week_key].get("summary_data_signature"), str)
     assert "summary_last_synced_at_utc" in outputs[week_key]
+
+
+def test_main_legacy_summary_with_reaction_change_triggers_edit(monkeypatch, tmp_path):
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(
+        tmp_path,
+        {
+            "2026-04-13_to_2026-04-19": {
+                "date_range": "Apr 13–19, 2026",
+                "users": {
+                    "100": {
+                        "username": "jan",
+                        "global_name": "Jan",
+                        "days": {
+                            day: {"reactions": ["✅"], "custom_reply": None}
+                            for day in sync.DAY_NAMES
+                        },
+                    },
+                    "200": {
+                        "username": "amy",
+                        "global_name": "Amy",
+                        "days": {
+                            day: {"reactions": ["✅"], "custom_reply": None}
+                            for day in sync.DAY_NAMES
+                        },
+                    },
+                },
+            }
+        },
+    )
+    old_responses = json.loads(responses_p.read_text(encoding="utf-8"))
+    roster = json.loads(roster_p.read_text(encoding="utf-8"))
+    old_summary = sync.build_weekly_summary(old_responses)[week_key]
+    old_missing = sync.compute_missing_user_ids_for_week(old_responses[week_key], roster)
+    active_user_count = sync.count_active_roster_users(roster)
+    old_responded = max(active_user_count - len(old_missing), 0)
+    legacy_content = sync.format_summary_message(
+        "Apr 13–19, 2026",
+        old_summary,
+        responded_count=old_responded,
+        active_user_count=active_user_count,
+        synced_at_utc=sync.datetime(2026, 4, 1, 0, 0, tzinfo=sync.timezone.utc),
+    )
+    _write(
+        outputs_p,
+        {
+            week_key: {
+                "summary_message_id": "sum-old",
+                "summary_message_content": legacy_content,
+            }
+        },
+    )
+
+    updated_responses = json.loads(responses_p.read_text(encoding="utf-8"))
+    updated_responses[week_key]["users"]["200"]["days"]["Monday"]["reactions"] = ["🌙"]
+    _write(responses_p, updated_responses)
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    assert fake_client.posts == []
+    assert len(fake_client.edits) == 1
+    assert outputs[week_key]["summary_message_content"] != legacy_content
+    assert isinstance(outputs[week_key].get("summary_data_signature"), str)
+    assert "summary_last_synced_at_utc" in outputs[week_key]


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where legacy outputs with `summary_message_content` but no `summary_data_signature` could be backfilled with a signature and then skip edits even when meaningful summary data (e.g., reactions) had changed. 
- Ensure the first post-migration run detects meaningful differences and updates Discord when appropriate while still backfilling signatures for unchanged content.

### Description
- Update `scripts/sync_weekly_schedule_responses.py` to explicitly regenerate a comparable summary message for legacy rows and compare normalized legacy content against the regenerated normalized content before backfilling the signature. 
- Use clearer local variables and comments (`previous_legacy_normalized_content`, `regenerated_legacy_normalized_content`) to document the intent and avoid accidentally treating volatile `Last updated` lines as meaningful. 
- Add a regression test `test_main_legacy_summary_with_reaction_change_triggers_edit` in `tests/test_weekly_sync_summary.py` that simulates a legacy output without a signature, mutates reactions while coverage remains full, and asserts an edit occurs and the signature/timestamp are updated. 
- Modified files: `scripts/sync_weekly_schedule_responses.py` and `tests/test_weekly_sync_summary.py`.

### Testing
- Ran the focused test file with `pytest -q tests/test_weekly_sync_summary.py` and observed `13 passed`. 
- The test suite confirms that unchanged legacy summaries are backfilled without noisy edits, changed legacy data triggers an edit and signature/timestamp update, and the new reaction-change regression test passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d746e405b08326bbbc181296ec9f90)