### PR TITLE
Tune scoring model to reduce noise and favor 4–6 player co-op games

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ MAX_PAGE_LIMIT = 50
 REQUEST_DELAY_SECONDS = 1.2
 REPOST_COOLDOWN_DAYS = 30
 MIN_SCORE_TO_POST_FREE = 9
-MIN_SCORE_TO_POST_PAID = 7
+MIN_SCORE_TO_POST_PAID = 8
 
 MAX_FETCH_RETRIES = 5
 BACKOFF_SECONDS = 4
@@ -129,6 +129,49 @@ BAD_TERMS = {
     "character creator": -4,
 }
 
+FRIEND_GROUP_PHRASE_SCORES = {
+    "4-player co-op": 2,
+    "4 player co-op": 2,
+    "4-player online co-op": 2,
+    "drop-in co-op": 1,
+    "couch co-op": 2,
+    "party game": 2,
+    "cross-platform multiplayer": 1,
+    "up to 6 players": 2,
+    "up to 8 players": 2,
+}
+
+REPLAYABILITY_PHRASE_SCORES = {
+    "procedurally generated": 1,
+    "roguelite co-op": 1,
+    "endless replayability": 1,
+    "loot": 1,
+    "runs": 1,
+    "randomized": 1,
+    "progression": 1,
+}
+
+LOW_SIGNAL_KEYWORD_SCORES = {
+    "clicker": -3,
+    "idle": -3,
+    "hentai": -4,
+    "nsfw": -4,
+    "prototype": -3,
+    "test": -2,
+    "ai-generated": -3,
+    "meme": -2,
+    "asset flip": -4,
+    "unity asset": -3,
+}
+
+TITLE_LOW_SIGNAL_KEYWORD_SCORES = {
+    "simulator": -1,
+    "clicker": -2,
+    "idle": -2,
+    "prototype": -2,
+    "test": -1,
+}
+
 PLAYER_COUNT_PATTERNS = [
     (r"\b1\s*-\s*4\b", 3),
     (r"\b1\s*-\s*6\b", 4),
@@ -152,7 +195,7 @@ REVIEW_SENTIMENT_SCORES = {
     "Very Positive": 9,
     "Positive": 7,
     "Mostly Positive": 5,
-    "Mixed": -4,
+    "Mixed": -6,
     "Mostly Negative": -8,
     "Negative": -8,
     "Very Negative": -10,
@@ -186,7 +229,29 @@ PAID_MINIMUM_REVIEW_SENTIMENTS = {
 }
 
 TEMPORARILY_FREE_SCORE_BONUS = 1
-DEMO_SCORE_PENALTY = 1
+DEMO_SCORE_PENALTY = 2
+
+UNKNOWN_REVIEW_SCORE_BY_TYPE = {
+    "free_game": -2,
+    "demo": -2,
+    "temporarily_free": -2,
+    "paid_under_20": -6,
+}
+
+STRONG_REVIEW_SENTIMENTS = {"Very Positive", "Overwhelmingly Positive"}
+POSITIVE_OR_BETTER_REVIEW_SENTIMENTS = {
+    "Positive",
+    "Mostly Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+REVIEW_CONFIDENCE_BASELINE_SENTIMENTS = {
+    "Positive",
+    "Mostly Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+REVIEW_CONFIDENCE_STRONG_SENTIMENTS = {"Very Positive", "Overwhelmingly Positive"}
 
 REJECT_PATTERNS = [
     r"\b1\s*-\s*2\b",
@@ -546,7 +611,7 @@ def score_player_count(text: str) -> Tuple[int, List[str], bool]:
     lower_text = text.lower()
 
     if "massively multiplayer" in lower_text or re.search(r"\bmmo\b", lower_text):
-        score += 6
+        score += 5
         hits.append("MMO/Massively Multiplayer")
         return score, hits, False
 
@@ -583,6 +648,131 @@ def score_genres_and_description(title: str, description: str, text: str) -> Tup
         if term.lower() in lower_combined:
             score += points
             hits.append(term)
+
+    return score, hits
+
+
+def has_4plus_player_signal(text: str) -> bool:
+    patterns = [
+        r"\b4\s*player\b",
+        r"\b4\s*players\b",
+        r"\b5\s*player\b",
+        r"\b5\s*players\b",
+        r"\b6\s*player\b",
+        r"\b6\s*players\b",
+        r"\bup to 4 players\b",
+        r"\bup to 5 players\b",
+        r"\bup to 6 players\b",
+        r"\bup to 8 players\b",
+        r"\b1\s*-\s*4\b",
+        r"\b1\s*-\s*6\b",
+        r"\b2\s*-\s*4\b",
+        r"\b2\s*-\s*6\b",
+        r"\b3\s*-\s*4\b",
+        r"\b3\s*-\s*6\b",
+        r"\b4\s*\+\b",
+    ]
+    return any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns)
+
+
+def extract_review_count(page_text: str) -> int:
+    match = re.search(r"([\d,]+)\s+(?:user\s+)?reviews?\b", page_text, re.IGNORECASE)
+    if not match:
+        return 0
+    try:
+        return int(match.group(1).replace(",", ""))
+    except ValueError:
+        return 0
+
+
+def score_quality_refinements(
+    title: str,
+    description: str,
+    text: str,
+    review_sentiment: Optional[str],
+    review_count: int,
+    multiplayer_score: int,
+    player_score: int,
+) -> Tuple[int, List[str]]:
+    score = 0
+    hits = []
+    lower_title = title.lower()
+    lower_text = text.lower()
+    lower_description = description.lower()
+    combined = f"{lower_title} {lower_description} {lower_text}"
+
+    strong_review = review_sentiment in STRONG_REVIEW_SENTIMENTS
+    positive_or_better = review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS
+    has_4plus = has_4plus_player_signal(text)
+    has_coop = "co-op" in lower_text or "co op" in lower_text or "online co-op" in lower_text
+    has_pvp = "pvp" in lower_text or "online pvp" in lower_text
+    strong_multiplayer = multiplayer_score >= 4 or player_score >= 3
+
+    if strong_review and has_4plus:
+        score += 2
+        hits.append("strong-review-4plus-combo")
+
+    if review_count >= 1000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
+        score += 1
+        hits.append("review-count-1k")
+    if review_count >= 10000 and review_sentiment in REVIEW_CONFIDENCE_STRONG_SENTIMENTS:
+        score += 1
+        hits.append("review-count-10k-strong")
+
+    for phrase, points in FRIEND_GROUP_PHRASE_SCORES.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"group:{phrase}")
+
+    for phrase, points in REPLAYABILITY_PHRASE_SCORES.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"replay:{phrase}")
+
+    if "single-player" in combined and multiplayer_score <= 2:
+        score -= 2
+        hits.append("single-player-with-weak-mp")
+
+    for keyword, points in LOW_SIGNAL_KEYWORD_SCORES.items():
+        if keyword in combined:
+            score += points
+            hits.append(f"low-signal:{keyword}")
+
+    for keyword, points in TITLE_LOW_SIGNAL_KEYWORD_SCORES.items():
+        if keyword in lower_title:
+            score += points
+            hits.append(f"title-low-signal:{keyword}")
+
+    story_terms = ["visual novel", "dating sim", "interactive fiction", "story-rich", "narrative"]
+    if not strong_multiplayer:
+        for term in story_terms:
+            if term in combined:
+                score -= 2
+                hits.append(f"story:{term}")
+
+    if "early access" in combined and not strong_review:
+        score -= 2
+        hits.append("early-access")
+
+    if has_coop:
+        score += 1
+        hits.append("coop-preference")
+    if has_pvp and not has_coop:
+        score -= 1
+        hits.append("pvp-only-penalty")
+
+    if has_4plus and any(token in combined for token in ["4 players", "4-player", "up to 4 players", "up to 5 players", "up to 6 players", "5 players", "6 players"]):
+        score += 1
+        hits.append("4to6-player-preference")
+
+    if multiplayer_score >= 6 and review_sentiment == "Mixed":
+        score -= 2
+        hits.append("keyword-stuffing-weak-review")
+
+    trusted_genres = ["survival", "shooter", "roguelite", "party"]
+    if strong_review and has_4plus and has_coop and any(term in combined for term in trusted_genres):
+        score += 2
+        hits.append("trusted-profile")
 
     return score, hits
 
@@ -649,7 +839,8 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     player_score, player_hits, rejected = score_player_count(page_text)
     flavor_score, flavor_hits = score_genres_and_description(title, description, page_text)
     review_sentiment = extract_review_sentiment(soup)
-    review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, 0)
+    review_count = extract_review_count(page_text)
+    review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, UNKNOWN_REVIEW_SCORE_BY_TYPE.get(item_type, 0))
 
     review_gate_failed = False
     if item_type in ["free_game", "demo", "temporarily_free"]:
