### PR TITLE
Final polish: unify section config, docs, and focused invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ Daily routing reference (operator-facing):
 | `temporarily_free` | Free Picks | Higher-confidence free games |
 | `paid_under_20` | Paid Under $20 | Strictest quality gate |
 
+Routing glossary (quick scan):
+- **`demo` / `playtest`** → **Demo & Playtest** (`demo_playtest`): friend-group discovery lane.
+- **`free_game` / `temporarily_free`** → **Free Picks** (`free`): higher-confidence free/temporarily-free titles.
+- **`paid_under_20`** → **Paid Under $20** (`paid`): strictest quality lane.
+
 Daily picks troubleshooting (operator quick guide):
 - If **New Demos & Playtests** is unexpectedly empty, check run logs for:
   - `DEMO_PLAYTEST_MIN_FRIEND_SIGNAL` gate misses,
@@ -277,6 +282,15 @@ Daily picks troubleshooting (operator quick guide):
 - For quality signal tuning, review replayability and legitimacy cue hits in logs/debug JSON before adjusting weights/thresholds.
 - At end of each daily run, start with the `RUN SUMMARY` block in logs, then inspect `daily_debug_summary.json` for per-item keep/filtered reasons.
   - `daily_debug_summary.json` is ephemeral: it is overwritten every run and is intended for current-run debugging only (not historical analytics).
+
+`daily_debug_summary.json` mini glossary:
+- `final_score`: final scoring output for the candidate.
+- `review_sentiment`: parsed Steam review sentiment used in scoring.
+- `friend_group_signal`: friend-group fit signal (especially important for demo/playtest).
+- `reason_list`: compact keep/filter reasons (for example `weak_review`, `repost_cooldown`).
+- `section_order`: canonical section order used for this run.
+- `generated_at_utc`: export timestamp.
+- `target_day_key`: UTC day key the run targeted.
 
 State + reliability:
 - Tracks daily post metadata in `discord_daily_posts.json`
