### PR TITLE
Add dedicated “New Demos & Playtests” daily section and friend-group scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Manual rerun quick commands (GitHub CLI):
   - Preview only: `gh workflow run weekly-scheduling-responses-sync.yml -f dry_run=true`
 
 ### Daily Picks (`daily.yml`)
-- **What it does:** posts daily free/paid/creator picks and updates `discord_daily_posts.json`.
+- **What it does:** posts daily demos/playtests + free/paid/creator picks and updates `discord_daily_posts.json`.
 - **Manual input:** `daily_date_utc` (optional `YYYY-MM-DD`).
 - **When to rerun:** partial morning run, stale/deleted daily messages, or date-targeted state repair.
 - **Examples:**
@@ -244,6 +244,7 @@ Operator controls (`workflow_dispatch` / env passthrough):
 Posting behavior in `daily-game-picks`:
 - Intro message
 - Section headers:
+  - New Demos & Playtests
   - Free Picks
   - Paid Under $20
   - Instagram Creator Picks

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -21,11 +21,12 @@ MAX_VOTERS_SHOWN_PER_GAME = 6
 DISCORD_MESSAGE_CHAR_LIMIT = 2000
 
 SECTION_CONFIG = {
+    "demo_playtest": "New Demos & Playtests",
     "free": "Free Picks",
     "paid": "Paid Under $20",
     "instagram": "Instagram Creator Picks",
 }
