### PR TITLE
Polish Instagram dedupe observability, retention, and edge-case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Posting behavior in `daily-game-picks`:
   - Instagram Creator Picks
 - One Discord message per item
 - Adds a default 👍 reaction to each posted item
+- Instagram creator picks are conservatively deduplicated using a caption-derived normalized game key; if a reliable key cannot be derived from caption text, the post is kept.
 - Selection intent (low-risk/quality-first):
   - **New Demos & Playtests** sits above Free Picks and prioritizes friend-group fit (co-op/player-count cues), freshness, and basic legitimacy cues (`demo available`, `request access`, `playtest available`) over random catalog fill.
   - **Free Picks** remain focused on full free and temporarily free full games.

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ INSTAGRAM_CREATORS = [
 ]
 
 MAX_INSTAGRAM_POSTS_PER_ACCOUNT = 2
+INSTAGRAM_SEEN_RETENTION_PER_CREATOR = 50
 INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS = [
     r"\bdemo\b",
     r"\bplaytest\b",
@@ -1074,6 +1075,7 @@ def export_daily_debug_summary(
     run_summary_lines: List[str],
     path: str = DAILY_DEBUG_SUMMARY_FILE,
     target_day_key: Optional[str] = None,
+    instagram_debug: Optional[Dict[str, object]] = None,
 ) -> None:
     # Intentionally ephemeral troubleshooting artifact: overwritten each run.
     payload = {
@@ -1081,6 +1083,7 @@ def export_daily_debug_summary(
         "target_day_key": target_day_key or get_target_day_key(),
         "section_order": DAILY_SECTION_ORDER,
         "run_summary": run_summary_lines,
+        "instagram_debug": instagram_debug or {},
         "records": records,
     }
     try:
@@ -1815,8 +1818,14 @@ def derive_instagram_game_key(caption: str) -> Optional[str]:
 
 
 def dedupe_instagram_posts(posts: List[dict]) -> List[dict]:
+    deduped_posts, _ = _dedupe_instagram_posts_with_debug(posts)
+    return deduped_posts
+
+
+def _dedupe_instagram_posts_with_debug(posts: List[dict]) -> Tuple[List[dict], Dict[str, object]]:
     seen_keys = set()
     deduped_posts: List[dict] = []
+    removed_keys: List[str] = []
 
     for post in posts:
         key = derive_instagram_game_key(post.get("caption", ""))
@@ -1825,12 +1834,33 @@ def dedupe_instagram_posts(posts: List[dict]) -> List[dict]:
             continue
 
         if key in seen_keys:
+            if len(removed_keys) < 3:
+                removed_keys.append(key)
             continue
 
         seen_keys.add(key)
         deduped_posts.append(post)
 
-    return deduped_posts
+    debug: Dict[str, object] = {
+        "fetched_count": len(posts),
+        "deduped_count": len(deduped_posts),
+        "removed_count": len(posts) - len(deduped_posts),
+    }
+    if removed_keys:
+        debug["removed_key_samples"] = removed_keys
+    return deduped_posts, debug
+
+
+def prune_instagram_seen_state(data: object) -> Dict[str, List[str]]:
+    if not isinstance(data, dict):
+        return {}
+    cleaned: Dict[str, List[str]] = {}
+    for username, shortcodes in data.items():
+        if not isinstance(username, str) or not isinstance(shortcodes, list):
+            continue
+        valid_shortcodes = [code for code in shortcodes if isinstance(code, str) and code]
+        cleaned[username] = valid_shortcodes[-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
+    return cleaned
 
 def load_instagram_seen():
     if not os.path.exists(INSTAGRAM_STATE_FILE):
@@ -1838,14 +1868,14 @@ def load_instagram_seen():
 
     try:
         with open(INSTAGRAM_STATE_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
+            return prune_instagram_seen_state(json.load(f))
     except Exception:
         return {}
 
 
 def save_instagram_seen(data):
     with open(INSTAGRAM_STATE_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+        json.dump(prune_instagram_seen_state(data), f, indent=2)
 
 
 def fetch_instagram_posts():
@@ -1912,7 +1942,7 @@ def fetch_instagram_posts():
                 if count >= MAX_INSTAGRAM_POSTS_PER_ACCOUNT:
                     break
 
-            seen[username] = seen[username][-50:]
+            seen[username] = seen[username][-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
 
         except Exception as e:
             print(f"Instagram scrape failed for {username}: {e}")
@@ -2082,7 +2112,14 @@ def main():
         f"(cap={MAX_DEMO_PLAYTEST_POSTS})"
     )
 
-    instagram_posts = dedupe_instagram_posts(fetch_instagram_posts())
+    fetched_instagram_posts = fetch_instagram_posts()
+    instagram_posts, instagram_debug = _dedupe_instagram_posts_with_debug(fetched_instagram_posts)
+    print(
+        "Instagram dedupe: "
+        f"fetched={instagram_debug['fetched_count']} "
+        f"kept={instagram_debug['deduped_count']} "
+        f"removed={instagram_debug['removed_count']}"
+    )
     post_daily_pick_messages(demo_playtest_items, free_items, paid_items, instagram_posts)
 
     if not demo_playtest_items and not free_items and not paid_items:
@@ -2150,7 +2187,12 @@ def main():
     )
     for line in run_summary_lines:
         print(line)
-    export_daily_debug_summary(debug_records, run_summary_lines, target_day_key=get_target_day_key())
+    export_daily_debug_summary(
+        debug_records,
+        run_summary_lines,
+        target_day_key=get_target_day_key(),
+        instagram_debug=instagram_debug,
+    )
 
     next_start_page = get_next_start_page(start_page)
     save_page_state(next_start_page)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -181,6 +181,56 @@ def test_dedupe_instagram_posts_preserves_surviving_order():
     assert [post["url"] for post in deduped] == ["u1", "u3"]
 
 
+def test_dedupe_instagram_posts_handles_separator_variants():
+    posts = [
+        {"username": "creator_a", "caption": "Sky Relay - out now", "url": "u1"},
+        {"username": "creator_b", "caption": "SKY RELAY | wishlist now", "url": "u2"},
+        {"username": "creator_c", "caption": "Sky Relay : free on Steam", "url": "u3"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1"]
+
+
+def test_dedupe_instagram_posts_handles_quoted_and_bracketed_titles():
+    posts = [
+        {"username": "creator_a", "caption": '[Echo Vale] - demo on Steam', "url": "u1"},
+        {"username": "creator_b", "caption": '"ECHO VALE" - link in bio', "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1"]
+
+
+def test_dedupe_instagram_posts_keeps_low_confidence_boilerplate_only_captions():
+    posts = [
+        {"username": "creator_a", "caption": "Demo - Steam - wishlist - link in bio", "url": "u1"},
+        {"username": "creator_b", "caption": "playtest : out now on steam", "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u2"]
+
+
+def test_instagram_dedupe_debug_summary_counts_and_samples():
+    posts = [
+        {"username": "creator_a", "caption": '"Nova Hex" - out now', "url": "u1"},
+        {"username": "creator_b", "caption": '"NOVA HEX" | wishlist', "url": "u2"},
+        {"username": "creator_c", "caption": '"Moon Harbor" - out now', "url": "u3"},
+    ]
+
+    deduped, debug = main._dedupe_instagram_posts_with_debug(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u3"]
+    assert debug["fetched_count"] == 3
+    assert debug["deduped_count"] == 2
+    assert debug["removed_count"] == 1
+    assert debug["removed_key_samples"] == ["nova hex"]
+
+
 def test_daily_sections_post_in_new_order(monkeypatch, tmp_path):
     daily_path = tmp_path / "daily.json"
     daily_path.write_text("{}", encoding="utf-8")
@@ -360,15 +410,35 @@ def test_debug_export_writes_expected_structure(tmp_path):
     ]
     summary = ["RUN SUMMARY", "- Steam candidates scanned: 1"]
 
-    main.export_daily_debug_summary(records, summary, path=str(output_path))
+    instagram_debug = {"fetched_count": 4, "deduped_count": 3, "removed_count": 1}
+
+    main.export_daily_debug_summary(records, summary, path=str(output_path), instagram_debug=instagram_debug)
     saved = json.loads(output_path.read_text(encoding="utf-8"))
 
     assert saved["run_summary"] == summary
     assert saved["generated_at_utc"]
     assert saved["target_day_key"]
     assert saved["section_order"] == ["demo_playtest", "free", "paid", "instagram"]
+    assert saved["instagram_debug"] == instagram_debug
     assert saved["records"][0]["title"] == "Demo A"
     assert saved["records"][0]["reason_list"] == ["qualified"]
+
+
+def test_prune_instagram_seen_state_enforces_retention_and_shape():
+    oversized = [f"code-{idx}" for idx in range(main.INSTAGRAM_SEEN_RETENTION_PER_CREATOR + 5)]
+    pruned = main.prune_instagram_seen_state(
+        {
+            "creator": oversized,
+            "bad_creator": "not-a-list",
+            123: ["ignored"],
+            "mixed": ["ok", "", None, "ok-2"],
+        }
+    )
+
+    assert pruned["creator"] == oversized[-main.INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
+    assert "bad_creator" not in pruned
+    assert "123" not in pruned
+    assert pruned["mixed"] == ["ok", "ok-2"]
 
 
 def test_debug_export_fails_gracefully(monkeypatch, capsys):


### PR DESCRIPTION
### Motivation
- Provide lightweight operator-facing visibility into Instagram dedupe behavior without changing selection semantics. 
- Prevent unbounded growth of the `instagram_seen.json` seen-state using a simple, conservative retention policy. 
- Improve confidence in the conservative caption-based dedupe with focused edge-case tests. 
- Leave a short README note so future maintainers understand the conservative dedupe intent and fallback behavior.

### Description
- Add `INSTAGRAM_SEEN_RETENTION_PER_CREATOR` and `prune_instagram_seen_state(...)` and enforce pruning on both `load_instagram_seen()` and `save_instagram_seen()` as well as the per-account trim in `fetch_instagram_posts()` to preserve existing shape while bounding growth. 
- Introduce `_dedupe_instagram_posts_with_debug(posts)` that returns `(deduped_posts, debug)` and keep `dedupe_instagram_posts(posts)` as a thin wrapper to preserve public behavior. 
- Log a compact Instagram dedupe summary (`fetched`, `kept`, `removed`) to stdout each run and add a compact `instagram_debug` object (with optional `removed_key_samples`) to the `daily_debug_summary.json` payload via `export_daily_debug_summary(...)`. 
- Add focused tests in `tests/test_main_daily_picks.py` covering separator variants, quoted/bracketed titles, boilerplate/low-confidence captions, case/hashtag resilience, survivor-order preservation, debug summary counts/samples, and the seen-state pruning sanitizer. 
- Add a brief README note describing the conservative, caption-derived normalized game-key dedupe and the fallback behavior when a reliable key cannot be derived.

### Testing
- Ran the updated test suite file with `pytest -q tests/test_main_daily_picks.py` and all tests passed (`24 passed`). 
- New unit tests exercise the `_dedupe_instagram_posts_with_debug` outputs and the `prune_instagram_seen_state` sanitizer and succeeded. 
- No behavior changes to Steam scoring, winners logic, or section ordering were made, and only Instagram debug/retention/testing/README polish was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84427048c83268068948cd2937677)