### PR TITLE
Tighten consolidated health report section spacing

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -221,7 +221,6 @@ def render_report(
             [
             f"{icon} {state_check_label}",
             f"Last run: {status} (see State / Artifact Health)",
-            "",
             ]
         )
     else:
@@ -229,7 +228,6 @@ def render_report(
             [
             f"🟢 {state_check_label}",
             "Last run: healthy (see State / Artifact Health)",
-            "",
             ]
         )
 

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -186,13 +186,14 @@ def test_final_report_snapshot_shape_with_mixed_signals():
         "🔴 Bot Data Health Check (consolidated)\n"
         "Last run: issues found (see State / Artifact Health)\n"
         "\n"
-        "\n"
         "## State / Artifact Health\n"
         "\n"
         "🔴 Winners state message id is missing\n"
         "🟡 Daily picks entry missing expected field"
     )
     assert rendered == expected
+    assert "\n\n## State / Artifact Health\n" in rendered
+    assert "\n\n\n## State / Artifact Health\n" not in rendered
 
     assert "## Workflow Status" in rendered
     assert "## State / Artifact Health" in rendered


### PR DESCRIPTION
### Motivation
- Remove the extra blank line that was producing two blank lines between the consolidated `Bot Data Health Check (consolidated)` block and the `## State / Artifact Health` header so the report shows exactly one blank line between sections.

### Description
- Remove the trailing blank line emitted by the consolidated block in `render_report` in `scripts/build_daily_health_report.py` and update the snapshot-style test in `tests/test_build_daily_health_report.py` to expect a single blank line before `## State / Artifact Health` while leaving `_render_section(...)` and all other formatting unchanged.

### Testing
- Ran `pytest -q tests/test_build_daily_health_report.py` and the test suite for that file succeeded (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7537a89e483269230ae06343a374f)