### PR TITLE
Polish scoring signals: reduce MMO bonus, add review-count confidence, junk penalties & trusted-profile tweaks

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,12 +153,12 @@ REPLAYABILITY_PHRASE_SCORES = {
 
 LOW_SIGNAL_KEYWORD_SCORES = {
     "clicker": -3,
-    "idle": -3,
+    "idle": -2,
     "hentai": -4,
     "nsfw": -4,
-    "prototype": -3,
+    "prototype": -2,
     "test": -2,
-    "ai-generated": -3,
+    "ai-generated": -2,
     "meme": -2,
     "asset flip": -4,
     "unity asset": -3,
@@ -611,7 +611,7 @@ def score_player_count(text: str) -> Tuple[int, List[str], bool]:
     lower_text = text.lower()
 
     if "massively multiplayer" in lower_text or re.search(r"\bmmo\b", lower_text):
-        score += 5
+        score += 4
         hits.append("MMO/Massively Multiplayer")
         return score, hits, False
 
@@ -712,12 +712,12 @@ def score_quality_refinements(
         score += 2
         hits.append("strong-review-4plus-combo")
 
-    if review_count >= 1000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
+    if review_count >= 10000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
+        score += 2
+        hits.append("review-count-10k")
+    elif review_count >= 1000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
         score += 1
         hits.append("review-count-1k")
-    if review_count >= 10000 and review_sentiment in REVIEW_CONFIDENCE_STRONG_SENTIMENTS:
-        score += 1
-        hits.append("review-count-10k-strong")
 
     for phrase, points in FRIEND_GROUP_PHRASE_SCORES.items():
         if phrase in combined:
@@ -769,7 +769,7 @@ def score_quality_refinements(
         score -= 2
         hits.append("keyword-stuffing-weak-review")
 
-    trusted_genres = ["survival", "shooter", "roguelite", "party"]
+    trusted_genres = ["survival", "shooter", "roguelike", "roguelite", "party", "extraction"]
     if strong_review and has_4plus and has_coop and any(term in combined for term in trusted_genres):
         score += 2
         hits.append("trusted-profile")

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -75,7 +75,7 @@ def test_mmo_player_bonus_is_reduced(monkeypatch):
     item = main.inspect_game("steam_free", "301")
     assert item is not None
     player_score, _, _ = main.score_player_count("Massively Multiplayer MMO Online Co-Op")
-    assert player_score == 5
+    assert player_score == 4
 
 
 def test_very_positive_group_game_ranks_above_mixed(monkeypatch):
@@ -109,6 +109,27 @@ def test_review_count_confidence_bonus(monkeypatch):
     high_item = main.inspect_game("steam_free", "502")
     assert low_item is not None and high_item is not None
     assert high_item["review_count"] == 12000
+    assert high_item["score"] >= low_item["score"] + 2
+
+
+def test_review_count_confidence_bonus_applies_to_mostly_positive(monkeypatch):
+    low_count = build_html(
+        "Low Count Mostly Positive",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players Mostly Positive 90 reviews",
+        "Mostly Positive",
+    )
+    high_count = build_html(
+        "High Count Mostly Positive",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players Mostly Positive 15,000 reviews",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"503": low_count, "504": high_count})
+
+    low_item = main.inspect_game("steam_free", "503")
+    high_item = main.inspect_game("steam_free", "504")
+    assert low_item is not None and high_item is not None
     assert high_item["score"] >= low_item["score"] + 2
 
 
@@ -205,3 +226,28 @@ def test_trusted_profile_bonus_lifts_best_fit_games(monkeypatch):
     weaker_item = main.inspect_game("steam_free", "1202")
     assert trusted_item is not None and weaker_item is not None
     assert trusted_item["score"] > weaker_item["score"]
+
+
+def test_keyword_stuffing_penalty_for_mixed_reviews(monkeypatch):
+    text = "Multiplayer Online Co-Op Co-op squad team-based online pvp up to 6 players"
+    mixed_score, mixed_hits = main.score_quality_refinements(
+        title="Stuffed Keywords",
+        description="friends game",
+        text=text,
+        review_sentiment="Mixed",
+        review_count=200,
+        multiplayer_score=8,
+        player_score=4,
+    )
+    positive_score, _ = main.score_quality_refinements(
+        title="Stuffed Keywords",
+        description="friends game",
+        text=text,
+        review_sentiment="Mostly Positive",
+        review_count=200,
+        multiplayer_score=8,
+        player_score=4,
+    )
+
+    assert "keyword-stuffing-weak-review" in mixed_hits
+    assert mixed_score <= positive_score - 2


### PR DESCRIPTION
### Motivation

- Tighten signal from Steam pages by implementing small, low-risk scoring refinements while keeping the existing pipeline and architecture unchanged. 
- Fix the remaining MMO player-count inconsistency and add a few targeted bonuses/penalties to reduce low-signal noise and reward the ideal friend-group game profile.

### Description

- Reduced the MMO special-case player-count bonus in `score_player_count(...)` from `+5` to `+4` to align with the updated multiplayer weighting. 
- Added a small review-count confidence bonus in `score_quality_refinements(...)` that awards `+1` at `>= 1,000` reviews and `+2` at `>= 10,000` reviews for positive-or-better sentiments. 
- Tuned low-signal keyword penalties in `LOW_SIGNAL_KEYWORD_SCORES` (e.g., `idle`, `prototype`, and `ai-generated` reduced to milder penalties) and kept slightly stronger title-level penalties in `TITLE_LOW_SIGNAL_KEYWORD_SCORES`. 
- Kept and enforced the weak-multiplayer single-player penalty (`-2` when `single-player` appears and multiplayer score <= 2), keyword-stuffing penalty for weak reviews (`-2` when `multiplayer_score >= 6` and sentiment is `Mixed`), subtle co-op preference (`+1`) and PvP-only penalty (`-1`), and expanded trusted-profile genres to include `roguelike` and `extraction` with a `+2` trusted-profile boost for the full match conditions. 
- All changes are localized to `main.py` and focused tests in `tests/test_main_scoring_model.py`; no new dependencies or pipeline/posting logic were altered.

### Testing

- Ran the focused test file with `pytest -q tests/test_main_scoring_model.py` and all tests passed (`14 passed`).
- Updated and added tests covering the MMO bonus reduction, review-count confidence behavior (including Mostly Positive at 10k+), single-player weak-multiplayer penalty, junk keyword penalties, trusted-profile uplift, keyword-stuffing protection for Mixed reviews, and co-op vs PvP preference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8225d0d0c832689518204dce03ee9)