### PR TITLE
Set PYTHONPATH in weekly scheduling bot workflow

### DIFF
--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Post weekly availability
         env:
+          PYTHONPATH: .
           DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
           DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
           SCHEDULE_WEEK_START: ${{ inputs.schedule_week_start }}


### PR DESCRIPTION
### Motivation
- The `post_weekly_availability.py` script imports repo-root modules such as `discord_api`, and the `weekly-scheduling-bot` workflow ran `python scripts/post_weekly_availability.py` without `PYTHONPATH: .`, which can cause `ModuleNotFoundError` in GitHub Actions.

### Description
- Add `PYTHONPATH: .` to the `Post weekly availability` step in `.github/workflows/weekly-scheduling-bot.yml` to match the working pattern used by `weekly-scheduling-responses-sync.yml` and avoid changing any script logic.

### Testing
- Verified the change with `git diff -- .github/workflows/weekly-scheduling-bot.yml`, inspected lines with `nl -ba` to confirm `PYTHONPATH: .` is present, and committed the updated workflow (`git commit`); all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80ca7ec9083269e039d6aa2895992)