-SECTION_ORDER = ["free", "paid", "instagram"]
+SECTION_ORDER = ["demo_playtest", "free", "paid", "instagram"]
 
 
 def load_discord_daily_posts() -> Dict[str, dict]:

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ HEADERS = {
 
 # ---------- CONFIG ----------
 MAX_FREE_POSTS = 10
+MAX_DEMO_PLAYTEST_POSTS = 10
 MAX_PAID_POSTS = 10
 
 PAGE_WINDOW_SIZE = 10
@@ -56,6 +57,7 @@ MAX_PAGE_LIMIT = 50
 REQUEST_DELAY_SECONDS = 1.2
 REPOST_COOLDOWN_DAYS = 30
 MIN_SCORE_TO_POST_FREE = 9
+MIN_SCORE_TO_POST_DEMO_PLAYTEST = 6
 MIN_SCORE_TO_POST_PAID = 8
 
 MAX_FETCH_RETRIES = 5
@@ -119,7 +121,6 @@ BAD_TERMS = {
     "soundtrack": -10,
     "DLC": -8,
     "benchmark": -6,
-    "playtest": -4,
     "test server": -5,
     "dedicated server": -5,
     "server tools": -6,
@@ -150,6 +151,50 @@ REPLAYABILITY_PHRASE_SCORES = {
     "randomized": 1,
     "progression": 1,
 }
+
+DEMO_PLAYTEST_FRIEND_SIGNALS = {
+    "online co-op": 4,
+    "co-op": 3,
+    "coop": 3,
+    "multiplayer": 3,
+    "party game": 3,
+    "party": 2,
+    "squad": 2,
+    "team up": 2,
+    "drop-in co-op": 2,
+    "couch co-op": 2,
+    "4-player co-op": 3,
+    "4 player co-op": 3,
+    "up to 4 players": 3,
+    "up to 5 players": 3,
+    "up to 6 players": 4,
+    "up to 8 players": 4,
+    "replayability": 1,
+    "loot": 1,
+    "runs": 1,
+    "progression": 1,
+    "randomized": 1,
+}
+
+DEMO_PLAYTEST_SOLO_SIGNALS = {
+    "single-player only": -6,
+    "single player only": -6,
+    "single-player": -3,
+    "single player": -3,
+    "solo": -2,
+    "story-rich": -2,
+    "narrative": -2,
+    "visual novel": -4,
+}
+
+DEMO_PLAYTEST_MIN_FRIEND_SIGNAL = 5
+
+RELEASE_DATE_FORMATS = [
+    "%b %d, %Y",
+    "%B %d, %Y",
+    "%d %b, %Y",
+    "%d %B, %Y",
+]
 
 LOW_SIGNAL_KEYWORD_SCORES = {
     "clicker": -3,
@@ -233,7 +278,8 @@ DEMO_SCORE_PENALTY = 2
 
 UNKNOWN_REVIEW_SCORE_BY_TYPE = {
     "free_game": -2,
-    "demo": -2,
+    "demo": -1,
+    "playtest": 0,
     "temporarily_free": -2,
     "paid_under_20": -6,
 }
@@ -573,6 +619,9 @@ def detect_item_type(source: str, app_id: str, title: str, text: str) -> str:
     if source == "steamdb_promo" or "free to keep" in lower_text or "100% off" in lower_text:
         return "temporarily_free"
 
+    if "playtest" in lower_title or "playtest" in lower_text:
+        return "playtest"
+
     if source == "steam_demo" or "demo" in lower_title or "demo" in lower_text:
         return "demo"
 
@@ -683,6 +732,84 @@ def extract_review_count(page_text: str) -> int:
         return int(match.group(1).replace(",", ""))
     except ValueError:
         return 0
+
+
+def extract_release_date(page_text: str) -> Optional[datetime]:
+    match = re.search(
+        r"Release Date:\s*([A-Za-z]{3,9}\s+\d{1,2},\s+\d{4})",
+        page_text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    raw = clean_text(match.group(1))
+    for fmt in RELEASE_DATE_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def score_demo_playtest_friend_group_fit(
+    title: str,
+    description: str,
+    text: str,
+    review_sentiment: Optional[str],
+    review_count: int,
+) -> Tuple[int, int, int, List[str]]:
+    score = 0
+    friend_signal_score = 0
+    freshness_bonus = 0
+    hits: List[str] = []
+
+    combined = f"{title} {description} {text}".lower()
+    for phrase, points in DEMO_PLAYTEST_FRIEND_SIGNALS.items():
+        if phrase in combined:
+            score += points
+            friend_signal_score += points
+            hits.append(f"friend:{phrase}")
+
+    for phrase, points in DEMO_PLAYTEST_SOLO_SIGNALS.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"solo:{phrase}")
+
+    has_coop_or_mp = (
+        "co-op" in combined
+        or "coop" in combined
+        or "multiplayer" in combined
+        or "massively multiplayer" in combined
+    )
+    if has_coop_or_mp:
+        friend_signal_score += 1
+        score += 1
+        hits.append("friend:coop-or-mp")
+
+    if has_4plus_player_signal(text):
+        friend_signal_score += 2
+        score += 2
+        hits.append("friend:4plus")
+
+    if review_sentiment in FREE_REVIEW_BLOCKLIST:
+        score -= 4
+        hits.append("review:negative")
+    elif review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS and review_count >= 100:
+        score += 1
+        hits.append("review:positive")
+
+    release_date = extract_release_date(text)
+    if release_date:
+        age_days = (datetime.now(timezone.utc) - release_date).days
+        if age_days <= 14:
+            freshness_bonus = 2
+        elif age_days <= 45:
+            freshness_bonus = 1
+        if freshness_bonus > 0:
+            score += freshness_bonus
+            hits.append(f"freshness:{freshness_bonus}")
+
+    return score, friend_signal_score, freshness_bonus, hits
 
 
 def score_quality_refinements(
@@ -843,8 +970,10 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, UNKNOWN_REVIEW_SCORE_BY_TYPE.get(item_type, 0))
 
     review_gate_failed = False
-    if item_type in ["free_game", "demo", "temporarily_free"]:
-        review_gate_failed = review_sentiment in FREE_REVIEW_BLOCKLIST
+    if item_type in ["free_game", "temporarily_free"]:
+        review_gate_failed = review_sentiment is None or review_sentiment in FREE_REVIEW_BLOCKLIST
+    elif item_type in ["demo", "playtest"]:
+        review_gate_failed = review_sentiment in {"Very Negative", "Overwhelmingly Negative"}
     elif item_type == "paid_under_20":
         review_gate_failed = review_sentiment not in PAID_MINIMUM_REVIEW_SENTIMENTS
 
@@ -861,8 +990,21 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     type_adjustment = 0
     if item_type == "temporarily_free" and review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS:
         type_adjustment += TEMPORARILY_FREE_SCORE_BONUS
-    if item_type == "demo":
+    if item_type in {"demo", "playtest"}:
         type_adjustment -= DEMO_SCORE_PENALTY
+
+    demo_section_score = 0
+    demo_friend_signal_score = 0
+    demo_freshness_bonus = 0
+    demo_hits: List[str] = []
+    if item_type in {"demo", "playtest"}:
+        demo_section_score, demo_friend_signal_score, demo_freshness_bonus, demo_hits = score_demo_playtest_friend_group_fit(
+            title=title,
+            description=description,
+            text=page_text,
+            review_sentiment=review_sentiment,
+            review_count=review_count,
+        )
 
     total_score = (
         multiplayer_score
@@ -871,6 +1013,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         + review_score
         + refinement_score
         + type_adjustment
+        + demo_section_score
     )
 
     has_multiplayer_signal = multiplayer_score > 0
@@ -883,13 +1026,21 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
             not review_gate_failed and
             total_score >= MIN_SCORE_TO_POST_PAID
         )
-    elif item_type in ["free_game", "demo", "temporarily_free"]:
+    elif item_type in ["free_game", "temporarily_free"]:
         keep = (
             has_multiplayer_signal and
             has_3plus_signal and
             not rejected and
             not review_gate_failed and
             total_score >= MIN_SCORE_TO_POST_FREE
+        )
+    elif item_type in {"demo", "playtest"}:
+        keep = (
+            has_multiplayer_signal and
+            not rejected and
+            not review_gate_failed and
+            demo_friend_signal_score >= DEMO_PLAYTEST_MIN_FRIEND_SIGNAL and
+            total_score >= MIN_SCORE_TO_POST_DEMO_PLAYTEST
         )
     else:
         keep = False
@@ -912,12 +1063,17 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         "review_score": review_score,
         "review_count": review_count,
         "review_gate_failed": review_gate_failed,
+        "demo_friend_signal_score": demo_friend_signal_score,
+        "demo_freshness_bonus": demo_freshness_bonus,
+        "demo_hits": demo_hits,
     }
 
 
 def type_label(item_type: str) -> str:
     if item_type == "demo":
         return "Demo"
+    if item_type == "playtest":
+        return "Playtest"
     if item_type == "temporarily_free":
         return "Temporarily Free"
     if item_type == "paid_under_20":
@@ -937,9 +1093,9 @@ def format_item_block(item: dict, idx: int, paid: bool = False) -> str:
     return "\n".join(lines)
 
 
-def format_steam_item_message(item: dict, idx: int, paid: bool = False) -> str:
-    emoji = "💸" if paid else "🎮"
-    label = "Paid Pick" if paid else "Free Pick"
+def format_steam_item_message(item: dict, idx: int, paid: bool = False, demo_playtest: bool = False) -> str:
+    emoji = "💸" if paid else ("🧪" if demo_playtest else "🎮")
+    label = "Paid Pick" if paid else ("Demo / Playtest Pick" if demo_playtest else "Free Pick")
     lines = [
         f"{emoji} {label} #{idx}",
         item["title"],
@@ -1153,8 +1309,13 @@ def post_message_chunks(chunks: List[str]) -> None:
         sleep_briefly()
 
 
-def post_daily_pick_messages(free_items: List[dict], paid_items: List[dict], instagram_posts: List[dict]) -> None:
-    if not (free_items or paid_items or instagram_posts):
+def post_daily_pick_messages(
+    demo_playtest_items: List[dict],
+    free_items: List[dict],
+    paid_items: List[dict],
+    instagram_posts: List[dict],
+) -> None:
+    if not (demo_playtest_items or free_items or paid_items or instagram_posts):
         return
 
     token_available = bool(DISCORD_BOT_TOKEN)
@@ -1226,6 +1387,7 @@ def post_daily_pick_messages(free_items: List[dict], paid_items: List[dict], ins
     sleep_briefly()
 
     section_inputs = [
+        ("demo_playtest", "🧪 New Demos & Playtests", demo_playtest_items, False, "steam_demo_playtest"),
         ("free", "🎮 Free Picks", free_items, False, "steam_free"),
         ("paid", "💸 Paid Under $20", paid_items, True, "paid_under_20"),
         ("instagram", "📸 Instagram Creator Picks", instagram_posts, False, "instagram"),
@@ -1273,7 +1435,7 @@ def post_daily_pick_messages(free_items: List[dict], paid_items: List[dict], ins
             content = (
                 format_instagram_item_message(item, idx)
                 if section_key == "instagram"
-                else format_steam_item_message(item, idx, paid=is_paid)
+                else format_steam_item_message(item, idx, paid=is_paid, demo_playtest=(section_key == "demo_playtest"))
             )
             metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
             if token_available and metadata and metadata.get("message_id") and metadata.get("channel_id"):
@@ -1424,6 +1586,7 @@ def main():
     print(f"Free candidates collected: {len(free_candidates)}")
     print(f"Paid candidates collected: {len(paid_candidates)}")
 
+    qualified_demo_playtest = []
     qualified_free = []
     qualified_paid = []
 
@@ -1438,7 +1601,10 @@ def main():
         if not can_repost(app_id, item["type"], state):
             continue
 
-        qualified_free.append(item)
+        if item["type"] in {"demo", "playtest"}:
+            qualified_demo_playtest.append(item)
+        elif item["type"] in {"free_game", "temporarily_free"}:
+            qualified_free.append(item)
 
     for source, app_id in paid_candidates:
         item = inspect_game(source, app_id)
@@ -1460,7 +1626,16 @@ def main():
             x["score"],
             x.get("review_score", 0),
             1 if x["type"] == "temporarily_free" else 0,
-            -1 if x["type"] == "demo" else 0,
+        ),
+        reverse=True
+    )
+
+    qualified_demo_playtest.sort(
+        key=lambda x: (
+            x["score"],
+            x.get("demo_friend_signal_score", 0),
+            x.get("demo_freshness_bonus", 0),
+            x.get("review_score", 0),
         ),
         reverse=True
     )
@@ -1473,27 +1648,37 @@ def main():
         reverse=True
     )
 
+    demo_playtest_items = qualified_demo_playtest[:MAX_DEMO_PLAYTEST_POSTS]
     free_items = qualified_free[:MAX_FREE_POSTS]
     paid_items = qualified_paid[:MAX_PAID_POSTS]
 
+    print(f"Qualified demo/playtest items before cap: {len(qualified_demo_playtest)}")
     print(f"Qualified free items before cap: {len(qualified_free)}")
     print(f"Qualified paid items before cap: {len(qualified_paid)}")
 
     instagram_posts = fetch_instagram_posts()
-    post_daily_pick_messages(free_items, paid_items, instagram_posts)
+    post_daily_pick_messages(demo_playtest_items, free_items, paid_items, instagram_posts)
 
-    if not free_items and not paid_items:
+    if not demo_playtest_items and not free_items and not paid_items:
         print("No qualifying games found from Steam.")
 
-    for item in free_items + paid_items:
+    for item in demo_playtest_items + free_items + paid_items:
         update_state_for_post(item["id"], item["type"], state)
 
     save_state(state)
 
-    total = len(free_items) + len(paid_items)
+    total = len(demo_playtest_items) + len(free_items) + len(paid_items)
     print(f"Posted {total} Steam item(s) to Discord.")
+    print(f"Demo/playtest items selected: {len(demo_playtest_items)}")
     print(f"Free items selected: {len(free_items)}")
     print(f"Paid items selected: {len(paid_items)}")
+
+    for item in demo_playtest_items:
+        print(
+            f"DEMO/PLAYTEST: {item['title']} ({item['type']}) "
+            f"score={item['score']} friend_signal={item.get('demo_friend_signal_score', 0)} "
+            f"freshness_bonus={item.get('demo_freshness_bonus', 0)}"
+        )
 
     for item in free_items:
         print(

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -300,6 +300,7 @@ def test_build_winners_message_voter_truncation():
 
 def test_build_winners_message_includes_description_when_present():
     winners_by_section = {
+        "demo_playtest": [],
         "free": [
             {
                 "title": "Game A",
@@ -320,6 +321,7 @@ def test_build_winners_message_includes_description_when_present():
 
 def test_build_winners_message_omits_description_when_absent_or_empty():
     winners_by_section = {
+        "demo_playtest": [],
         "free": [
             {
                 "title": "Game A",
@@ -353,6 +355,7 @@ def test_normalize_winner_description_truncates_long_text():
 
 def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
     winners_by_section = {
+        "demo_playtest": [],
         "free": [
             {
                 "title": f"Game {idx}",
@@ -372,6 +375,26 @@ def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
     assert "Voters —" not in compact
     assert "BBBBB" not in compact
     assert "- Game 0 (2 votes)" in compact
+
+
+def test_build_winners_message_supports_demo_playtest_section():
+    winners_by_section = {
+        "demo_playtest": [
+            {
+                "title": "Squad Demo",
+                "description": "A co-op demo for friend groups.",
+                "url": "u-demo",
+                "human_votes": 2,
+                "voter_names": ["Jan", "Jerry"],
+            }
+        ],
+        "free": [],
+        "paid": [],
+        "instagram": [],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert "New Demos & Playtests" in content
+    assert "Squad Demo" in content
 
 
 def test_winners_pipeline_integration_late_votes_dedupe_and_coherent_edit(monkeypatch, tmp_path):

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -62,19 +62,22 @@ def test_daily_pick_rerun_and_partial_recovery(monkeypatch, tmp_path, load_fixtu
     monkeypatch.setattr(main, "sleep_briefly", lambda: None)
     monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
 
+    demo_items = [
+        {"title": "Demo A", "url": "https://store.steampowered.com/app/9", "price": "Free", "score": 10},
+    ]
     free_items = [
         {"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9},
         {"title": "Game B", "url": "https://store.steampowered.com/app/2", "price": "Free", "score": 8},
     ]
-    main.post_daily_pick_messages(free_items, [], [])
+    main.post_daily_pick_messages(demo_items, free_items, [], [])
 
     saved = json.loads(daily_path.read_text(encoding="utf-8"))
     assert any("Game B" in msg for msg in posted)
     assert saved[day_key]["run_state"]["completed"] is True
-    assert len(fake_client.reactions) == 1  # only new item gets default 👍
+    assert len(fake_client.reactions) == 2  # demo + newly posted free item get default 👍
 
     posted_before = len(posted)
-    main.post_daily_pick_messages(free_items, [], [])
+    main.post_daily_pick_messages(demo_items, free_items, [], [])
     assert len(posted) == posted_before
 
 
@@ -122,7 +125,7 @@ def test_daily_item_persistence_stores_descriptions(monkeypatch, tmp_path):
             "url": "https://www.instagram.com/p/abc/",
         }
     ]
-    main.post_daily_pick_messages(free_items, [], instagram_posts)
+    main.post_daily_pick_messages([], free_items, [], instagram_posts)
 
     saved = json.loads(daily_path.read_text(encoding="utf-8"))
     items = saved[day_key]["items"]
@@ -131,3 +134,48 @@ def test_daily_item_persistence_stores_descriptions(monkeypatch, tmp_path):
 
     assert steam_item["description"] == "Steam short description"
     assert instagram_item["description"] == "Creator caption text"
+
+
+def test_daily_sections_post_in_new_order(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-08"
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        counter["i"] += 1
+        return {"message_id": f"m-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages(
+        [{"title": "Demo", "url": "https://store.steampowered.com/app/11", "score": 10}],
+        [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}],
+        [{"title": "Paid", "url": "https://store.steampowered.com/app/13", "score": 10}],
+        [{"username": "creator", "caption": "caption", "url": "https://www.instagram.com/p/a/"}],
+    )
+
+    headers = [
+        message for message in posted
+        if message in {
+            "🎯 Daily Picks — vote with 👍 on your favorites",
+            "🧪 New Demos & Playtests",
+            "🎮 Free Picks",
+            "💸 Paid Under $20",
+        }
+    ]
+    assert headers[:4] == [
+        "🎯 Daily Picks — vote with 👍 on your favorites",
+        "🧪 New Demos & Playtests",
+        "🎮 Free Picks",
+        "💸 Paid Under $20",
+    ]

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -146,7 +146,7 @@ def test_paid_rejects_unknown_and_mixed(monkeypatch):
     assert mixed_item["review_gate_failed"] is True
 
 
-def test_demo_penalty_keeps_full_game_above_demo(monkeypatch):
+def test_demo_pick_scoring_tracks_friend_group_signals(monkeypatch):
     shared = "Multiplayer Online Co-Op up to 6 players party game Very Positive"
     full_html = build_html("Full Game", "friends", shared, "Very Positive")
     demo_html = build_html("Demo Game", "friends", shared, "Very Positive")
@@ -155,7 +155,74 @@ def test_demo_penalty_keeps_full_game_above_demo(monkeypatch):
     full_item = main.inspect_game("steam_free", "701")
     demo_item = main.inspect_game("steam_demo", "702")
     assert full_item is not None and demo_item is not None
-    assert full_item["score"] > demo_item["score"]
+    assert demo_item["demo_friend_signal_score"] >= main.DEMO_PLAYTEST_MIN_FRIEND_SIGNAL
+    assert demo_item["keep"] is True
+
+
+def test_demo_and_playtest_detected_and_routed(monkeypatch):
+    demo_html = build_html("Demo Game", "friends", "Multiplayer Online Co-Op up to 6 players", "Mostly Positive")
+    playtest_html = build_html("Squad Rush Playtest", "team up", "Multiplayer squad up to 6 players", "")
+    stub_app_pages(monkeypatch, {"730": demo_html, "731": playtest_html})
+
+    demo_item = main.inspect_game("steam_demo", "730")
+    playtest_item = main.inspect_game("steam_demo", "731")
+
+    assert demo_item is not None and playtest_item is not None
+    assert demo_item["type"] == "demo"
+    assert playtest_item["type"] == "playtest"
+
+
+def test_demo_group_play_fit_beats_solo_demo(monkeypatch):
+    group_html = build_html(
+        "Group Demo",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players squad loot runs progression",
+        "",
+    )
+    solo_html = build_html(
+        "Solo Story Demo",
+        "single-player narrative",
+        "single-player only story-rich demo",
+        "",
+    )
+    stub_app_pages(monkeypatch, {"740": group_html, "741": solo_html})
+
+    group_item = main.inspect_game("steam_demo", "740")
+    solo_item = main.inspect_game("steam_demo", "741")
+    assert group_item is not None and solo_item is not None
+    assert group_item["keep"] is True
+    assert group_item["demo_friend_signal_score"] > solo_item["demo_friend_signal_score"]
+    assert solo_item["keep"] is False
+
+
+def test_demo_missing_reviews_more_tolerant_than_free_game(monkeypatch):
+    shared_text = "Multiplayer Online Co-Op up to 6 players party game loot runs"
+    demo_html = build_html("Co-op Demo", "friends", shared_text, "")
+    free_html = build_html("Co-op Full", "friends", shared_text, "")
+    stub_app_pages(monkeypatch, {"750": demo_html, "751": free_html})
+
+    demo_item = main.inspect_game("steam_demo", "750")
+    free_item = main.inspect_game("steam_free", "751")
+
+    assert demo_item is not None and free_item is not None
+    assert demo_item["keep"] is True
+    assert free_item["keep"] is False
+
+
+def test_demo_newness_bonus_is_small_and_optional(monkeypatch):
+    recent_text = "Release Date: Apr 01, 2026 Multiplayer Online Co-Op up to 6 players"
+    older_text = "Release Date: Jan 01, 2024 Multiplayer Online Co-Op up to 6 players squad loot runs progression"
+    recent_html = build_html("Recent Demo", "friends", recent_text, "")
+    older_html = build_html("Older Strong Demo", "team up with friends", older_text, "")
+    stub_app_pages(monkeypatch, {"760": recent_html, "761": older_html})
+
+    recent_item = main.inspect_game("steam_demo", "760")
+    older_item = main.inspect_game("steam_demo", "761")
+
+    assert recent_item is not None and older_item is not None
+    assert recent_item["demo_freshness_bonus"] >= 1
+    assert older_item["demo_freshness_bonus"] == 0
+    assert older_item["keep"] is True
 
 
 def test_temporarily_free_bonus_requires_positive_or_better(monkeypatch):


### PR DESCRIPTION
### Motivation
- Surface demos/playtests that are intentionally meant to be played with friends (multiplayer/co-op/party-focused) in their own daily lane above Free Picks. 
- Ensure demos/playtests do not double-appear in Free Picks and keep Free Picks focused on full free / temporarily free titles. 
- Reuse the existing posting/state/winners architecture to keep changes low-risk and operator-friendly.

### Description
- New section and caps: added `demo_playtest` lane with `MAX_DEMO_PLAYTEST_POSTS = 10` and a threshold `MIN_SCORE_TO_POST_DEMO_PLAYTEST = 6`, and header `🧪 New Demos & Playtests`. (changes in `main.py` and `evening_winners.py`).
- Routing: `detect_item_type` now recognizes `playtest` (checked before `demo`), and the candidate selection logic routes `demo`/`playtest` exclusively into the new demo_playtest list while `free_game`/`temporarily_free` go into Free Picks, preventing double-appearance. (`main.py`).
- Scoring/model changes: introduced friend-group signal maps (`DEMO_PLAYTEST_FRIEND_SIGNALS`, `DEMO_PLAYTEST_SOLO_SIGNALS`), `score_demo_playtest_friend_group_fit()` to reward co-op/multiplayer/4+ player phrasing, replayability, and a small release-date freshness bonus; demo/playtest items get a demo-specific gate that tolerates missing reviews but requires friend-signal minimum; demo/playtest items receive the same auto-penalty (`DEMO_SCORE_PENALTY`) but have separate keep logic. (`main.py`).
- UI/formatting: item labels and emoji include a demo/playtest variant (🧪) and `format_steam_item_message` now supports a `demo_playtest` flag so messages remain clear and consistent. (`main.py`).
- State & reuse: `post_daily_pick_messages` was extended to accept `demo_playtest_items` and reuses the same section-header + one-message-per-item + auto-👍 + `discord_daily_posts.json` message-id recording / rerun-safety logic already in place. (`main.py`).
- Winners compatibility: registered `demo_playtest` in `SECTION_CONFIG` and moved it to the front of `SECTION_ORDER` so demo/playtest winners appear above Free Picks in the evening winners rendering, and continue to participate in the same winners aggregation. (`evening_winners.py`).
- Docs & tests: updated `README.md` and added/adjusted focused unit tests to cover routing, ordering, scoring, freshness, winner rendering, and state/reuse behavior. (`tests/test_main_daily_picks.py`, `tests/test_main_scoring_model.py`, `tests/test_evening_winners.py`).

### Testing
- Ran the focused test suite: `pytest -q tests/test_main_daily_picks.py tests/test_main_scoring_model.py tests/test_evening_winners.py`.
- Result: all tests passed: `37 passed` (no failures).
- Tests exercise: demo/playtest routing, demo vs free routing exclusion, demo/playtest scoring and friend-group signal handling, demo freshness bonus, daily posting order (demo_playtest → free → paid → instagram), winners rendering including the new section, and rerun/reuse behavior with state persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8279a90dc832694bc062223f9467b)