### PR TITLE
Align health guidance with weekly scheduling bot and refresh operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is now **channel-based** (no thread-based posting).
 
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)
 - Daily picks channel: `daily-game-picks` (`1491294533751799809`)
-- Winners destination channel: `daily-game-picks` (uses `DISCORD_DAILY_PICKS_CHANNEL_ID` when set; otherwise falls back to daily item channel/state and then `DISCORD_WINNERS_CHANNEL_ID`)
+- Winners destination channel: configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`)
 - Health monitor channel: `xiann-gpt-bot-health-monitor` (`1491520649917628536`)
 
 ---
@@ -41,10 +41,14 @@ If something fails:
 Operational alerts are now centralized in `xiann-gpt-bot-health-monitor`.
 
 - **Immediate failure pings:** key production workflows send a compact `🔴 XiannGPT Bot Failure` message with workflow, job, context, and run URL.
-- **Daily health report:** `bot-health-report.yml` posts one summary per day with signal lights:
-  - 🟢 healthy (latest run succeeded)
-  - 🟡 warning (stale, skipped, cancelled, or otherwise non-success)
-  - 🔴 failed (latest run failed)
+- **Daily health report:** `bot-health-report.yml` posts one summary per day with:
+  - A top-level **Overall** block (`🟢/🟡/🔴`) that tells operators if action is needed.
+  - Workflow and state sections that include `Disposition` and `Next step` on yellow/red items.
+  - Informational warnings that can explicitly be `No action needed`.
+  - Action meaning:
+    - 🟢 = no action needed
+    - 🟡 = monitor / follow-up
+    - 🔴 = action needed
 - **Operator default path:** this channel is now the primary dashboard for bot operations; email is no longer the preferred alerting path.
 
 Manual rerun quick commands (GitHub CLI):
@@ -117,6 +121,10 @@ Use this section as the fast triage guide when a workflow or state file drifts.
 - State/artifact consistency (missing or malformed files, missing summary/output links, winners-state coherence).
 - Roster/config integrity (missing/malformed/empty expected roster).
 - Winners + weekly scheduling sanity (expected week/day entries, summary freshness, picks↔winners coherence).
+- Top-level operator signal derived from workflow + state dispositions:
+  - 🟢 no action needed
+  - 🟡 monitor / follow-up
+  - 🔴 action needed
 
 ### Manual recovery / triage playbook
 
@@ -127,6 +135,9 @@ Use this section as the fast triage guide when a workflow or state file drifts.
 - **Weekly summary missing**
   1. Confirm the week exists in `weekly_schedule_messages.json` and `weekly_schedule_responses.json`.
   2. Run sync with `target_week_key=<week>` and `rebuild_summary_only=true`.
+- **Expected weekly schedule post missing**
+  1. Re-run `weekly-scheduling-bot.yml` (not responses sync) to post/repair weekly intro/day messages.
+  2. Confirm `data/scheduling/weekly_schedule_messages.json` includes the current/next expected week key.
 - **Winners state missing**
   1. Confirm picks exist for expected winners day in `discord_daily_posts.json`.
   2. Re-run `evening-winners.yml` with `winners_date_utc=<day>`.
@@ -142,7 +153,7 @@ Use this section as the fast triage guide when a workflow or state file drifts.
 
 - Weekly scheduling post/sync: `DISCORD_SCHEDULING_BOT_TOKEN`, `DISCORD_SCHEDULING_CHANNEL_ID`.
 - Daily picks: `DISCORD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, `INSTAGRAM_USERNAME`, `INSTAGRAM_SESSION_B64`.
-- Evening winners: `DISCORD_BOT_TOKEN`, winners destination channel env (`DISCORD_DAILY_PICKS_CHANNEL_ID` and/or `DISCORD_WINNERS_CHANNEL_ID`).
+- Evening winners: `DISCORD_BOT_TOKEN`, winners destination channel env (`DISCORD_WINNERS_CHANNEL_ID`).
 - Health reporting: `DISCORD_HEALTH_MONITOR_WEBHOOK_URL`.
 
 ---
