### PR TITLE
Tighten scoring: review-quality gates and rebalanced weights

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,8 +55,8 @@ MAX_PAGE_LIMIT = 50
 
 REQUEST_DELAY_SECONDS = 1.2
 REPOST_COOLDOWN_DAYS = 30
-MIN_SCORE_TO_POST_FREE = 8
-MIN_SCORE_TO_POST_PAID = 4
+MIN_SCORE_TO_POST_FREE = 9
+MIN_SCORE_TO_POST_PAID = 7
 
 MAX_FETCH_RETRIES = 5
 BACKOFF_SECONDS = 4
@@ -69,18 +69,18 @@ STEAMDB_FREE_PROMO_URL = "https://steamdb.info/upcoming/free/"
 DISCORD_CHAR_LIMIT = 1900
 
 MULTIPLAYER_TERMS = {
-    "Massively Multiplayer": 6,
-    "MMO": 6,
-    "Online Co-Op": 5,
-    "Online Co-op": 5,
-    "Co-op": 4,
-    "Co-Op": 4,
-    "Multiplayer": 3,
-    "Multi-player": 3,
-    "Online PvP": 3,
-    "PvP": 2,
-    "Squad": 2,
-    "Team-based": 2,
+    "Massively Multiplayer": 4,
+    "MMO": 4,
+    "Online Co-Op": 3,
+    "Online Co-op": 3,
+    "Co-op": 2,
+    "Co-Op": 2,
+    "Multiplayer": 2,
+    "Multi-player": 2,
+    "Online PvP": 2,
+    "PvP": 1,
+    "Squad": 1,
+    "Team-based": 1,
 }
 
 GOOD_GENRE_TERMS = {
@@ -130,22 +130,63 @@ BAD_TERMS = {
 }
 
 PLAYER_COUNT_PATTERNS = [
-    (r"\b1\s*-\s*4\b", 4),
-    (r"\b1\s*-\s*6\b", 5),
-    (r"\b1\s*-\s*8\b", 6),
-    (r"\b2\s*-\s*4\b", 4),
-    (r"\b2\s*-\s*6\b", 5),
-    (r"\b2\s*-\s*8\b", 6),
-    (r"\b3\s*\+\b", 5),
-    (r"\b3\s*-\s*4\b", 4),
-    (r"\b3\s*-\s*6\b", 5),
-    (r"\b3\s*-\s*8\b", 6),
-    (r"\b4\s*player\b", 4),
-    (r"\b4\s*players\b", 4),
-    (r"\bup to 4 players\b", 4),
-    (r"\bup to 6 players\b", 5),
-    (r"\bup to 8 players\b", 6),
+    (r"\b1\s*-\s*4\b", 3),
+    (r"\b1\s*-\s*6\b", 4),
+    (r"\b1\s*-\s*8\b", 5),
+    (r"\b2\s*-\s*4\b", 3),
+    (r"\b2\s*-\s*6\b", 4),
+    (r"\b2\s*-\s*8\b", 5),
+    (r"\b3\s*\+\b", 4),
+    (r"\b3\s*-\s*4\b", 3),
+    (r"\b3\s*-\s*6\b", 4),
+    (r"\b3\s*-\s*8\b", 5),
+    (r"\b4\s*player\b", 3),
+    (r"\b4\s*players\b", 3),
+    (r"\bup to 4 players\b", 3),
+    (r"\bup to 6 players\b", 4),
+    (r"\bup to 8 players\b", 5),
 ]
+
+REVIEW_SENTIMENT_SCORES = {
+    "Overwhelmingly Positive": 12,
+    "Very Positive": 9,
+    "Positive": 7,
+    "Mostly Positive": 5,
+    "Mixed": -4,
+    "Mostly Negative": -8,
+    "Negative": -8,
+    "Very Negative": -10,
+    "Overwhelmingly Negative": -12,
+}
+
+REVIEW_SENTIMENT_PATTERNS = [
+    "Overwhelmingly Positive",
+    "Very Positive",
+    "Mostly Positive",
+    "Positive",
+    "Mixed",
+    "Overwhelmingly Negative",
+    "Very Negative",
+    "Mostly Negative",
+    "Negative",
+]
+
+FREE_REVIEW_BLOCKLIST = {
+    "Mostly Negative",
+    "Negative",
+    "Very Negative",
+    "Overwhelmingly Negative",
+}
+
+PAID_MINIMUM_REVIEW_SENTIMENTS = {
+    "Mostly Positive",
+    "Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+
+TEMPORARILY_FREE_SCORE_BONUS = 1
+DEMO_SCORE_PENALTY = 1
 
 REJECT_PATTERNS = [
     r"\b1\s*-\s*2\b",
@@ -546,29 +587,22 @@ def score_genres_and_description(title: str, description: str, text: str) -> Tup
     return score, hits
 
 
-def extract_review_score(soup: BeautifulSoup) -> int:
+def extract_review_sentiment(soup: BeautifulSoup) -> Optional[str]:
     page_text = soup.get_text(" ", strip=True)
 
-    if "Overwhelmingly Positive" in page_text:
-        return 6
-    if "Very Positive" in page_text:
-        return 5
-    if "Mostly Positive" in page_text:
-        return 3
-    if "Positive" in page_text:
-        return 4
-    if "Mixed" in page_text:
-        return 0
-    if "Mostly Negative" in page_text:
-        return -3
-    if "Very Negative" in page_text:
-        return -5
-    if "Overwhelmingly Negative" in page_text:
-        return -6
-    if "Negative" in page_text:
-        return -4
+    for sentiment in REVIEW_SENTIMENT_PATTERNS:
+        if sentiment in page_text:
+            return sentiment
 
-    return 0
+    return None
+
+
+def extract_review_score(soup: BeautifulSoup) -> int:
+    sentiment = extract_review_sentiment(soup)
+    if sentiment is None:
+        return 0
+
+    return REVIEW_SENTIMENT_SCORES[sentiment]
 
 
 def inspect_game(source: str, app_id: str) -> Optional[dict]:
@@ -614,9 +648,22 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     multiplayer_score, multiplayer_hits = score_multiplayer(page_text)
     player_score, player_hits, rejected = score_player_count(page_text)
     flavor_score, flavor_hits = score_genres_and_description(title, description, page_text)
-    review_score = extract_review_score(soup)
+    review_sentiment = extract_review_sentiment(soup)
+    review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, 0)
 
-    total_score = multiplayer_score + player_score + flavor_score + review_score
+    review_gate_failed = False
+    if item_type in ["free_game", "demo", "temporarily_free"]:
+        review_gate_failed = review_sentiment in FREE_REVIEW_BLOCKLIST
+    elif item_type == "paid_under_20":
+        review_gate_failed = review_sentiment not in PAID_MINIMUM_REVIEW_SENTIMENTS
+
+    type_adjustment = 0
+    if item_type == "temporarily_free":
+        type_adjustment += TEMPORARILY_FREE_SCORE_BONUS
+    if item_type == "demo":
+        type_adjustment -= DEMO_SCORE_PENALTY
+
+    total_score = multiplayer_score + player_score + flavor_score + review_score + type_adjustment
 
     has_multiplayer_signal = multiplayer_score > 0
     has_3plus_signal = player_score > 0
@@ -625,6 +672,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         keep = (
             has_multiplayer_signal and
             not rejected and
+            not review_gate_failed and
             total_score >= MIN_SCORE_TO_POST_PAID
         )
     elif item_type in ["free_game", "demo", "temporarily_free"]:
@@ -632,6 +680,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
             has_multiplayer_signal and
             has_3plus_signal and
             not rejected and
+            not review_gate_failed and
             total_score >= MIN_SCORE_TO_POST_FREE
         )
     else:
@@ -650,7 +699,9 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         "multiplayer_hits": multiplayer_hits,
         "player_hits": player_hits,
         "flavor_hits": flavor_hits,
+        "review_sentiment": review_sentiment,
         "review_score": review_score,
+        "review_gate_failed": review_gate_failed,
     }
 
 
