### PR TITLE
escalate stale workflow runs to action required in health report

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Operational alerts are now centralized in `xiann-gpt-bot-health-monitor`.
   - Informational warnings that can explicitly be `No action needed`.
   - Action meaning:
     - 🟢 = no action needed
-    - 🟡 = monitor / follow-up
+    - 🟡 = monitor / follow-up (non-urgent warnings)
     - 🔴 = action needed
+    - Missed workflow freshness windows (`stale`) are treated as 🔴 action needed.
 - **Operator default path:** this channel is now the primary dashboard for bot operations; email is no longer the preferred alerting path.
 
 Manual rerun quick commands (GitHub CLI):
@@ -135,8 +136,9 @@ Use this section as the fast triage guide when a workflow or state file drifts.
 - Winners + weekly scheduling sanity (expected week/day entries, summary freshness, picks↔winners coherence).
 - Top-level operator signal derived from workflow + state dispositions:
   - 🟢 no action needed
-  - 🟡 monitor / follow-up
+  - 🟡 monitor / follow-up (informational/non-urgent only)
   - 🔴 action needed
+  - Note: stale workflow freshness is classified as 🔴 with `Disposition: Action required`.
 
 ### Manual recovery / triage playbook
 

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -95,7 +95,7 @@ def evaluate_workflow_status(run: dict[str, Any] | None, stale_hours: int) -> tu
     conclusion = str(run.get("conclusion") or run.get("status") or "unknown")
 
     if age_hours > stale_hours:
-        return "🟡", f"{conclusion} ({recency}) — stale", True, "stale"
+        return "🔴", f"{conclusion} ({recency}) — stale", True, "stale"
     if conclusion == "success":
         return "🟢", f"{conclusion} ({recency})", False, "success"
     if conclusion in {"failure", "timed_out", "startup_failure", "action_required"}:
@@ -201,7 +201,7 @@ def _workflow_guidance(
     run_url = run.get("html_url") if isinstance(run, dict) and isinstance(run.get("html_url"), str) else None
     if status_reason == "stale":
         return (
-            "Action recommended",
+            "Action required",
             f"Re-run {workflow_name} if no run is expected soon; otherwise monitor the next scheduled run.",
         )
     if status_reason in {"no_recent_run", "timestamp_missing"}:

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -92,12 +92,12 @@ def test_stale_workflow_includes_triage_metadata():
     )
     rendered = "\n".join(lines)
 
-    assert "🟡 Weekly Scheduling Responses Sync" in rendered
+    assert "🔴 Weekly Scheduling Responses Sync" in rendered
     assert "Expected freshness: ≤2h" in rendered
     assert "Trigger: schedule" in rendered
     assert "Last run time:" in rendered
     assert "Run: https://example.test/run/1" in rendered
-    assert "Disposition: Action recommended" in rendered
+    assert "Disposition: Action required" in rendered
     assert "Next step: Re-run Weekly Scheduling Responses Sync" in rendered
 
 
@@ -179,7 +179,7 @@ def test_final_report_snapshot_shape_with_mixed_signals_and_triage_metadata():
         "🟢 Daily Steam Picks",
         "Last run: success (2h ago)",
         "",
-        "🟡 Evening Winners",
+        "🔴 Evening Winners",
         "Last run: success (40h ago) — stale",
         "Expected freshness: ≤30h",
         "Trigger: schedule",
@@ -221,12 +221,12 @@ def test_final_report_snapshot_shape_with_mixed_signals_and_triage_metadata():
 
     assert "## Workflow Status" in rendered
     assert "🟢 Daily Steam Picks" in rendered
-    assert "🟡 Evening Winners" in rendered
+    assert "🔴 Evening Winners" in rendered
     assert "🔴 Weekly Scheduling Responses Sync" in rendered
     assert "Expected freshness: ≤30h" in rendered
     assert "Trigger: schedule" in rendered
     assert "Run: https://example.test/run/42" in rendered
-    assert "Disposition: Action recommended" in rendered
+    assert "Disposition: Action required" in rendered
     assert "Disposition: Action required" in rendered
 
     assert "## State / Artifact Health" in rendered
@@ -413,13 +413,13 @@ def test_overall_summary_is_green_when_only_no_action_needed_warnings():
     assert "1 low-priority warning detected. No action needed." in rendered
 
 
-def test_overall_summary_is_yellow_for_monitor_or_follow_up_dispositions():
+def test_overall_summary_is_red_when_stale_workflow_is_action_required():
     rendered = report.render_report(
         workflow_status_lines=[
-            "🟡 Evening Winners",
+            "🔴 Evening Winners",
             "Last run: success (40h ago) — stale",
-            "Disposition: Monitor only",
-            "Next step: Watch next run.",
+            "Disposition: Action required",
+            "Next step: Re-run Evening Winners if no run is expected soon; otherwise monitor the next scheduled run.",
             "",
         ],
         state_issues=[
@@ -435,8 +435,8 @@ def test_overall_summary_is_yellow_for_monitor_or_follow_up_dispositions():
         report_date="Apr 9, 2026",
     )
 
-    assert "🟡 Overall: Follow-up recommended" in rendered
-    assert "2 items should be monitored or reviewed soon." in rendered
+    assert "🔴 Overall: Action needed" in rendered
+    assert "1 item requires immediate attention." in rendered
 
 
 def test_overall_summary_is_red_when_action_required_or_error_exists():


### PR DESCRIPTION
### Motivation
- Stale workflow runs (missed freshness windows) should be treated as immediate operational failures so they surface as actionable (red) in the daily Bot Health Report. 

### Description
- Change `evaluate_workflow_status()` in `scripts/build_daily_health_report.py` to return `🔴` for runs older than their `staleHours` window instead of `🟡` so stale workflows appear critical. 
- Update `_workflow_guidance()` in `scripts/build_daily_health_report.py` so stale workflows yield `Disposition: Action required` while keeping the existing rerun guidance text. 
- Update `README.md` phrasing to document that missed workflow freshness windows (`stale`) are classified as `🔴` / `Action required`. 
- Update `tests/test_build_daily_health_report.py` expectations to reflect stale workflows rendering as `🔴` and rolling up to a red overall summary where applicable. 

### Testing
- Ran `pytest -q tests/test_build_daily_health_report.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85eb268e883269bc04deec7ff63d4)