### PR TITLE
Remove stale `state-sanity-check.yml` references from health report and docs

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -29,7 +29,6 @@ jobs:
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
               { file: "daily.yml", name: "Daily Steam Picks", staleHours: 30 },
               { file: "evening-winners.yml", name: "Evening Winners", staleHours: 30 },
-              { file: "state-sanity-check.yml", name: "State Sanity Check", staleHours: 240 },
             ];
 
             const output = [];

--- a/README.md
+++ b/README.md
@@ -85,12 +85,6 @@ Manual rerun quick commands (GitHub CLI):
   - Default run date: `gh workflow run evening-winners.yml`
   - Target date: `gh workflow run evening-winners.yml -f winners_date_utc=2026-04-08`
 
-### State sanity check (`state-sanity-check.yml`)
-- **What it does:** read-only parse/shape checks for key JSON state files.
-- **Schedule:** Mondays at 12:00 UTC.
-- **Manual rerun:** `gh workflow run state-sanity-check.yml`
-- **Local run:** `python scripts/check_state_sanity.py`
-
 ### Bot health report (`bot-health-report.yml`)
 - **What it does:** posts a once-daily Discord health summary across core workflows.
 - **Schedule:** `10 3 * * *` (03:10 UTC daily; ~11:10 PM New York during EDT).
@@ -138,7 +132,8 @@ Use this section as the fast triage guide when a workflow or state file drifts.
   2. Re-run `evening-winners.yml` with `winners_date_utc=<day>`.
 - **Malformed roster**
   1. Repair `data/scheduling/expected_schedule_roster.json` to a valid `users` object with active user entries.
-  2. Re-run `state-sanity-check.yml`, then `weekly-scheduling-responses-sync.yml`.
+  2. Re-run `weekly-scheduling-responses-sync.yml`.
+  3. Confirm the next `bot-health-report.yml` run clears the warning.
 - **Daily picks / winners inconsistency**
   1. Verify `discord_daily_posts.json` day entry has valid `items` message IDs.
   2. Re-run `daily.yml` (if items missing/stale) then `evening-winners.yml` for the same day.

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -231,6 +231,37 @@ def test_final_report_snapshot_shape_with_mixed_signals_and_triage_metadata():
     assert "Context: Weekly responses exist but summary entry is absent." in rendered
 
 
+def test_health_report_cleanup_removes_state_sanity_check_references_from_workflow_monitoring():
+    workflow_file = Path(".github/workflows/bot-health-report.yml").read_text(encoding="utf-8")
+
+    assert "state-sanity-check.yml" not in workflow_file
+    assert "State Sanity Check" not in workflow_file
+
+    rendered = report.render_report(
+        workflow_status_lines=[
+            "🟢 Weekly Scheduling Bot",
+            "Last run: success (4h ago)",
+            "",
+            "🟢 Weekly Scheduling Responses Sync",
+            "Last run: success (1h ago)",
+            "",
+            "🟢 Daily Steam Picks",
+            "Last run: success (6h ago)",
+            "",
+            "🟢 Evening Winners",
+            "Last run: success (8h ago)",
+            "",
+        ],
+        state_issues=[],
+        report_date="Apr 9, 2026",
+    )
+
+    assert "## Workflow Status" in rendered
+    assert "## State / Artifact Health" in rendered
+    assert "🟢 No state inconsistencies detected" in rendered
+    assert "State Sanity Check" not in rendered
+
+
 def test_report_date_new_york_format_is_portable_and_unpadded_day():
     now_utc = datetime(2026, 4, 9, 16, 0, tzinfo=timezone.utc)
     assert report._report_date_new_york(now_utc) == "Apr 9, 2026"


### PR DESCRIPTION
### Motivation

- Remove stale references to the retired `state-sanity-check.yml` so the daily health report does not forever warn about a non-existent workflow.  

### Description

- Removed the `state-sanity-check.yml` entry from the monitored workflows array in `.github/workflows/bot-health-report.yml`.  
- Updated `README.md` to remove the `State sanity check` section and replaced the malformed-roster recovery steps with: repair `data/scheduling/expected_schedule_roster.json`, re-run `weekly-scheduling-responses-sync.yml`, and confirm the next `bot-health-report.yml` run clears the warning.  
- Added a focused test `test_health_report_cleanup_removes_state_sanity_check_references_from_workflow_monitoring` to `tests/test_build_daily_health_report.py` which asserts the workflow file and rendered report no longer reference `state-sanity-check.yml` / `State Sanity Check` while leaving report rendering behavior unchanged.  
- This is a minimal cleanup-only change and does not alter any health-report logic, scheduling, winners behavior, thresholds, or formatting.  

### Testing

- Ran the focused health report test suite: `pytest -q tests/test_build_daily_health_report.py`.  
- Result: `9 passed in 0.09s` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75a81f85883268ed97da5b4798198)