@@ -1199,7 +1250,7 @@ def main():
             x["score"],
             x.get("review_score", 0),
             1 if x["type"] == "temporarily_free" else 0,
-            1 if x["type"] == "demo" else 0,
+            -1 if x["type"] == "demo" else 0,
         ),
         reverse=True
     )

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -1,0 +1,142 @@
+import main
+
+
+class FakeResponse:
+    def __init__(self, app_id, text):
+        self.url = f"https://store.steampowered.com/app/{app_id}/"
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+
+def build_html(title: str, description: str, review_sentiment: str, feature_text: str) -> str:
+    return f"""
+    <html>
+      <head><meta property="og:title" content="{title}" /></head>
+      <body>
+        <div id="appHubAppName">{title}</div>
+        <div class="game_description_snippet">{description}</div>
+        <div>{review_sentiment}</div>
+        <div>{feature_text}</div>
+      </body>
+    </html>
+    """
+
+
+def stub_app_pages(monkeypatch, html_by_app_id):
+    def fake_get(url, headers=None, timeout=30):
+        app_id = url.rstrip("/").split("/")[-1]
+        return FakeResponse(app_id, html_by_app_id[app_id])
+
+    monkeypatch.setattr(main.requests, "get", fake_get)
+
+
+def test_bad_review_free_games_are_rejected(monkeypatch):
+    html = build_html(
+        title="Noisy Co-op Game",
+        description="Play with friends online.",
+        review_sentiment="Mostly Negative",
+        feature_text="Multiplayer Online Co-Op Up to 8 players",
+    )
+    stub_app_pages(monkeypatch, {"101": html})
+
+    item = main.inspect_game("steam_free", "101")
+
+    assert item is not None
+    assert item["review_sentiment"] == "Mostly Negative"
+    assert item["review_gate_failed"] is True
+    assert item["keep"] is False
+
+
+def test_paid_games_below_mostly_positive_are_rejected(monkeypatch):
+    html = build_html(
+        title="Paid Mixed Game",
+        description="Online squad game.",
+        review_sentiment="Mixed",
+        feature_text="Multiplayer Online Co-Op Up to 8 players",
+    )
+    stub_app_pages(monkeypatch, {"202": html})
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (14.99, False))
+
+    item = main.inspect_game("paid_candidate", "202")
+
+    assert item is not None
+    assert item["type"] == "paid_under_20"
+    assert item["review_sentiment"] == "Mixed"
+    assert item["review_gate_failed"] is True
+    assert item["keep"] is False
+
+
+def test_strong_reviews_rank_above_weaker_reviews(monkeypatch):
+    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
+    html_good = build_html("Good Game", "Team up with friends", "Very Positive", shared_features)
+    html_weak = build_html("Weak Game", "Team up with friends", "Mixed", shared_features)
+    stub_app_pages(monkeypatch, {"301": html_good, "302": html_weak})
+
+    good_item = main.inspect_game("steam_free", "301")
+    weak_item = main.inspect_game("steam_free", "302")
+
+    assert good_item is not None and weak_item is not None
+    assert good_item["score"] > weak_item["score"]
+
+    ranked = sorted(
+        [good_item, weak_item],
+        key=lambda x: (x["score"], x.get("review_score", 0)),
+        reverse=True,
+    )
+    assert ranked[0]["id"] == "301"
+
+
+def test_mixed_reviews_get_meaningful_penalty(monkeypatch):
+    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
+    html_mostly_positive = build_html(
+        "Mostly Positive Game",
+        "Play with friends online",
+        "Mostly Positive",
+        shared_features,
+    )
+    html_mixed = build_html(
+        "Mixed Game",
+        "Play with friends online",
+        "Mixed",
+        shared_features,
+    )
+    stub_app_pages(monkeypatch, {"401": html_mostly_positive, "402": html_mixed})
+
+    mostly_positive = main.inspect_game("steam_free", "401")
+    mixed = main.inspect_game("steam_free", "402")
+
+    assert mostly_positive is not None and mixed is not None
+    assert mostly_positive["review_score"] - mixed["review_score"] >= 8
+    assert mostly_positive["score"] - mixed["score"] >= 8
+
+
+def test_demo_does_not_outrank_equivalent_full_game(monkeypatch):
+    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
+    html_full = build_html("Full Game", "Play with friends online", "Very Positive", shared_features)
+    html_demo = build_html("Demo Version", "Play with friends online", "Very Positive", shared_features)
+    stub_app_pages(monkeypatch, {"501": html_full, "502": html_demo})
+
+    full_game = main.inspect_game("steam_free", "501")
+    demo_game = main.inspect_game("steam_demo", "502")
+
+    assert full_game is not None and demo_game is not None
+    assert full_game["type"] == "free_game"
+    assert demo_game["type"] == "demo"
+    assert full_game["score"] > demo_game["score"]
+
+
+def test_temporarily_free_gets_only_modest_preference(monkeypatch):
+    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
+    html_regular = build_html("Regular Free", "Play with friends online", "Very Positive", shared_features)
+    html_temp = build_html("Temp Free", "100% off play with friends online", "Very Positive", shared_features)
+    stub_app_pages(monkeypatch, {"601": html_regular, "602": html_temp})
+
+    regular = main.inspect_game("steam_free", "601")
+    temporary = main.inspect_game("steamdb_promo", "602")
+
+    assert regular is not None and temporary is not None
+    assert regular["type"] == "free_game"
+    assert temporary["type"] == "temporarily_free"
+    assert temporary["score"] == regular["score"] + main.TEMPORARILY_FREE_SCORE_BONUS


