### PR TITLE
Add end-of-run RUN SUMMARY and safe daily debug export; small scoring comments & helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ Posting behavior in `daily-game-picks`:
   - **Free Picks** remain focused on full free and temporarily free full games.
   - The bot prefers quality over maxing section caps (especially for demos/playtests), so some days intentionally post fewer than the section maximum.
 
+Daily picks troubleshooting (operator quick guide):
+- If **New Demos & Playtests** is unexpectedly empty, check run logs for:
+  - `DEMO_PLAYTEST_MIN_FRIEND_SIGNAL` gate misses,
+  - low total score vs `MIN_SCORE_TO_POST_DEMO_PLAYTEST`,
+  - repost cooldown filtering.
+- If the section becomes too noisy, inspect `daily_debug_summary.json` first, then tighten:
+  - `DEMO_PLAYTEST_MIN_FRIEND_SIGNAL` (friend-group strictness),
+  - `MIN_SCORE_TO_POST_DEMO_PLAYTEST` (overall quality floor).
+- If variety feels repetitive, tune only the light diversity knobs (`LIGHT_DIVERSITY_PER_EXTRA_DUPLICATE`, `LIGHT_DIVERSITY_DUPLICATE_FREE_SLOTS`) — this rerank is intentionally weak and should stay secondary to score quality.
+- For quality signal tuning, review replayability and legitimacy cue hits in logs/debug JSON before adjusting weights/thresholds.
+- At end of each daily run, start with the `RUN SUMMARY` block in logs, then inspect `daily_debug_summary.json` for per-item keep/filtered reasons.
+
 State + reliability:
 - Tracks daily post metadata in `discord_daily_posts.json`
 - Retains latest 30 date keys

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ INSTAGRAM_STATE_FILE = "instagram_seen.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
+DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -47,6 +48,8 @@ HEADERS = {
 }
 
 # ---------- CONFIG ----------
+# Section caps are intentionally independent: Demo/Playtest picks are curated separately
+# from Free Picks so one noisy pool cannot crowd out the other.
 MAX_FREE_POSTS = 10
 MAX_DEMO_PLAYTEST_POSTS = 10
 MAX_PAID_POSTS = 10
@@ -195,7 +198,11 @@ DEMO_PLAYTEST_SOLO_SIGNALS = {
 }
 
 DEMO_PLAYTEST_MIN_FRIEND_SIGNAL = 5
+# Quality-over-cap for Demo/Playtest: we prefer fewer stronger items over filling
+# the entire section with borderline picks.
 DEMO_PLAYTEST_QUALITY_FLOOR_SCORE = MIN_SCORE_TO_POST_DEMO_PLAYTEST + 1
+# Diversity rerank is intentionally weak (light penalty only after a couple repeats)
+# so quality remains primary and variety is just a soft tie-breaker.
 LIGHT_DIVERSITY_PER_EXTRA_DUPLICATE = 1
 LIGHT_DIVERSITY_DUPLICATE_FREE_SLOTS = 2
 
@@ -206,6 +213,8 @@ RELEASE_DATE_FORMATS = [
     "%d %B, %Y",
 ]
 
+# Heavier penalties here are intentional to suppress low-signal/junk entries from
+# leaking into daily picks despite keyword stuffing elsewhere on the page.
 LOW_SIGNAL_KEYWORD_SCORES = {
     "clicker": -3,
     "idle": -2,
@@ -922,6 +931,85 @@ def log_candidate_decision(item: dict, phase: str) -> None:
     )
 
 
