### PR TITLE
tune health report stale thresholds for daily and weekly workflows

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           script: |
             const workflows = [
-              { file: "weekly-scheduling-bot.yml", name: "Weekly Scheduling Bot", staleHours: 192 },
+              { file: "weekly-scheduling-bot.yml", name: "Weekly Scheduling Bot", staleHours: 168 },
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
-              { file: "daily.yml", name: "Daily Steam Picks", staleHours: 30 },
-              { file: "evening-winners.yml", name: "Evening Winners", staleHours: 30 },
+              { file: "daily.yml", name: "Daily Steam Picks", staleHours: 20 },
+              { file: "evening-winners.yml", name: "Evening Winners", staleHours: 12 },
             ];
 
             const output = [];

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Manual rerun quick commands (GitHub CLI):
 ### Bot health report (`bot-health-report.yml`)
 - **What it does:** posts a once-daily Discord health summary across core workflows.
 - **Schedule:** `10 3 * * *` (03:10 UTC daily; ~11:10 PM New York during EDT).
+- **Workflow freshness thresholds:** Weekly Scheduling Bot `168h`, Weekly Scheduling Responses Sync `6h`, Daily Steam Picks `20h`, Evening Winners `12h`.
 - **Manual rerun:** `gh workflow run bot-health-report.yml`
 
 ## Operator Runbook (Consolidated)


### PR DESCRIPTION
### Motivation
- The Bot Health Report was marking some daily/Evening Winners runs as healthy despite missed same-day runs because configured `staleHours` thresholds were too loose for operator expectations.

### Description
- Updated workflow freshness thresholds in `.github/workflows/bot-health-report.yml` to `weekly-scheduling-bot.yml: 168`, `weekly-scheduling-responses-sync.yml: 6`, `daily.yml: 20`, and `evening-winners.yml: 12`.
- Aligned operator-facing docs by adding a short `Workflow freshness thresholds` note to `README.md` under the Bot health report section to keep guidance consistent with the new thresholds.

### Testing
- Ran `python scripts/build_daily_health_report.py --help` to verify the script invocation remains healthy and it succeeded.
- Ran `python -m py_compile scripts/build_daily_health_report.py` to ensure the health report script still compiles and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85bf5d45c83268f1f6864bf937001)