### PR DESCRIPTION
### Motivation
- Reduce noisy top picks by making review quality a primary gating and ranking signal while keeping the existing candidate collection and posting flow unchanged.  
- Make paid picks stricter than free ones and prevent multiplayer/player-count keyword stuffing from rescuing low-quality titles.  
- Keep the change low-risk and localized inside the existing `main.py` scoring path with minimal helper additions and focused unit tests.

### Description
- Add explicit review sentiment extraction (`extract_review_sentiment`) and map sentiments to stronger numeric scores using `REVIEW_SENTIMENT_SCORES`, while treating unknown sentiment as neutral (`0`).  
- Introduce conservative quality gates so free/demo/temporarily-free are rejected if sentiment is in `FREE_REVIEW_BLOCKLIST = {"Mostly Negative","Negative","Very Negative","Overwhelmingly Negative"}` and paid-under-$20 requires sentiment in `PAID_MINIMUM_REVIEW_SENTIMENTS = {"Mostly Positive","Positive","Very Positive","Overwhelmingly Positive"}`.  
- Rebalance weights by lowering multiplayer and player-count points (e.g., `Massively Multiplayer` and `MMO` from 6→4, `Co-op` from 4→2, and player-count entries reduced by ~1 point) and raise thresholds to `MIN_SCORE_TO_POST_FREE = 9` and `MIN_SCORE_TO_POST_PAID = 7`.  
- Apply small type adjustments so temporarily-free gets `+1` (`TEMPORARILY_FREE_SCORE_BONUS`) and demos get a slight `-1` (`DEMO_SCORE_PENALTY`), and add `review_sentiment` and `review_gate_failed` to the returned item metadata for debugging and sorting.

(Exact review sentiment scores implemented: Overwhelmingly Positive +12, Very Positive +9, Positive +7, Mostly Positive +5, Mixed -4, Mostly Negative -8, Negative -8, Very Negative -10, Overwhelmingly Negative -12.)

### Testing
- Added `tests/test_main_scoring_model.py` with focused unit cases for: rejecting bad-review free games, rejecting paid games below Mostly Positive, ensuring strongly-reviewed multiplayer games outrank weaker-reviewed ones, penalizing Mixed reviews, keeping demos disadvantaged versus full games, and modestly preferring temporarily-free items.  
- Ran `pytest -q tests/test_main_scoring_model.py tests/test_main_daily_picks.py` and observed all tests passing: `10 passed in 0.53s`.  
- No external dependencies or pipeline changes were added and the change is limited to scoring constants and functions inside `main.py`, making this a conservative, low-risk tuning pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81d8a5aec8326be0c2bd3644c8ea1)