@@ -266,7 +277,7 @@ Behavior:
   - raw 👍 = 1 → excluded (0 human votes)
   - raw 👍 = 2 → included (1 human vote)
   - raw 👍 = 3 → included (2 human votes)
-- Posts winners to `daily-game-picks` (`DISCORD_DAILY_PICKS_CHANNEL_ID` preferred; backward-compatible fallback to `DISCORD_WINNERS_CHANNEL_ID`)
+- Posts winners to the channel configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`)
 
 Rerun/idempotency behavior:
 - Same-day reruns do not duplicate winners posts
@@ -307,7 +318,6 @@ This shared layer is used by weekly + daily flows for consistency and safer reru
   - `INSTAGRAM_SESSION_B64`
 - Evening winners:
   - `DISCORD_BOT_TOKEN`
-  - `DISCORD_DAILY_PICKS_CHANNEL_ID` (recommended)
   - `DISCORD_WINNERS_CHANNEL_ID`
 - Health monitor notifications (failure pings + daily report):
   - `DISCORD_HEALTH_MONITOR_WEBHOOK_URL`

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -178,7 +178,7 @@ def _state_issue_guidance(code: str, severity: str, *, file_path: str | None = N
         ),
         "weekly.expected_post_missing": (
             "Action recommended",
-            "Re-run weekly-scheduling-responses-sync.yml to generate the expected weekly schedule post state.",
+            "Re-run weekly-scheduling-bot.yml to post/repair the expected weekly schedule messages for the current or next week.",
         ),
     }
     if code in code_map:

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -360,7 +360,7 @@ def test_actionable_warning_has_specific_next_step(tmp_path, monkeypatch):
     issues = report.compute_state_issues(now_utc=now_utc)
     weekly_issue = next(issue for issue in issues if issue.code == "weekly.expected_post_missing")
     assert weekly_issue.disposition == "Action recommended"
-    assert "Re-run weekly-scheduling-responses-sync.yml" in (weekly_issue.next_step or "")
+    assert "Re-run weekly-scheduling-bot.yml" in (weekly_issue.next_step or "")
 
 
 def test_error_rendering_uses_action_required():
@@ -429,7 +429,7 @@ def test_overall_summary_is_yellow_for_monitor_or_follow_up_dispositions():
                 title="Expected weekly schedule post missing",
                 context="No current/next expected weekly schedule message entry found.",
                 disposition="Action recommended",
-                next_step="Re-run weekly-scheduling-responses-sync.yml.",
+                next_step="Re-run weekly-scheduling-bot.yml.",
             )
         ],
         report_date="Apr 9, 2026",


### PR DESCRIPTION
### Motivation
- Fix an incorrect operator guidance mapping where `weekly.expected_post_missing` pointed to the responses sync workflow even though the weekly-post state is owned by the weekly scheduling bot workflow. 
- Bring top-level operator docs and runbook into sync with the recently-merged health-report behavior (Overall summary, disposition/next-step fields, and informational warnings). 
- Perform a small, low-risk hygiene pass (no architecture changes) so operator-facing text matches the actual code/workflows.

### Description
- Updated health guidance in `scripts/build_daily_health_report.py` so `weekly.expected_post_missing` now recommends re-running `weekly-scheduling-bot.yml` with concise operator wording. 
- Updated `README.md` to document the daily health report's top-level **Overall** block and explicit action meaning for 🟢/🟡/🔴, to note `Disposition` and `Next step` on actionable items, and to call out informational/no-action-needed warnings. 
- Revised README winners-channel references to match current runtime behavior (use of `DISCORD_WINNERS_CHANNEL_ID`) and added a short runbook entry for the “Expected weekly schedule post missing” recovery that points to `weekly-scheduling-bot.yml`. 
- Adjusted focused tests in `tests/test_build_daily_health_report.py` to expect the new next-step wording. 
- Duplicate-PR cleanup: attempted to verify/close duplicates but local tooling lacked `gh` and direct GitHub API calls were blocked, so any duplicate open PRs still require manual review/cleanup.

### Testing
- Ran the focused health-report tests: `pytest -q tests/test_build_daily_health_report.py` and received `18 passed` (all tests passed). 
- No other automated test suites were changed or required for this focused documentation/guidance update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d815d6251c8326b8b79b4686396857)