### PR TITLE
Persist daily pick descriptions and show them in evening winners

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -73,6 +73,9 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
         lines.append(SECTION_CONFIG[section])
         for item in items:
             lines.append(item["title"])
+            description = normalize_winner_description_for_message(item.get("description"))
+            if description:
+                lines.append(description)
             lines.append(item["url"])
             vote_word = "vote" if item["human_votes"] == 1 else "votes"
             lines.append(f"👍 {item['human_votes']} {vote_word}")
@@ -106,6 +109,19 @@ def build_winners_message_compact(winners_by_section: Dict[str, List[dict]]) -> 
         lines.append("_No votes yet today._")
 
     return "\n".join(lines).strip()
+
+
+def normalize_winner_description_for_message(
+    description: Optional[str], max_length: int = 110
+) -> str:
+    if not isinstance(description, str):
+        return ""
+    cleaned = " ".join(description.split()).strip()
+    if not cleaned:
+        return ""
+    if len(cleaned) <= max_length:
+        return cleaned
+    return f"{cleaned[:max_length - 3].rstrip()}..."
 
 
 def resolve_display_name(user: dict) -> str:
@@ -271,6 +287,7 @@ def main() -> None:
                 "section": section,
                 "title": item.get("title", "Untitled"),
                 "url": item.get("url", ""),
+                "description": item.get("description"),
                 "human_votes": human_votes,
                 "voter_names": voter_names,
             }
@@ -283,6 +300,7 @@ def main() -> None:
                 {
                     "title": winner["title"],
                     "url": winner["url"],
+                    "description": winner.get("description"),
                     "human_votes": winner["human_votes"],
                     "voter_names": winner["voter_names"],
                 }

--- a/main.py
+++ b/main.py
@@ -852,6 +852,7 @@ def record_posted_item(
     item_key: str,
     message_id: str,
     channel_id: Optional[str],
+    description: Optional[str] = None,
 ) -> None:
     try:
         day_entry = daily_posts.setdefault(day_key, {"items": []})
@@ -870,6 +871,8 @@ def record_posted_item(
             "source_type": source_type,
             "posted_at": utc_now_iso(),
         }
+        if isinstance(description, str):
+            item_record["description"] = description
         existing_index = next(
             (index for index, existing in enumerate(items) if isinstance(existing, dict) and existing.get("item_key") == item_key),
             None,
@@ -1028,6 +1031,7 @@ def post_daily_pick_messages(free_items: List[dict], paid_items: List[dict], ins
                     item_key=item_key,
                     message_id=metadata["message_id"],
                     channel_id=metadata["channel_id"],
+                    description=item.get("caption") if section_key == "instagram" else item.get("description"),
                 )
                 print(f"CREATE: posted {section_key} item {title} for {day_key}")
             else:

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -298,11 +298,65 @@ def test_build_winners_message_voter_truncation():
     assert "Voters — Jan, Jerry, Akhil, Thomas, Charlie, Kevin, +3 more" in content
 
 
+def test_build_winners_message_includes_description_when_present():
+    winners_by_section = {
+        "free": [
+            {
+                "title": "Game A",
+                "description": "A fast co-op roguelike shooter.",
+                "url": "u-a",
+                "human_votes": 2,
+                "voter_names": ["Jan", "Jerry"],
+            }
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert "Game A" in content
+    assert "A fast co-op roguelike shooter." in content
+    assert "u-a" in content
+
+
+def test_build_winners_message_omits_description_when_absent_or_empty():
+    winners_by_section = {
+        "free": [
+            {
+                "title": "Game A",
+                "description": " \n\t ",
+                "url": "u-a",
+                "human_votes": 2,
+                "voter_names": ["Jan"],
+            },
+            {
+                "title": "Game B",
+                "url": "u-b",
+                "human_votes": 1,
+                "voter_names": ["Jerry"],
+            },
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert " \n\t " not in content
+    assert "Voters — Jan" in content
+    assert "Voters — Jerry" in content
+
+
+def test_normalize_winner_description_truncates_long_text():
+    long_description = "A" * 200
+    normalized = winners.normalize_winner_description_for_message(long_description)
+    assert len(normalized) == 110
+    assert normalized.endswith("...")
+
+
 def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
     winners_by_section = {
         "free": [
             {
                 "title": f"Game {idx}",
+                "description": "B" * 300,
                 "url": f"https://example.com/{idx}",
                 "human_votes": 2,
                 "voter_names": [f"User {i}" for i in range(10)],
@@ -316,6 +370,7 @@ def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
     assert len(message) > winners.DISCORD_MESSAGE_CHAR_LIMIT
     compact = winners.build_winners_message_compact(winners_by_section)
     assert "Voters —" not in compact
+    assert "BBBBB" not in compact
     assert "- Game 0 (2 votes)" in compact
 
 

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -84,3 +84,50 @@ def test_load_discord_daily_posts_handles_old_shapes(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(path))
 
     assert main.load_discord_daily_posts() == {}
+
+
+def test_daily_item_persistence_stores_descriptions(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-08"
+
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        counter["i"] += 1
+        return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [
+        {
+            "title": "Game A",
+            "url": "https://store.steampowered.com/app/1",
+            "description": "Steam short description",
+            "price": "Free",
+            "score": 9,
+        }
+    ]
+    instagram_posts = [
+        {
+            "username": "creator",
+            "caption": "Creator caption text",
+            "url": "https://www.instagram.com/p/abc/",
+        }
+    ]
+    main.post_daily_pick_messages(free_items, [], instagram_posts)
+
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    items = saved[day_key]["items"]
+    steam_item = next(item for item in items if item["section"] == "free")
+    instagram_item = next(item for item in items if item["section"] == "instagram")
+
+    assert steam_item["description"] == "Steam short description"
+    assert instagram_item["description"] == "Creator caption text"


### PR DESCRIPTION
### Motivation
- Evening winners lacked a short context/description which made it hard to understand picks without opening each link.  
- Use already-available text from the daily picks flow (Steam description or Instagram caption) and display it in the winners summary with minimal risk and no new network/scrape reads.  

### Description
- Added an optional `description` field to persisted daily item records via `record_posted_item(...)` and only write it when a string is present to preserve backward compatibility.  
- During daily posting, persist Steam item `item.get("description")` and Instagram creator `item.get("caption")` into the `description` field without adding any new scraping, network, or Discord reads.  
- Propagated stored `description` into the evening winners candidate objects and into the winners rendering pipeline.  
- Implemented a local helper `normalize_winner_description_for_message(...)` that collapses internal whitespace/newlines, trims, omits empty results, and truncates to ~110 characters with `...` when needed.  
- Preserve existing behavior for compact fallback and Discord length safety by falling back to the existing compact, description-free message when the normal message exceeds the character limit.  

### Testing
- Added focused unit tests in `tests/test_evening_winners.py` and `tests/test_main_daily_picks.py` covering description rendering, omission, truncation, compact fallback behavior, and persistence of Steam/Instagram descriptions.  
- Ran `pytest -q tests/test_evening_winners.py tests/test_main_daily_picks.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7685c599c83269ccca5a14c86bf64)