+def _is_filtered_for_weak_group_fit(item: dict) -> bool:
+    item_type = item.get("type")
+    if item.get("rejected"):
+        return True
+    if item_type in {"free_game", "temporarily_free"}:
+        return not item.get("multiplayer_hits") or not item.get("player_hits")
+    if item_type in {"demo", "playtest"}:
+        return item.get("demo_friend_signal_score", 0) < DEMO_PLAYTEST_MIN_FRIEND_SIGNAL
+    if item_type == "paid_under_20":
+        return not item.get("multiplayer_hits")
+    return False
+
+
+def _is_filtered_as_low_signal_junk(item: dict) -> bool:
+    for hit in item.get("refinement_hits", []):
+        if hit.startswith("low-signal:") or hit.startswith("title-low-signal:"):
+            return True
+    return False
+
+
+def build_filter_reason_list(item: dict) -> List[str]:
+    reasons: List[str] = []
+    if item.get("review_gate_failed"):
+        reasons.append("weak_review_signal")
+    if _is_filtered_for_weak_group_fit(item):
+        reasons.append("weak_multiplayer_or_friend_group_fit")
+    if _is_filtered_as_low_signal_junk(item):
+        reasons.append("junk_or_prototype_low_signal")
+    return reasons
+
+
+def build_run_summary(
+    *,
+    steam_candidates_scanned: int,
+    demo_playtest_candidates_qualified: int,
+    free_candidates_qualified: int,
+    paid_candidates_qualified: int,
+    demo_playtest_posted: int,
+    free_posted: int,
+    paid_posted: int,
+    filtered_weak_reviews: int,
+    filtered_weak_group_fit: int,
+    filtered_low_signal_junk: int,
+    filtered_repost_cooldown: int,
+) -> List[str]:
+    return [
+        "RUN SUMMARY",
+        f"- Steam candidates scanned: {steam_candidates_scanned}",
+        f"- Demo/playtest candidates qualified: {demo_playtest_candidates_qualified}",
+        f"- Free candidates qualified: {free_candidates_qualified}",
+        f"- Paid candidates qualified: {paid_candidates_qualified}",
+        f"- Demo/playtest posted: {demo_playtest_posted}",
+        f"- Free posted: {free_posted}",
+        f"- Paid posted: {paid_posted}",
+        f"- Filtered for weak reviews: {filtered_weak_reviews}",
+        f"- Filtered for weak multiplayer/friend-group fit: {filtered_weak_group_fit}",
+        f"- Filtered as junk/prototype/low-signal: {filtered_low_signal_junk}",
+        f"- Filtered by repost cooldown: {filtered_repost_cooldown}",
+    ]
+
+
+def export_daily_debug_summary(
+    records: List[dict],
+    run_summary_lines: List[str],
+    path: str = DAILY_DEBUG_SUMMARY_FILE,
+) -> None:
+    payload = {
+        "generated_at_utc": utc_now_iso(),
+        "run_summary": run_summary_lines,
+        "records": records,
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+        print(f"DEBUG EXPORT: wrote {path} ({len(records)} records)")
+    except Exception as e:
+        print(f"WARN: failed to write debug summary ({path}): {e}")
+
+
 def score_quality_refinements(
     title: str,
     description: str,
@@ -1145,6 +1233,8 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
             total_score >= MIN_SCORE_TO_POST_FREE
         )
     elif item_type in {"demo", "playtest"}:
+        # Demo/Playtest has a stricter friend-group gate than full free games:
+        # we only post tests that already show multiplayer viability for group nights.
         keep = (
             has_multiplayer_signal and
             not rejected and
@@ -1701,10 +1791,16 @@ def main():
 
     print(f"Free candidates collected: {len(free_candidates)}")
     print(f"Paid candidates collected: {len(paid_candidates)}")
+    steam_candidates_scanned = len(free_candidates) + len(paid_candidates)
 
     qualified_demo_playtest = []
     qualified_free = []
     qualified_paid = []
+    filtered_weak_reviews = 0
+    filtered_weak_group_fit = 0
+    filtered_low_signal_junk = 0
+    filtered_repost_cooldown = 0
+    debug_records: List[dict] = []
 
     for source, app_id in free_candidates:
         item = inspect_game(source, app_id)
@@ -1713,13 +1809,36 @@ def main():
         if not item:
             continue
         log_candidate_decision(item, phase="evaluated")
+        record = {
+            "title": item["title"],
+            "type": item["type"],
+            "final_score": item["score"],
+            "review_sentiment": item.get("review_sentiment"),
+            "friend_group_signal": item.get("demo_friend_signal_score", 0),
+            "keep": bool(item["keep"]),
+            "reason_list": [],
+        }
         if not item["keep"]:
+            reason_list = build_filter_reason_list(item)
+            if "weak_review_signal" in reason_list:
+                filtered_weak_reviews += 1
+            if "weak_multiplayer_or_friend_group_fit" in reason_list:
+                filtered_weak_group_fit += 1
+            if "junk_or_prototype_low_signal" in reason_list:
+                filtered_low_signal_junk += 1
+            record["reason_list"] = reason_list
             log_candidate_decision(item, phase="filtered_not_kept")
+            debug_records.append(record)
             continue
         if not can_repost(app_id, item["type"], state):
+            filtered_repost_cooldown += 1
+            record["reason_list"] = ["repost_cooldown"]
             log_candidate_decision(item, phase="filtered_repost_cooldown")
+            debug_records.append(record)
             continue
 
+        record["reason_list"] = ["qualified"]
+        debug_records.append(record)
         if item["type"] in {"demo", "playtest"}:
             qualified_demo_playtest.append(item)
         elif item["type"] in {"free_game", "temporarily_free"}:
@@ -1732,15 +1851,40 @@ def main():
         if not item:
             continue
         log_candidate_decision(item, phase="evaluated")
+        record = {
+            "title": item["title"],
+            "type": item["type"],
+            "final_score": item["score"],
+            "review_sentiment": item.get("review_sentiment"),
+            "friend_group_signal": item.get("demo_friend_signal_score", 0),
+            "keep": bool(item["keep"]),
+            "reason_list": [],
+        }
         if item["type"] != "paid_under_20":
+            record["reason_list"] = ["not_paid_under_20"]
+            debug_records.append(record)
             continue
         if not item["keep"]:
+            reason_list = build_filter_reason_list(item)
+            if "weak_review_signal" in reason_list:
+                filtered_weak_reviews += 1
+            if "weak_multiplayer_or_friend_group_fit" in reason_list:
+                filtered_weak_group_fit += 1
+            if "junk_or_prototype_low_signal" in reason_list:
+                filtered_low_signal_junk += 1
+            record["reason_list"] = reason_list
             log_candidate_decision(item, phase="filtered_not_kept")
+            debug_records.append(record)
             continue
         if not can_repost(app_id, item["type"], state):
+            filtered_repost_cooldown += 1
+            record["reason_list"] = ["repost_cooldown"]
             log_candidate_decision(item, phase="filtered_repost_cooldown")
+            debug_records.append(record)
             continue
 
+        record["reason_list"] = ["qualified"]
+        debug_records.append(record)
         qualified_paid.append(item)
 
     qualified_free.sort(
@@ -1823,6 +1967,23 @@ def main():
             f"PAID: {item['title']} ({item['type']}) "
             f"score={item['score']} review_score={item.get('review_score', 0)}"
         )
+
+    run_summary_lines = build_run_summary(
+        steam_candidates_scanned=steam_candidates_scanned,
+        demo_playtest_candidates_qualified=len(qualified_demo_playtest),
+        free_candidates_qualified=len(qualified_free),
+        paid_candidates_qualified=len(qualified_paid),
+        demo_playtest_posted=len(demo_playtest_items),
+        free_posted=len(free_items),
+        paid_posted=len(paid_items),
+        filtered_weak_reviews=filtered_weak_reviews,
+        filtered_weak_group_fit=filtered_weak_group_fit,
+        filtered_low_signal_junk=filtered_low_signal_junk,
+        filtered_repost_cooldown=filtered_repost_cooldown,
+    )
+    for line in run_summary_lines:
+        print(line)
+    export_daily_debug_summary(debug_records, run_summary_lines)
 
     next_start_page = get_next_start_page(start_page)
     save_page_state(next_start_page)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -219,3 +219,55 @@ def test_demo_selection_prefers_quality_over_filling_cap():
     selected = main.select_demo_playtest_items(qualified, cap=10)
 
     assert [item["title"] for item in selected] == ["Strong"]
+
+
+def test_run_summary_aggregation_lines():
+    lines = main.build_run_summary(
+        steam_candidates_scanned=40,
+        demo_playtest_candidates_qualified=5,
+        free_candidates_qualified=9,
+        paid_candidates_qualified=3,
+        demo_playtest_posted=4,
+        free_posted=8,
+        paid_posted=2,
+        filtered_weak_reviews=7,
+        filtered_weak_group_fit=6,
+        filtered_low_signal_junk=4,
+        filtered_repost_cooldown=3,
+    )
+
+    assert lines[0] == "RUN SUMMARY"
+    assert "- Steam candidates scanned: 40" in lines
+    assert "- Demo/playtest posted: 4" in lines
+    assert "- Filtered by repost cooldown: 3" in lines
+
+
+def test_debug_export_writes_expected_structure(tmp_path):
+    output_path = tmp_path / "daily_debug_summary.json"
+    records = [
+        {
+            "title": "Demo A",
+            "type": "demo",
+            "final_score": 11,
+            "review_sentiment": "Very Positive",
+            "friend_group_signal": 7,
+            "keep": True,
+            "reason_list": ["qualified"],
+        }
+    ]
+    summary = ["RUN SUMMARY", "- Steam candidates scanned: 1"]
+
+    main.export_daily_debug_summary(records, summary, path=str(output_path))
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert saved["run_summary"] == summary
+    assert saved["records"][0]["title"] == "Demo A"
+    assert saved["records"][0]["reason_list"] == ["qualified"]
+
+
+def test_debug_export_fails_gracefully(monkeypatch):
+    def fake_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    main.export_daily_debug_summary([], ["RUN SUMMARY"], path="ignored.json")


### PR DESCRIPTION
### Motivation
- Improve operator visibility and make tuning/trouble‑shooting faster by emitting a concise end‑of‑run summary and a small per‑run debug JSON without changing workflows or adding storage services.
- Keep risk extremely low by making all additions additive, non‑blocking on failures, and avoiding architectural or behavioral changes to selection/posting logic.

### Description
- Add a `DAILY_DEBUG_SUMMARY_FILE` constant and lightweight export: `export_daily_debug_summary` writes `daily_debug_summary.json` (overwritten each run) with compact per‑item fields (`title`, `type`, `final_score`, `review_sentiment`, `friend_group_signal`, `keep`, `reason_list`) and a `run_summary` block, and it fails gracefully if writing/serialization fails.
- Add helper functions to centralize filter reasoning: `_is_filtered_for_weak_group_fit`, `_is_filtered_as_low_signal_junk`, and `build_filter_reason_list`, plus `build_run_summary` and integration in `main()` to accumulate counters and `debug_records` during candidate evaluation.
- Add concise inline comments around scoring thresholds and heuristics (demo/playtest friend‑group gate, quality‑over‑cap, light diversity rerank, and low‑signal penalties) and keep these changes strictly local to existing scoring constants.
- Update `README.md` with a short operator troubleshooting guide for Demo/Playtest emptiness/noise and where to inspect `RUN SUMMARY` and `daily_debug_summary.json`; add focused tests in `tests/test_main_daily_picks.py` for run summary output, debug export structure, and graceful failure.
- Files changed: `main.py`, `README.md`, `tests/test_main_daily_picks.py`.

### Testing
- Ran `pytest -q tests/test_main_scoring_model.py` and all tests passed (`21 passed`).
- Ran `pytest -q tests/test_main_daily_picks.py` and all tests passed (`11 passed`).
- Ran `pytest -q tests/test_evening_winners.py` and all tests passed (`14 passed`).
- The new tests cover run summary formatting, debug export content, and that debug export failures do not crash the run (they log a warning instead).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d831d0eb988326bce8843524847513)