### PR TITLE
Add actionable overall summary block to daily health report

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -37,6 +37,13 @@ class Issue:
     extra: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class OverallHealthSummary:
+    icon: str
+    headline: str
+    detail: str
+
+
 def _load_json(path: Path) -> Any | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -475,6 +482,64 @@ def _render_state_issue(issue: Issue) -> list[str]:
     return lines
 
 
+def summarize_overall_health(*, workflow_status_lines: list[str], state_issues: list[Issue]) -> OverallHealthSummary:
+    dispositions: list[str] = []
+    for line in workflow_status_lines:
+        if line.startswith("Disposition: "):
+            dispositions.append(line.removeprefix("Disposition: ").strip())
+
+    for issue in state_issues:
+        disposition = issue.disposition
+        if not disposition:
+            disposition, _ = _state_issue_guidance(issue.code, issue.severity, file_path=issue.file_path)
+        dispositions.append(disposition)
+
+    action_required_count = sum(1 for disposition in dispositions if disposition == "Action required")
+    monitor_or_follow_up_count = sum(
+        1 for disposition in dispositions if disposition in {"Monitor only", "Action recommended"}
+    )
+    no_action_needed_count = sum(1 for disposition in dispositions if disposition == "No action needed")
+    error_issue_count = sum(1 for issue in state_issues if issue.severity == "error")
+
+    if action_required_count > 0 or error_issue_count > 0:
+        urgent_count = max(action_required_count, error_issue_count)
+        noun = "item requires" if urgent_count == 1 else "items require"
+        return OverallHealthSummary(
+            icon="🔴",
+            headline="Action needed",
+            detail=f"{urgent_count} {noun} immediate attention.",
+        )
+
+    if monitor_or_follow_up_count > 0:
+        noun = "item should" if monitor_or_follow_up_count == 1 else "items should"
+        return OverallHealthSummary(
+            icon="🟡",
+            headline="Follow-up recommended",
+            detail=f"{monitor_or_follow_up_count} {noun} be monitored or reviewed soon.",
+        )
+
+    if no_action_needed_count > 0:
+        noun = "warning" if no_action_needed_count == 1 else "warnings"
+        return OverallHealthSummary(
+            icon="🟢",
+            headline="Healthy with informational warnings",
+            detail=f"{no_action_needed_count} low-priority {noun} detected. No action needed.",
+        )
+
+    return OverallHealthSummary(
+        icon="🟢",
+        headline="Healthy",
+        detail="No action needed.",
+    )
+
+
+def render_overall_summary(summary: OverallHealthSummary) -> list[str]:
+    return [
+        f"{summary.icon} Overall: {summary.headline}",
+        summary.detail,
+    ]
+
+
 def render_report(
     *,
     workflow_status_lines: list[str],
@@ -483,6 +548,8 @@ def render_report(
     state_check_label: str = "Bot Data Health Check (consolidated)",
 ) -> str:
     lines = [f"🚦 XiannGPT Bot Daily Health — {report_date}"]
+    summary = summarize_overall_health(workflow_status_lines=workflow_status_lines, state_issues=state_issues)
+    lines.extend(["", *render_overall_summary(summary)])
     lines.extend(_render_section("Workflow Status", workflow_status_lines))
 
     if state_issues:

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -391,3 +391,84 @@ def test_green_workflow_output_has_no_guidance_lines():
     rendered = "\n".join(lines)
     assert "Disposition:" not in rendered
     assert "Next step:" not in rendered
+
+
+def test_overall_summary_is_green_when_only_no_action_needed_warnings():
+    rendered = report.render_report(
+        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", ""],
+        state_issues=[
+            report.Issue(
+                code="weekly.summary_freshness_missing",
+                severity="warning",
+                title="Weekly summary freshness fields missing",
+                context="Summary exists but outputs are missing summary_last_synced_at_utc.",
+                disposition="No action needed",
+                next_step="None.",
+            )
+        ],
+        report_date="Apr 9, 2026",
+    )
+
+    assert "🟢 Overall: Healthy with informational warnings" in rendered
+    assert "1 low-priority warning detected. No action needed." in rendered
+
+
+def test_overall_summary_is_yellow_for_monitor_or_follow_up_dispositions():
+    rendered = report.render_report(
+        workflow_status_lines=[
+            "🟡 Evening Winners",
+            "Last run: success (40h ago) — stale",
+            "Disposition: Monitor only",
+            "Next step: Watch next run.",
+            "",
+        ],
+        state_issues=[
+            report.Issue(
+                code="weekly.expected_post_missing",
+                severity="warning",
+                title="Expected weekly schedule post missing",
+                context="No current/next expected weekly schedule message entry found.",
+                disposition="Action recommended",
+                next_step="Re-run weekly-scheduling-responses-sync.yml.",
+            )
+        ],
+        report_date="Apr 9, 2026",
+    )
+
+    assert "🟡 Overall: Follow-up recommended" in rendered
+    assert "2 items should be monitored or reviewed soon." in rendered
+
+
+def test_overall_summary_is_red_when_action_required_or_error_exists():
+    rendered = report.render_report(
+        workflow_status_lines=[
+            "🔴 Weekly Scheduling Responses Sync",
+            "Last run: failure (1h ago)",
+            "Disposition: Action required",
+            "Next step: Fix workflow failure.",
+            "",
+        ],
+        state_issues=[
+            report.Issue(
+                code="winners.message_id_missing",
+                severity="error",
+                title="Winners state inconsistent",
+                context="message_id is missing from winners state.",
+            )
+        ],
+        report_date="Apr 9, 2026",
+    )
+
+    assert "🔴 Overall: Action needed" in rendered
+    assert "items require immediate attention." in rendered
+
+
+def test_overall_summary_is_green_when_fully_healthy():
+    rendered = report.render_report(
+        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", ""],
+        state_issues=[],
+        report_date="Apr 9, 2026",
+    )
+
+    assert "🟢 Overall: Healthy" in rendered
+    assert "No action needed." in rendered


### PR DESCRIPTION
### Motivation
- Provide a compact, top-level overall summary/signal that communicates whether human action is required, independent of raw warning presence.  
- The summary must reflect actionability (green = safe to ignore, yellow = monitor/follow-up, red = act now) and reuse existing `disposition` values and error severity.

### Description
- Added `OverallHealthSummary` dataclass plus `summarize_overall_health(...)` to aggregate dispositions from `workflow_status_lines` and `state_issues` (falling back to existing guidance when dispositions are unset).  
- Implemented `render_overall_summary(...)` and insert the compact 1–2 line summary directly under the report title in `render_report`.  
- Classification rules implemented: RED if any disposition == "Action required" or any state issue has severity == "error"; YELLOW if any disposition is in {"Monitor only", "Action recommended"} and no red conditions; GREEN otherwise (including when all warnings are "No action needed" or when fully healthy).  
- Added focused tests in `tests/test_build_daily_health_report.py` that cover: only no-action-needed warnings (GREEN), monitor/action-recommended signals (YELLOW), action-required/error signals (RED), and fully healthy (GREEN).

### Testing
- Ran `pytest tests/test_build_daily_health_report.py`; final run: `18 passed in 0.10s`.  
- During development an earlier test run showed one failing assertion which was corrected and re-run; the corrected test suite passes.  
- Tests added/updated: `tests/test_build_daily_health_report.py` (new cases validating overall summary color/text for the 4 requested scenarios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8126797748326a40d8b23eef1be8e)