### PR TITLE
docs: clarify Instagram retention constant and env var coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Posting behavior in `daily-game-picks`:
 - One Discord message per item
 - Adds a default 👍 reaction to each posted item
 - Instagram creator picks are conservatively deduplicated using a caption-derived normalized game key; if a reliable key cannot be derived from caption text, the post is kept.
-- Instagram seen-state is intentionally bounded: only the most recent 50 shortcodes per creator are retained in `instagram_seen.json`, preventing unbounded state growth.
+- Instagram seen-state is intentionally bounded by `INSTAGRAM_SEEN_RETENTION_PER_CREATOR` (default `50`): only the most recent 50 shortcodes per creator are retained in `instagram_seen.json`, preventing unbounded state growth over time.
 - Selection intent (low-risk/quality-first):
   - **New Demos & Playtests** sits above Free Picks and prioritizes friend-group fit (co-op/player-count cues), freshness, and basic legitimacy cues (`demo available`, `request access`, `playtest available`) over random catalog fill.
   - **Free Picks** remain focused on full free and temporarily free full games.
@@ -363,20 +363,24 @@ This shared layer is used by weekly + daily flows for consistency and safer reru
 ## Environment / Secrets (GitHub Actions)
 
 - Weekly scheduling bot:
-  - `DISCORD_SCHEDULING_BOT_TOKEN`
-  - `DISCORD_SCHEDULING_CHANNEL_ID`
+  - `DISCORD_SCHEDULING_BOT_TOKEN` — required bot token used to post/repair weekly intro/day prompts.
+  - `DISCORD_SCHEDULING_CHANNEL_ID` — required channel ID where weekly scheduling prompts are posted.
+  - `SCHEDULE_WEEK_START` (optional, `YYYY-MM-DD` Monday) — manual week override for backfill/repair runs.
 - Weekly responses sync:
-  - `DISCORD_SCHEDULING_BOT_TOKEN`
+  - `DISCORD_SCHEDULING_BOT_TOKEN` — required bot token used to fetch reactions and post/edit weekly summary/reminders.
+  - `TARGET_WEEK_KEY` (optional; workflow input `target_week_key`) — limit sync/rebuild to a specific stored week key.
+  - `REBUILD_SUMMARY_ONLY` (optional; workflow input `rebuild_summary_only`) — skip reaction fetch and only rebuild/repair summary output.
+  - `DRY_RUN` (optional; workflow input `dry_run`) — preview behavior without mutating Discord messages.
 - Daily picks:
-  - `DISCORD_WEBHOOK_URL`
-  - `DISCORD_BOT_TOKEN`
-  - `INSTAGRAM_USERNAME`
-  - `INSTAGRAM_SESSION_B64`
+  - `DISCORD_WEBHOOK_URL` — required webhook URL used to post daily intro/section/item content.
+  - `DISCORD_BOT_TOKEN` — required bot token for reactions, message checks, and daily state linkage.
+  - `INSTAGRAM_USERNAME` — required Instagram account username used for session-authenticated scraping.
+  - `INSTAGRAM_SESSION_B64` — required base64-encoded Instaloader session content (written to `instaloader.session` by workflow).
 - Evening winners:
-  - `DISCORD_BOT_TOKEN`
-  - `DISCORD_WINNERS_CHANNEL_ID`
+  - `DISCORD_BOT_TOKEN` — required bot token used to fetch reactions/voters and post winners output.
+  - `DISCORD_WINNERS_CHANNEL_ID` — required destination channel ID for winners posts.
 - Health monitor notifications (failure pings + daily report):
-  - `DISCORD_HEALTH_MONITOR_WEBHOOK_URL`
+  - `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` — webhook URL used by workflow failure handlers and `bot-health-report.yml`.
 
 ## Voice-channel join alert bot (live process)
 


### PR DESCRIPTION
### Motivation
- Make the README explicit about the Instagram seen-state retention constant so operators understand the bounded retention policy and its default value.
- Ensure the documented environment / secrets list matches the actual scripts and workflow inputs so required variables are clear for operators.
- Preserve existing runtime behavior and avoid introducing new runtime flags or behavior changes.

### Description
- Added a one-line README note naming `INSTAGRAM_SEEN_RETENTION_PER_CREATOR` and its default value (`50`) with a short explanation that this bounds `instagram_seen.json` to prevent unbounded state growth.
- Expanded the README `Environment / Secrets (GitHub Actions)` section to document each required/optional variable with a brief purpose, including `SCHEDULE_WEEK_START`, `TARGET_WEEK_KEY`, `REBUILD_SUMMARY_ONLY`, and `DRY_RUN`, and clarified Discord/Instagram/health-monitor variables.
- Did not modify runtime code or behavior; the unconditional Instagram dedupe print in `main.py` was left unchanged because no existing debug/verbosity flag was present to gate it behind.

### Testing
- Ran the test suite with `pytest -q`, all tests passed (`112 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8512e43e48326b140d13ba08d462d)