### PR TITLE
Dedupe Instagram Creator Picks by normalized game key

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,15 @@ INSTAGRAM_CREATORS = [
 ]
 
 MAX_INSTAGRAM_POSTS_PER_ACCOUNT = 2
+INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS = [
+    r"\bdemo\b",
+    r"\bplaytest\b",
+    r"\bfree\b",
+    r"\bsteam\b",
+    r"\bwishlist\b",
+    r"\bout\s+now\b",
+    r"\blink\s+in\s+bio\b",
+]
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0"
@@ -1759,6 +1768,70 @@ def dedupe_by_app_id(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
             output.append((source, app_id))
     return output
 
+
+def _normalize_instagram_game_key_fragment(text: str) -> str:
+    normalized = text.lower()
+    normalized = re.sub(r"#\w+", " ", normalized)
+    for pattern in INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS:
+        normalized = re.sub(pattern, " ", normalized)
+    normalized = re.sub(r"[^a-z0-9\s]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def derive_instagram_game_key(caption: str) -> Optional[str]:
+    if not caption:
+        return None
+
+    raw_caption = caption.strip()
+    if not raw_caption or raw_caption == "(no caption)":
+        return None
+
+    quoted_or_bracketed_patterns = [
+        r"[\"“”]([^\"“”]{2,80})[\"“”]",
+        r"\[([^\[\]]{2,80})\]",
+        r"\(([^\(\)]{2,80})\)",
+    ]
+    for pattern in quoted_or_bracketed_patterns:
+        match = re.search(pattern, raw_caption)
+        if match:
+            key = _normalize_instagram_game_key_fragment(match.group(1))
+            if key:
+                return key
+
+    separator_match = re.search(r"\s[-|:]\s", raw_caption)
+    if not separator_match:
+        return None
+
+    candidate = raw_caption[:separator_match.start()].strip()
+    key = _normalize_instagram_game_key_fragment(candidate)
+    if not key:
+        return None
+
+    if len(key) < 3 or not re.search(r"[a-z]", key):
+        return None
+
+    return key
+
+
+def dedupe_instagram_posts(posts: List[dict]) -> List[dict]:
+    seen_keys = set()
+    deduped_posts: List[dict] = []
+
+    for post in posts:
+        key = derive_instagram_game_key(post.get("caption", ""))
+        if key is None:
+            deduped_posts.append(post)
+            continue
+
+        if key in seen_keys:
+            continue
+
+        seen_keys.add(key)
+        deduped_posts.append(post)
+
+    return deduped_posts
+
 def load_instagram_seen():
     if not os.path.exists(INSTAGRAM_STATE_FILE):
         return {}
@@ -2009,7 +2082,7 @@ def main():
         f"(cap={MAX_DEMO_PLAYTEST_POSTS})"
     )
 
-    instagram_posts = fetch_instagram_posts()
+    instagram_posts = dedupe_instagram_posts(fetch_instagram_posts())
     post_daily_pick_messages(demo_playtest_items, free_items, paid_items, instagram_posts)
 
     if not demo_playtest_items and not free_items and not paid_items:

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -136,6 +136,51 @@ def test_daily_item_persistence_stores_descriptions(monkeypatch, tmp_path):
     assert instagram_item["description"] == "Creator caption text"
 
 
+def test_dedupe_instagram_posts_merges_same_game_across_creators():
+    posts = [
+        {"username": "creator_a", "caption": '"Star Drift" - free on Steam #indie 🚀', "url": "u1"},
+        {"username": "creator_b", "caption": '"STAR DRIFT" | wishlist now #Steam ✨', "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1"]
+
+
+def test_dedupe_instagram_posts_keeps_different_games():
+    posts = [
+        {"username": "creator_a", "caption": '"Star Drift" - out now', "url": "u1"},
+        {"username": "creator_b", "caption": '"Moon Harbor" - out now', "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u2"]
+
+
+def test_dedupe_instagram_posts_keeps_low_confidence_captions():
+    posts = [
+        {"username": "creator_a", "caption": "Go check this out link in bio", "url": "u1"},
+        {"username": "creator_b", "caption": "Super fun pick today 🔥", "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u2"]
+
+
+def test_dedupe_instagram_posts_preserves_surviving_order():
+    posts = [
+        {"username": "creator_a", "caption": "[Night Signal]: out now", "url": "u1"},
+        {"username": "creator_b", "caption": '"NIGHT SIGNAL" - demo', "url": "u2"},
+        {"username": "creator_c", "caption": '"Orbit Tail" - wishlist', "url": "u3"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u3"]
+
+
 def test_daily_sections_post_in_new_order(monkeypatch, tmp_path):
     daily_path = tmp_path / "daily.json"
     daily_path.write_text("{}", encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Instagram Creator Picks sometimes show the same game multiple times when different creators post the same title, so Instagram ingestion needs conservative de-duplication without changing section ordering or seen-state behavior.

### Description
- Added conservative caption normalization helpers: `INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS`, `_normalize_instagram_game_key_fragment`, and `derive_instagram_game_key` to extract a stable game identity from captions using quoted/bracketed detection and phrase-before-separator heuristics.
- Implemented `dedupe_instagram_posts(posts)` which preserves input order, keeps the first post per derived game key, and leaves posts with low-confidence (`None`) keys untouched.
- Wired the dedupe to run immediately after `fetch_instagram_posts()` and before calling `post_daily_pick_messages()`, leaving fetch/seen-state behavior unchanged.
- Added focused unit tests in `tests/test_main_daily_picks.py` covering duplicate creators with formatting differences, hashtag/case/emoji tolerance, distinct titles remaining separate, low-confidence captions being preserved, and survivor order preservation.

### Testing
- Ran the unit tests with `pytest -q tests/test_main_daily_picks.py` and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83c5d52b483269218ce69b75c18da)