@@ -657,13 +848,30 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     elif item_type == "paid_under_20":
         review_gate_failed = review_sentiment not in PAID_MINIMUM_REVIEW_SENTIMENTS
 
+    refinement_score, refinement_hits = score_quality_refinements(
+        title=title,
+        description=description,
+        text=page_text,
+        review_sentiment=review_sentiment,
+        review_count=review_count,
+        multiplayer_score=multiplayer_score,
+        player_score=player_score,
+    )
+
     type_adjustment = 0
-    if item_type == "temporarily_free":
+    if item_type == "temporarily_free" and review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS:
         type_adjustment += TEMPORARILY_FREE_SCORE_BONUS
     if item_type == "demo":
         type_adjustment -= DEMO_SCORE_PENALTY
 
-    total_score = multiplayer_score + player_score + flavor_score + review_score + type_adjustment
+    total_score = (
+        multiplayer_score
+        + player_score
+        + flavor_score
+        + review_score
+        + refinement_score
+        + type_adjustment
+    )
 
     has_multiplayer_signal = multiplayer_score > 0
     has_3plus_signal = player_score > 0
@@ -699,8 +907,10 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         "multiplayer_hits": multiplayer_hits,
         "player_hits": player_hits,
         "flavor_hits": flavor_hits,
+        "refinement_hits": refinement_hits,
         "review_sentiment": review_sentiment,
         "review_score": review_score,
