### PR TITLE
docs: fix winners destination channel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Section order and labels are intentionally centralized, threshold comments are i
 
 - Weekly scheduling channel: `update-weekly-schedule-here` (`1491294381418741870`)
 - Daily picks channel: `xianngpt-bot-daily-vote-here` (`1491294533751799809`)
-- Winners destination channel: configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `xianngpt-bot-daily-vote-here`)
+- Winners destination channel: configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`)
 - Health monitor channel: `xiann-gpt-bot-health-monitor` (`1491520649917628536`)
 
 ---
@@ -332,7 +332,7 @@ Behavior:
   - raw 👍 = 1 → excluded (0 human votes)
   - raw 👍 = 2 → included (1 human vote)
   - raw 👍 = 3 → included (2 human votes)
-- Posts winners to the channel configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `xianngpt-bot-daily-vote-here`)
+- Posts winners to the channel configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`)
 - Winners intentionally inherit the same section order as daily picks (`demo_playtest`, `free`, `paid`, `instagram`).
 
 Rerun/idempotency behavior:


### PR DESCRIPTION
### Motivation
- Clarify README so it accurately documents the channel split where daily picks post to `#xianngpt-bot-daily-vote-here` and winners post to `#daily-game-picks` because the README previously implied both used the same destination.

### Description
- Updated `README.md` to change the `Winners destination channel` line to state it is configured by `DISCORD_WINNERS_CHANNEL_ID` (currently `daily-game-picks`) and to update the Evening Winners behavior text to the same value while leaving the daily picks posting header unchanged.

### Testing
- No automated tests were run because this is a documentation-only change.
- Validated the README edits with repository text search and a file diff to confirm references now show daily voting in `#xianngpt-bot-daily-vote-here` and winners output in `#daily-game-picks`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d857c21838832692a4a4bd62a511f0)