### PR TITLE
Final cosmetic polish: centralized section config docs and tiny invariant test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Additionally, this repo contains a **live voice-channel join alert bot script** 
 
 This repository is now **channel-based** (no thread-based posting).
 
+## Tiny Repo File Map
+
+- `main.py` → scoring, routing, daily pick selection, posting.
+- `evening_winners.py` → winners selection and rendering.
+- `daily_section_config.py` → shared daily section order/labels/routing ownership.
+- `daily_debug_summary.json` → ephemeral operator debug output for the current run.
+
+### Maintainer note
+
+Section order and labels are intentionally centralized, threshold comments are intentional operator guidance, and any future tuning should happen only after observing real-world runs.
+
 ## Current Discord Channels
 
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)

--- a/daily_section_config.py
+++ b/daily_section_config.py
@@ -1,7 +1,6 @@
-"""Shared daily/winners section configuration.
+"""Single shared config for section order, labels, and routing ownership.
 
-Daily picks and evening winners intentionally use the same section order and labels
-so operators see a consistent product flow.
+Keeping this centralized ensures daily picks and evening winners stay aligned.
 """
 
 from typing import Dict, List

--- a/main.py
+++ b/main.py
@@ -75,6 +75,8 @@ REPOST_COOLDOWN_DAYS = 30
 # - Demo/Playtest has lower review strictness but stronger friend-group gating.
 # - Free raises review-confidence expectations.
 # - Paid is strictest overall.
+# These thresholds are intentionally conservative; do not tune further without
+# first observing real Discord output over multiple runs.
 MIN_SCORE_TO_POST_FREE = 9
 MIN_SCORE_TO_POST_DEMO_PLAYTEST = 6
 MIN_SCORE_TO_POST_PAID = 8
@@ -1064,6 +1066,7 @@ def export_daily_debug_summary(
     path: str = DAILY_DEBUG_SUMMARY_FILE,
     target_day_key: Optional[str] = None,
 ) -> None:
+    # Intentionally ephemeral troubleshooting artifact: overwritten each run.
     payload = {
         "generated_at_utc": utc_now_iso(),
         "target_day_key": target_day_key or get_target_day_key(),

--- a/tests/test_daily_section_config.py
+++ b/tests/test_daily_section_config.py
@@ -1,0 +1,15 @@
+from daily_section_config import (
+    DAILY_SECTION_CONFIG,
+    DAILY_SECTION_DISPLAY_LABELS,
+    DAILY_SECTION_ORDER,
+)
+
+
+def test_daily_section_config_canonical_order_and_labels():
+    assert DAILY_SECTION_ORDER == ["demo_playtest", "free", "paid", "instagram"]
+
+    keys_from_config = [entry["key"] for entry in DAILY_SECTION_CONFIG]
+    assert keys_from_config == DAILY_SECTION_ORDER
+
+    assert set(DAILY_SECTION_DISPLAY_LABELS.keys()) == set(DAILY_SECTION_ORDER)
+    assert all(DAILY_SECTION_DISPLAY_LABELS[section].strip() for section in DAILY_SECTION_ORDER)


### PR DESCRIPTION
### Motivation

- Make a final ultra-small clarity pass so section configuration and operator-facing notes are explicit and discoverable without changing any runtime behavior.
- Add a minimal guardrail test to catch accidental drift in the canonical daily section order and labels.

### Description

- Added a concise top-of-file module docstring to `daily_section_config.py` explaining it is the single shared source of truth for section order, labels, and routing ownership.  
- Added a tiny `README.md` subsection `Tiny Repo File Map` that maps high-level responsibilities to `main.py`, `evening_winners.py`, `daily_section_config.py`, and `daily_debug_summary.json`, plus a short maintainer note about centralized comments/config.  
- Inserted two small inline comments in `main.py`: one near the score thresholds advising those values are intentionally conservative, and one near `export_daily_debug_summary` noting `daily_debug_summary.json` is an ephemeral per-run troubleshooting artifact.  
- Added a focused test `tests/test_daily_section_config.py` asserting the canonical section order is `['demo_playtest','free','paid','instagram']`, that display labels exist for each section, and that the config/order/labels stay internally consistent.  
- Reviewed helper naming and constant ordering for tiny stylistic normalization and intentionally made no behavioral changes or renames to avoid churn.

### Testing

- Ran `pytest -q tests/test_main_scoring_model.py` which passed (`21 passed`).  
- Ran `pytest -q tests/test_main_daily_picks.py` which passed (`15 passed`).  
- Ran `pytest -q tests/test_evening_winners.py` which passed (`16 passed`).  
- Ran `pytest -q tests/test_daily_section_config.py` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d839ef5fe0832690c5c420529101bc)