+        "review_count": review_count,
         "review_gate_failed": review_gate_failed,
     }
 

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -10,7 +10,12 @@ class FakeResponse:
         return None
 
 
-def build_html(title: str, description: str, review_sentiment: str, feature_text: str) -> str:
+def build_html(
+    title: str,
+    description: str,
+    feature_text: str,
+    review_sentiment: str = "",
+) -> str:
     return f"""
     <html>
       <head><meta property="og:title" content="{title}" /></head>
@@ -32,111 +37,171 @@ def stub_app_pages(monkeypatch, html_by_app_id):
     monkeypatch.setattr(main.requests, "get", fake_get)
 
 
-def test_bad_review_free_games_are_rejected(monkeypatch):
-    html = build_html(
-        title="Noisy Co-op Game",
-        description="Play with friends online.",
-        review_sentiment="Mostly Negative",
-        feature_text="Multiplayer Online Co-Op Up to 8 players",
-    )
-    stub_app_pages(monkeypatch, {"101": html})
+def test_unknown_review_sentiment_penalized_and_blocked_for_paid(monkeypatch):
+    base_text = "Multiplayer Online Co-Op up to 6 players party game"
+    free_html = build_html("Unknown Free", "friends game", base_text, review_sentiment="")
+    paid_html = build_html("Unknown Paid", "friends game", base_text, review_sentiment="")
+    stub_app_pages(monkeypatch, {"101": free_html, "102": paid_html})
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (9.99, False))
 
-    item = main.inspect_game("steam_free", "101")
+    free_item = main.inspect_game("steam_free", "101")
+    paid_item = main.inspect_game("paid_candidate", "102")
 
-    assert item is not None
-    assert item["review_sentiment"] == "Mostly Negative"
-    assert item["review_gate_failed"] is True
-    assert item["keep"] is False
-
-
-def test_paid_games_below_mostly_positive_are_rejected(monkeypatch):
-    html = build_html(
-        title="Paid Mixed Game",
-        description="Online squad game.",
-        review_sentiment="Mixed",
-        feature_text="Multiplayer Online Co-Op Up to 8 players",
-    )
-    stub_app_pages(monkeypatch, {"202": html})
-    monkeypatch.setattr(main, "get_price_info", lambda app_id: (14.99, False))
-
-    item = main.inspect_game("paid_candidate", "202")
-
-    assert item is not None
-    assert item["type"] == "paid_under_20"
-    assert item["review_sentiment"] == "Mixed"
-    assert item["review_gate_failed"] is True
-    assert item["keep"] is False
+    assert free_item is not None and paid_item is not None
+    assert free_item["review_sentiment"] is None
+    assert free_item["review_score"] == -2
+    assert paid_item["review_sentiment"] is None
+    assert paid_item["review_gate_failed"] is True
 
 
-def test_strong_reviews_rank_above_weaker_reviews(monkeypatch):
-    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
-    html_good = build_html("Good Game", "Team up with friends", "Very Positive", shared_features)
-    html_weak = build_html("Weak Game", "Team up with friends", "Mixed", shared_features)
-    stub_app_pages(monkeypatch, {"301": html_good, "302": html_weak})
+def test_mixed_reviews_are_harder_to_qualify(monkeypatch):
+    shared = "Multiplayer Online Co-Op up to 6 players party game"
+    html_mostly_positive = build_html("Mostly Positive Game", "friends game", shared, "Mostly Positive")
+    html_mixed = build_html("Mixed Game", "friends game", shared, "Mixed")
+    stub_app_pages(monkeypatch, {"201": html_mostly_positive, "202": html_mixed})
 
-    good_item = main.inspect_game("steam_free", "301")
-    weak_item = main.inspect_game("steam_free", "302")
-
-    assert good_item is not None and weak_item is not None
-    assert good_item["score"] > weak_item["score"]
-
-    ranked = sorted(
-        [good_item, weak_item],
-        key=lambda x: (x["score"], x.get("review_score", 0)),
-        reverse=True,
-    )
-    assert ranked[0]["id"] == "301"
-
-
-def test_mixed_reviews_get_meaningful_penalty(monkeypatch):
-    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
-    html_mostly_positive = build_html(
-        "Mostly Positive Game",
-        "Play with friends online",
-        "Mostly Positive",
-        shared_features,
-    )
-    html_mixed = build_html(
-        "Mixed Game",
-        "Play with friends online",
-        "Mixed",
-        shared_features,
-    )
-    stub_app_pages(monkeypatch, {"401": html_mostly_positive, "402": html_mixed})
-
-    mostly_positive = main.inspect_game("steam_free", "401")
-    mixed = main.inspect_game("steam_free", "402")
+    mostly_positive = main.inspect_game("steam_free", "201")
+    mixed = main.inspect_game("steam_free", "202")
 
     assert mostly_positive is not None and mixed is not None
-    assert mostly_positive["review_score"] - mixed["review_score"] >= 8
-    assert mostly_positive["score"] - mixed["score"] >= 8
+    assert mixed["review_score"] == -6
+    assert mostly_positive["score"] > mixed["score"]
 
 
-def test_demo_does_not_outrank_equivalent_full_game(monkeypatch):
-    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
-    html_full = build_html("Full Game", "Play with friends online", "Very Positive", shared_features)
-    html_demo = build_html("Demo Version", "Play with friends online", "Very Positive", shared_features)
-    stub_app_pages(monkeypatch, {"501": html_full, "502": html_demo})
+def test_mmo_player_bonus_is_reduced(monkeypatch):
+    html = build_html("MMO Game", "friends game", "Massively Multiplayer MMO Online Co-Op")
+    stub_app_pages(monkeypatch, {"301": html})
 
-    full_game = main.inspect_game("steam_free", "501")
-    demo_game = main.inspect_game("steam_demo", "502")
-
-    assert full_game is not None and demo_game is not None
-    assert full_game["type"] == "free_game"
-    assert demo_game["type"] == "demo"
-    assert full_game["score"] > demo_game["score"]
+    item = main.inspect_game("steam_free", "301")
+    assert item is not None
+    player_score, _, _ = main.score_player_count("Massively Multiplayer MMO Online Co-Op")
+    assert player_score == 5
 
 
-def test_temporarily_free_gets_only_modest_preference(monkeypatch):
-    shared_features = "Multiplayer Online Co-Op Up to 8 players friends party action"
-    html_regular = build_html("Regular Free", "Play with friends online", "Very Positive", shared_features)
-    html_temp = build_html("Temp Free", "100% off play with friends online", "Very Positive", shared_features)
-    stub_app_pages(monkeypatch, {"601": html_regular, "602": html_temp})
+def test_very_positive_group_game_ranks_above_mixed(monkeypatch):
+    shared = "Multiplayer Online Co-Op up to 6 players party game"
+    strong = build_html("Strong Co-op", "team up with friends", shared, "Very Positive")
+    weak = build_html("Weak Co-op", "team up with friends", shared, "Mixed")
+    stub_app_pages(monkeypatch, {"401": strong, "402": weak})
 
-    regular = main.inspect_game("steam_free", "601")
-    temporary = main.inspect_game("steamdb_promo", "602")
+    strong_item = main.inspect_game("steam_free", "401")
+    weak_item = main.inspect_game("steam_free", "402")
+    assert strong_item is not None and weak_item is not None
+    assert strong_item["score"] > weak_item["score"]
 
-    assert regular is not None and temporary is not None
-    assert regular["type"] == "free_game"
-    assert temporary["type"] == "temporarily_free"
-    assert temporary["score"] == regular["score"] + main.TEMPORARILY_FREE_SCORE_BONUS
+
+def test_review_count_confidence_bonus(monkeypatch):
+    low_count = build_html(
+        "Low Count",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players Very Positive 80 reviews",
+        "Very Positive",
+    )
+    high_count = build_html(
+        "High Count",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players Very Positive 12,000 reviews",
+        "Very Positive",
+    )
+    stub_app_pages(monkeypatch, {"501": low_count, "502": high_count})
+
+    low_item = main.inspect_game("steam_free", "501")
+    high_item = main.inspect_game("steam_free", "502")
+    assert low_item is not None and high_item is not None
+    assert high_item["review_count"] == 12000
+    assert high_item["score"] >= low_item["score"] + 2
+
+
+def test_paid_rejects_unknown_and_mixed(monkeypatch):
+    unknown = build_html("Paid Unknown", "friends", "Multiplayer Online Co-Op up to 6 players")
+    mixed = build_html("Paid Mixed", "friends", "Multiplayer Online Co-Op up to 6 players", "Mixed")
+    stub_app_pages(monkeypatch, {"601": unknown, "602": mixed})
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (15.0, False))
+
+    unknown_item = main.inspect_game("paid_candidate", "601")
+    mixed_item = main.inspect_game("paid_candidate", "602")
+    assert unknown_item is not None and mixed_item is not None
+    assert unknown_item["review_gate_failed"] is True
+    assert mixed_item["review_gate_failed"] is True
+
+
+def test_demo_penalty_keeps_full_game_above_demo(monkeypatch):
+    shared = "Multiplayer Online Co-Op up to 6 players party game Very Positive"
+    full_html = build_html("Full Game", "friends", shared, "Very Positive")
+    demo_html = build_html("Demo Game", "friends", shared, "Very Positive")
+    stub_app_pages(monkeypatch, {"701": full_html, "702": demo_html})
+
+    full_item = main.inspect_game("steam_free", "701")
+    demo_item = main.inspect_game("steam_demo", "702")
+    assert full_item is not None and demo_item is not None
+    assert full_item["score"] > demo_item["score"]
+
+
+def test_temporarily_free_bonus_requires_positive_or_better(monkeypatch):
+    pos = build_html("Promo Positive", "friends", "100% off Multiplayer up to 6 players", "Positive")
+    mixed = build_html("Promo Mixed", "friends", "100% off Multiplayer up to 6 players", "Mixed")
+    stub_app_pages(monkeypatch, {"801": pos, "802": mixed})
+
+    pos_item = main.inspect_game("steamdb_promo", "801")
+    mixed_item = main.inspect_game("steamdb_promo", "802")
+    assert pos_item is not None and mixed_item is not None
+    assert pos_item["score"] >= mixed_item["score"] + main.TEMPORARILY_FREE_SCORE_BONUS
+
+
+def test_single_player_weak_multiplayer_gets_penalty(monkeypatch):
+    weak = build_html("Solo Leaning", "single-player narrative", "single-player Multiplayer", "Mostly Positive")
+    strong = build_html("Strong MP", "friends game", "single-player Multiplayer Online Co-Op up to 6 players", "Mostly Positive")
+    stub_app_pages(monkeypatch, {"901": weak, "902": strong})
+
+    weak_item = main.inspect_game("steam_free", "901")
+    strong_item = main.inspect_game("steam_free", "902")
+    assert weak_item is not None and strong_item is not None
+    assert weak_item["score"] < strong_item["score"]
+
+
+def test_junk_keywords_and_titles_are_penalized(monkeypatch):
+    junk = build_html(
+        "Prototype Clicker Simulator Test",
+        "idle meme game",
+        "Multiplayer up to 6 players clicker idle prototype",
+        "Mostly Positive",
+    )
+    clean = build_html("Team Party Ops", "friends game", "Multiplayer Online Co-Op up to 6 players", "Mostly Positive")
+    stub_app_pages(monkeypatch, {"1001": junk, "1002": clean})
+
+    junk_item = main.inspect_game("steam_free", "1001")
+    clean_item = main.inspect_game("steam_free", "1002")
+    assert junk_item is not None and clean_item is not None
+    assert junk_item["score"] < clean_item["score"]
+
+
+def test_coop_preferred_over_pvp_only(monkeypatch):
+    coop = build_html("Coop Game", "friends", "Multiplayer Online Co-Op up to 6 players", "Mostly Positive")
+    pvp = build_html("PvP Arena", "friends", "Multiplayer Online PvP up to 6 players", "Mostly Positive")
+    stub_app_pages(monkeypatch, {"1101": coop, "1102": pvp})
+
+    coop_item = main.inspect_game("steam_free", "1101")
+    pvp_item = main.inspect_game("steam_free", "1102")
+    assert coop_item is not None and pvp_item is not None
+    assert coop_item["score"] > pvp_item["score"]
+
+
+def test_trusted_profile_bonus_lifts_best_fit_games(monkeypatch):
+    trusted = build_html(
+        "Survival Squad",
+        "team up with friends",
+        "Very Positive Multiplayer Online Co-Op up to 6 players survival progression 20,000 reviews",
+        "Very Positive",
+    )
+    weaker = build_html(
+        "Generic Multiplayer",
+        "team up with friends",
+        "Mostly Positive Multiplayer Online PvP up to 4 players 20,000 reviews",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"1201": trusted, "1202": weaker})
+
+    trusted_item = main.inspect_game("steam_free", "1201")
+    weaker_item = main.inspect_game("steam_free", "1202")
+    assert trusted_item is not None and weaker_item is not None
+    assert trusted_item["score"] > weaker_item["score"]


### PR DESCRIPTION
### Motivation
- Improve signal-to-noise in the posting pipeline so the channel surfaces genuinely good games, prioritizes titles that fit 3–6 person friend groups, and reduces demos, low-effort junk, and keyword-stuffed multiplayer pages.
- Keep this as a LOW-RISK change that only adjusts scoring inside `main.py` and does not alter the posting/scheduling architecture or add dependencies. 

### Description
- Adjusted core thresholds and sentiment handling: raised `MIN_SCORE_TO_POST_PAID` to `8`, made `Mixed` sentiment harsher (`-6`), increased demo penalty to `-2`, and added `UNKNOWN_REVIEW_SCORE_BY_TYPE` so unknown sentiment is penalized by item type (free/demo/temp-free `-2`, paid_under_20 `-6`).
- Reduced the MMO player-count special-case bonus from `+6` to `+5`, and added a focused refinement layer (`score_quality_refinements`) inside `main.py` to apply small, conservative boosts/penalties for group-fit and quality signals (kept all logic local to `main.py`).
- New refinement signals include: strong-review + 4+ players combo (`+2`), review-count confidence (`+1` at >=1k positive+, extra `+1` at >=10k very+), friend-group phrase boosts, replayability boosts, single-player-with-weak-multiplayer penalty (`-2`), low-signal/junk keyword penalties (approx `-2` to `-4`), title-specific low-signal penalties, mild story-heavy penalties when multiplayer is weak, Early Access penalty (waived for very strong reviews), slight co-op preference (`+1`) and PvP-only penalty (`-1`), slight 4–6 player preference (`+1`), keyword-stuffing penalty for Mixed reviews, and a tiny trusted-profile bonus (`+2`).
- Kept temporarily-free bonus small and quality-dependent: `TEMPORARILY_FREE_SCORE_BONUS = +1` now only applies when review sentiment is Positive or better.
- Preserved gating rules for paid picks so unknown or Mixed reviews fail the paid gate; exposed `review_count` and `refinement_hits` in the inspect output for observability. Files changed: `main.py` (scoring and helpers) and `tests/test_main_scoring_model.py` (expanded focused tests).

### Testing
- Ran the focused scoring tests with `pytest -q tests/test_main_scoring_model.py`, which passed: `12 passed`.
- Ran the daily-picks suite with `pytest -q tests/test_main_daily_picks.py`, which passed: `4 passed`.
- All automated tests executed during this change completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8209f8b888326ba72d3f7ba01c437)