@@ -306,6 +320,7 @@ Behavior:
   - raw 👍 = 2 → included (1 human vote)
   - raw 👍 = 3 → included (2 human votes)
 - Posts winners to the channel configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`)
+- Winners intentionally inherit the same section order as daily picks (`demo_playtest`, `free`, `paid`, `instagram`).
 
 Rerun/idempotency behavior:
 - Same-day reruns do not duplicate winners posts

--- a/daily_section_config.py
+++ b/daily_section_config.py
@@ -1,0 +1,44 @@
+"""Shared daily/winners section configuration.
+
+Daily picks and evening winners intentionally use the same section order and labels
+so operators see a consistent product flow.
+"""
+
+from typing import Dict, List
+
+# Centralized source of truth: keep these labels/order in sync for both pipelines.
+DAILY_SECTION_CONFIG: List[dict] = [
+    {
+        "key": "demo_playtest",
+        "header": "🧪 New Demos & Playtests",
+        "source_type": "steam_demo_playtest",
+        "message_label": "Demo/Playtest",
+        "display_label": "New Demos & Playtests",
+    },
+    {
+        "key": "free",
+        "header": "🎮 Free Picks",
+        "source_type": "steam_free",
+        "message_label": "Free",
+        "display_label": "Free Picks",
+    },
+    {
+        "key": "paid",
+        "header": "💸 Paid Under $20",
+        "source_type": "paid_under_20",
+        "message_label": "Paid",
+        "display_label": "Paid Under $20",
+    },
+    {
+        "key": "instagram",
+        "header": "📸 Instagram Creator Picks",
+        "source_type": "instagram",
+        "message_label": "Instagram",
+        "display_label": "Instagram Creator Picks",
+    },
+]
+
+DAILY_SECTION_ORDER: List[str] = [entry["key"] for entry in DAILY_SECTION_CONFIG]
+DAILY_SECTION_DISPLAY_LABELS: Dict[str, str] = {
+    entry["key"]: entry["display_label"] for entry in DAILY_SECTION_CONFIG
+}

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 
 import requests
 
+from daily_section_config import DAILY_SECTION_DISPLAY_LABELS, DAILY_SECTION_ORDER
 from discord_api import DiscordClient, DiscordMessageNotFoundError
 from state_utils import load_json_object, save_json_object_atomic
 
@@ -20,13 +21,10 @@ WINNERS_LOOKBACK_DAYS = 10
 MAX_VOTERS_SHOWN_PER_GAME = 6
 DISCORD_MESSAGE_CHAR_LIMIT = 2000
 
-SECTION_CONFIG = {
-    "demo_playtest": "New Demos & Playtests",
-    "free": "Free Picks",
-    "paid": "Paid Under $20",
-    "instagram": "Instagram Creator Picks",
-}
-SECTION_ORDER = ["demo_playtest", "free", "paid", "instagram"]
+# Winners intentionally mirror daily section ordering as product behavior,
+# not an incidental implementation detail.
+SECTION_CONFIG = DAILY_SECTION_DISPLAY_LABELS
+SECTION_ORDER = DAILY_SECTION_ORDER
 
 
 def load_discord_daily_posts() -> Dict[str, dict]:

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     instaloader = None
 from discord_api import DiscordClient, DiscordMessageNotFoundError
+from daily_section_config import DAILY_SECTION_CONFIG, DAILY_SECTION_ORDER
 from state_utils import (
     load_json_object,
     prune_latest_iso_dates,
@@ -48,6 +49,8 @@ HEADERS = {
 }
 
 # ---------- CONFIG ----------
+# Edit-safely note: tune thresholds only after observing real production runs;
+# avoid speculative changes that are not feedback-driven.
 # Daily routing intent (do not redesign without explicit product change):
 # - demo / playtest -> Demo & Playtest section (discovery lane for promising friend-group titles).
 # - free_game / temporarily_free -> Free Picks (higher-confidence full free or temporary-free full games).
@@ -92,34 +95,6 @@ FILTER_REASON_LOW_SIGNAL_JUNK = "low_signal_junk"
 FILTER_REASON_REPOST_COOLDOWN = "repost_cooldown"
 FILTER_REASON_BELOW_THRESHOLD = "below_threshold"
 FILTER_REASON_QUALIFIED = "qualified"
-
-DAILY_SECTION_CONFIG = [
-    {
-        "key": "demo_playtest",
-        "header": "🧪 New Demos & Playtests",
-        "source_type": "steam_demo_playtest",
-        "message_label": "Demo/Playtest",
-    },
-    {
-        "key": "free",
-        "header": "🎮 Free Picks",
-        "source_type": "steam_free",
-        "message_label": "Free",
-    },
-    {
-        "key": "paid",
-        "header": "💸 Paid Under $20",
-        "source_type": "paid_under_20",
-        "message_label": "Paid",
-    },
-    {
-        "key": "instagram",
-        "header": "📸 Instagram Creator Picks",
-        "source_type": "instagram",
-        "message_label": "Instagram",
-    },
-]
-DAILY_SECTION_ORDER = [entry["key"] for entry in DAILY_SECTION_CONFIG]
 
 MULTIPLAYER_TERMS = {
     "Massively Multiplayer": 4,
@@ -913,6 +888,9 @@ def extract_diversity_tags(title: str, description: str, text: str) -> List[str]
 
 
 def apply_light_diversity_rerank(items: List[dict]) -> List[dict]:
+    # Diversity rerank is intentionally weaker than base quality scoring:
+    # it only nudges away from near-identical same-day picks and should never
+    # overpower stronger underlying scores.
     if len(items) <= 2:
         return items
 
@@ -946,7 +924,8 @@ def apply_light_diversity_rerank(items: List[dict]) -> List[dict]:
 
 def select_demo_playtest_items(qualified_demo_playtest: List[dict], cap: int) -> List[dict]:
     # Explicit quality-over-cap behavior:
-    # keep section short on weak days instead of filling to max with borderline picks.
+    # for demo/playtest we intentionally prefer posting fewer strong picks over
+    # filling the cap with weak borderline items.
     strong_items = [item for item in qualified_demo_playtest if item["score"] >= DEMO_PLAYTEST_QUALITY_FLOOR_SCORE]
     if strong_items:
         return strong_items[:cap]
@@ -1023,14 +1002,17 @@ def build_filter_reason_list(item: dict) -> List[str]:
     return reasons
 
 
+ITEM_TYPE_TO_DAILY_SECTION = {
+    "demo": "demo_playtest",
+    "playtest": "demo_playtest",
+    "free_game": "free",
+    "temporarily_free": "free",
+    "paid_under_20": "paid",
+}
+
+
 def route_item_to_daily_section(item_type: str) -> Optional[str]:
-    if item_type in {"demo", "playtest"}:
-        return "demo_playtest"
-    if item_type in {"free_game", "temporarily_free"}:
-        return "free"
-    if item_type == "paid_under_20":
-        return "paid"
-    return None
+    return ITEM_TYPE_TO_DAILY_SECTION.get(item_type)
 
 
 def build_run_summary(

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -412,6 +412,12 @@ def test_winners_section_order_is_product_invariant():
     assert demo_idx < free_idx < paid_idx < instagram_idx
 
 
+def test_winners_use_same_section_order_as_daily_picks():
+    assert winners.SECTION_ORDER == ["demo_playtest", "free", "paid", "instagram"]
+    assert winners.SECTION_CONFIG["demo_playtest"] == "New Demos & Playtests"
+    assert winners.SECTION_CONFIG["instagram"] == "Instagram Creator Picks"
+
+
 def test_winners_pipeline_integration_late_votes_dedupe_and_coherent_edit(monkeypatch, tmp_path):
     day_key, path = _setup_daily(tmp_path)
     payloads = {

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -211,6 +211,16 @@ def test_routing_exclusivity_invariants():
     assert all(main.route_item_to_daily_section(item_type) not in {"demo_playtest", "free"} for item_type in paid_like)
 
 
+def test_each_item_type_has_exactly_one_section_owner():
+    item_types = ["demo", "playtest", "free_game", "temporarily_free", "paid_under_20"]
+    owned_sections = [main.route_item_to_daily_section(item_type) for item_type in item_types]
+
+    assert all(section is not None for section in owned_sections)
+    assert owned_sections.count("demo_playtest") == 2
+    assert owned_sections.count("free") == 2
+    assert owned_sections.count("paid") == 1
+
+
 def test_demo_playtest_label_uses_specific_type():
     demo_message = main.format_steam_item_message(
         {"title": "Demo A", "url": "https://store.steampowered.com/app/1", "score": 9, "type": "demo"},
@@ -309,8 +319,9 @@ def test_debug_export_writes_expected_structure(tmp_path):
     saved = json.loads(output_path.read_text(encoding="utf-8"))
 
     assert saved["run_summary"] == summary
+    assert saved["generated_at_utc"]
     assert saved["target_day_key"]
-    assert saved["section_order"] == main.DAILY_SECTION_ORDER
+    assert saved["section_order"] == ["demo_playtest", "free", "paid", "instagram"]
     assert saved["records"][0]["title"] == "Demo A"
     assert saved["records"][0]["reason_list"] == ["qualified"]
 


### PR DESCRIPTION
### Motivation
- Remove small drift risk between daily picks and winners by centralizing section keys/labels/order in a tiny shared source of truth. 
- Improve operator clarity with a short routing glossary and a compact debug JSON glossary in `README.md`.
- Add a few low-risk comments and focused unit tests to lock down invariants and make future edits safer.

### Description
- Introduced `daily_section_config.py` as a minimal shared config containing section `key`, `header`/`display_label`, `source_type`, `message_label`, and canonical `DAILY_SECTION_ORDER` so daily picks and winners stay in sync. 
- Switched `main.py` and `evening_winners.py` to import the shared config rather than maintain separate copies, and added a short comment near winners explaining the order is product intent. 
- Added small clarifying comments explaining: threshold edit-discipline, that diversity rerank is a weak soft-tie breaker, and that demo/playtest uses a quality-over-cap preference. 
- Made the routing helper explicit and stable by adding `ITEM_TYPE_TO_DAILY_SECTION` and having `route_item_to_daily_section(...)` use it without changing routing behavior. 
- README: added a concise routing glossary, a tiny `daily_debug_summary.json` mini-glossary, and a note that winners inherit daily section order. 
- Tests: added focused invariants — one asserting each item type maps to exactly one section owner, one asserting `daily_debug_summary.json` header fields and canonical `section_order`, and one asserting winners use the same canonical section order/labels. No behavioral or scoring logic was changed.

### Testing
- Ran `pytest -q tests/test_main_scoring_model.py` which passed: `21 passed`.
- Ran `pytest -q tests/test_main_daily_picks.py` which passed: `15 passed`.
- Ran `pytest -q tests/test_evening_winners.py` which passed: `16 passed`.
- All new and existing tests passed locally; changes are limited to config/queries/docs/comments/tests and do not alter scoring thresholds, routing behavior, winners computation, workflows, or persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8378698d08326b17b98617c5b192b)