### PR TITLE
fix winners message chunking for Discord 2000-character limit

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -19,6 +19,7 @@ WINNERS_DATE_OVERRIDE_ENV = "WINNERS_DATE_UTC"
 WINNERS_LOOKBACK_DAYS = 10
 MAX_VOTERS_SHOWN_PER_GAME = 6
 DISCORD_MESSAGE_CHAR_LIMIT = 2000
+WINNERS_MESSAGE_TARGET_MAX = 1900
 
 # Winners intentionally mirror daily section ordering as product behavior,
 # not an incidental implementation detail.
@@ -84,6 +85,80 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
         lines.append("_No votes yet today._")
 
     return "\n".join(lines).strip()
+
+
+def _build_winner_item_lines(item: dict) -> List[str]:
+    lines = [item["title"]]
+    description = normalize_winner_description_for_message(item.get("description"))
+    if description:
+        lines.append(description)
+    lines.append(item["url"])
+    vote_word = "vote" if item["human_votes"] == 1 else "votes"
+    lines.append(f"👍 {item['human_votes']} {vote_word}")
+    lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
+    lines.append("")
+    return lines
+
+
+def build_winners_message_chunks(
+    winners_by_section: Dict[str, List[dict]],
+    *,
+    target_max: int = WINNERS_MESSAGE_TARGET_MAX,
+    hard_limit: int = DISCORD_MESSAGE_CHAR_LIMIT,
+) -> List[str]:
+    full_message = build_winners_message(winners_by_section)
+    if len(full_message) <= hard_limit:
+        return [full_message]
+
+    header = "🏆 Daily Game Picks — Winners"
+    chunks: List[str] = []
+    current_lines: List[str] = [header, ""]
+    has_any_winners = any(isinstance(winners_by_section.get(section), list) and winners_by_section.get(section) for section in SECTION_ORDER)
+
+    def finalize_current_chunk() -> None:
+        if current_lines:
+            rendered = "\n".join(current_lines).strip()
+            if rendered:
+                chunks.append(rendered)
+
+    def can_fit(lines: List[str], extra_lines: List[str]) -> bool:
+        rendered = "\n".join(lines + extra_lines).strip()
+        return len(rendered) <= target_max
+
+    if not has_any_winners:
+        return [full_message]
+
+    for section in SECTION_ORDER:
+        items = winners_by_section.get(section, [])
+        if not items:
+            continue
+
+        section_header_lines = [SECTION_CONFIG[section]]
+        section_full_lines = section_header_lines[:]
+        for item in items:
+            section_full_lines.extend(_build_winner_item_lines(item))
+
+        if can_fit(current_lines, section_full_lines):
+            current_lines.extend(section_full_lines)
+            continue
+
+        if len("\n".join(current_lines).strip()) > len(header):
+            finalize_current_chunk()
+            current_lines = []
+
+        current_lines.extend(section_header_lines)
+        for item in items:
+            item_lines = _build_winner_item_lines(item)
+            if not can_fit(current_lines, item_lines):
+                finalize_current_chunk()
+                current_lines = [SECTION_CONFIG[section]]
+            current_lines.extend(item_lines)
+
+    finalize_current_chunk()
+    for chunk in chunks:
+        if len(chunk) > hard_limit:
+            raise RuntimeError("Winners chunk exceeded Discord character limit")
+    return chunks
 
 
 def build_winners_message_compact(winners_by_section: Dict[str, List[dict]]) -> str:
@@ -201,6 +276,18 @@ def post_winners_message(client: DiscordClient, channel_id: str, message: str) -
     return message_id
 
 
+def normalize_winners_message_ids(winners_state: dict) -> List[str]:
+    message_ids = winners_state.get("message_ids")
+    if isinstance(message_ids, list):
+        normalized = [str(message_id).strip() for message_id in message_ids if str(message_id).strip()]
+        if normalized:
+            return normalized
+    message_id = winners_state.get("message_id")
+    if isinstance(message_id, str) and message_id.strip():
+        return [message_id.strip()]
+    return []
+
+
 def main() -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
@@ -304,9 +391,7 @@ def main() -> None:
                 }
             )
 
-        message = build_winners_message(winners_by_section)
-        if len(message) > DISCORD_MESSAGE_CHAR_LIMIT:
-            message = build_winners_message_compact(winners_by_section)
+        messages = build_winners_message_chunks(winners_by_section)
         winners_state = today_entry.get("winners_state")
         if not isinstance(winners_state, dict):
             winners_state = {}
@@ -317,7 +402,7 @@ def main() -> None:
             key: int(deduped_winners[key]["human_votes"])
             for key in current_winner_keys
         }
-        previous_message_id = winners_state.get("message_id")
+        previous_message_ids = normalize_winners_message_ids(winners_state)
         previous_winner_keys = winners_state.get("winner_keys")
         if not isinstance(previous_winner_keys, list):
             previous_winner_keys = []
@@ -331,7 +416,7 @@ def main() -> None:
             if str(key)
         }
 
-        if not current_winner_keys and not (isinstance(previous_message_id, str) and previous_message_id):
+        if not current_winner_keys and not previous_message_ids:
             print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
             return
 
@@ -349,40 +434,54 @@ def main() -> None:
             print(f"SKIP: no newly eligible winners for {day_key}")
             return
 
-        if isinstance(previous_message_id, str) and previous_message_id:
+        if previous_message_ids:
             try:
-                client.get_message(
-                    winners_channel_id,
-                    previous_message_id,
-                    context=f"verify winners message for {day_key}",
-                )
+                for index, previous_message_id in enumerate(previous_message_ids):
+                    client.get_message(
+                        winners_channel_id,
+                        previous_message_id,
+                        context=f"verify winners message {index + 1}/{len(previous_message_ids)} for {day_key}",
+                    )
+            except DiscordMessageNotFoundError:
+                previous_message_ids = []
+                print(f"RECOVER: stale/deleted winners message for {day_key}; posting replacement")
+
+        resulting_message_ids: List[str] = []
+        if previous_message_ids:
+            for index, message in enumerate(messages):
+                if index < len(previous_message_ids):
+                    message_id = previous_message_ids[index]
+                    client.edit_message(
+                        winners_channel_id,
+                        message_id,
+                        message,
+                        context=f"edit winners message chunk {index + 1}/{len(messages)} for {day_key}",
+                    )
+                    resulting_message_ids.append(message_id)
+                else:
+                    resulting_message_ids.append(post_winners_message(client, winners_channel_id, message))
+            for stale_index in range(len(messages), len(previous_message_ids)):
+                stale_message_id = previous_message_ids[stale_index]
                 client.edit_message(
                     winners_channel_id,
-                    previous_message_id,
-                    message,
-                    context=f"edit winners message for {day_key}",
+                    stale_message_id,
+                    "_(Winners content moved to earlier message chunks.)_",
+                    context=f"clear stale winners chunk {stale_index + 1}/{len(previous_message_ids)} for {day_key}",
                 )
-                winners_state["winner_keys"] = current_winner_keys
-                winners_state["winner_vote_counts"] = current_winner_vote_counts
-                winners_state["last_action"] = "edit"
-                winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
-                save_discord_daily_posts(daily_posts)
-                print(f"EDIT: updated winners message for {day_key} (message_id={previous_message_id})")
-                return
-            except DiscordMessageNotFoundError:
-                print(
-                    f"RECOVER: stale/deleted winners message for {day_key} "
-                    f"(message_id={previous_message_id}); posting replacement"
-                )
+            winners_state["last_action"] = "edit"
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            print(f"EDIT: updated winners messages for {day_key} (message_ids={resulting_message_ids})")
+        else:
+            resulting_message_ids = [post_winners_message(client, winners_channel_id, message) for message in messages]
+            winners_state["last_action"] = "create"
+            winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
+            print(f"CREATE: posted winners messages for {day_key} (message_ids={resulting_message_ids})")
 
-        new_message_id = post_winners_message(client, winners_channel_id, message)
-        winners_state["message_id"] = new_message_id
+        winners_state["message_id"] = resulting_message_ids[0]
+        winners_state["message_ids"] = resulting_message_ids
         winners_state["winner_keys"] = current_winner_keys
         winners_state["winner_vote_counts"] = current_winner_vote_counts
-        winners_state["last_action"] = "create"
-        winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
         save_discord_daily_posts(daily_posts)
-        print(f"CREATE: posted winners message for {day_key} (message_id={new_message_id})")
 
 
 if __name__ == "__main__":

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -376,6 +376,51 @@ def test_build_winners_message_compact_fallback_when_too_long(monkeypatch):
     assert "- Game 0 (2 votes)" in compact
 
 
+def test_build_winners_message_chunks_keeps_single_message_under_limit():
+    winners_by_section = {
+        "demo_playtest": [],
+        "free": [
+            {
+                "title": "Game A",
+                "description": "Short description.",
+                "url": "https://example.com/a",
+                "human_votes": 2,
+                "voter_names": ["Jan", "Jerry"],
+            }
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+
+    chunks = winners.build_winners_message_chunks(winners_by_section)
+    assert len(chunks) == 1
+    assert chunks[0] == winners.build_winners_message(winners_by_section)
+
+
+def test_build_winners_message_chunks_splits_over_limit_without_exceeding_discord_limit():
+    winners_by_section = {
+        "demo_playtest": [],
+        "free": [
+            {
+                "title": f"Very Long Winner Title {idx}",
+                "description": "A" * 110,
+                "url": f"https://example.com/{idx}",
+                "human_votes": 2,
+                "voter_names": [f"User {i}" for i in range(12)],
+            }
+            for idx in range(30)
+        ],
+        "paid": [],
+        "instagram": [],
+    }
+
+    chunks = winners.build_winners_message_chunks(winners_by_section)
+    assert len(chunks) > 1
+    assert chunks[0].startswith("🏆 Daily Game Picks — Winners")
+    for chunk in chunks:
+        assert len(chunk) <= winners.DISCORD_MESSAGE_CHAR_LIMIT
+
+
 def test_build_winners_message_supports_demo_playtest_section():
     winners_by_section = {
         "demo_playtest": [
@@ -455,3 +500,107 @@ def test_winners_pipeline_integration_late_votes_dedupe_and_coherent_edit(monkey
     edit_content = fake_edit.edits[0][2]
     assert "Current Paid Winner" in edit_content
     assert "👍 2 votes" in edit_content
+
+
+def test_winners_main_chunked_create_posts_multiple_messages(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    items = [
+        {
+            "section": "free",
+            "title": f"Chunked Winner {idx}",
+            "description": "A" * 110,
+            "url": f"https://example.com/{idx}",
+            "channel_id": "c",
+            "message_id": f"m-{idx}",
+        }
+        for idx in range(35)
+    ]
+    path.write_text(json.dumps({day_key: {"items": items}}), encoding="utf-8")
+    payloads = {f"m-{idx}": {"reactions": [{"emoji": {"name": "👍"}, "count": (3 if idx == 0 else 2)}]} for idx in range(35)}
+    reaction_users = {f"m-{idx}": ([{"id": "bot-1"}, {"id": "u-extra", "username": "extra"}, {"id": f"u-{idx}", "username": f"user-{idx}"}] if idx == 0 else [{"id": "bot-1"}, {"id": f"u-{idx}", "username": f"user-{idx}"}]) for idx in range(35)}
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) > 1
+    state = json.loads(path.read_text(encoding="utf-8"))[day_key]["winners_state"]
+    assert state["message_id"] == "w-1"
+    assert state["message_ids"] == [post[2] for post in fake.posts]
+    for _, content, _ in fake.posts:
+        assert len(content) <= winners.DISCORD_MESSAGE_CHAR_LIMIT
+
+
+def test_winners_main_legacy_single_message_id_state_still_edits(monkeypatch, tmp_path):
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"] = {
+        "message_id": "w-old",
+        "winner_keys": ["paid-win", "shared-dupe"],
+        "winner_vote_counts": {"paid-win": 1, "shared-dupe": 1},
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    payloads = {
+        "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 4}]},
+        "m-dupe": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-paid": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+    }
+    reaction_users = {
+        "m-late": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}, {"id": "u5", "username": "u5"}, {"id": "u8", "username": "u8"}],
+        "m-paid": [{"id": "bot-1"}, {"id": "u2", "username": "u2"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert len(fake.edits) == 1
+    assert fake.edits[0][1] == "w-old"
+    assert fake.posts == []
+
+
+def test_winners_main_multi_message_state_updates_without_duplicate_reposts(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    items = [
+        {
+            "section": "free",
+            "title": f"Chunked Winner {idx}",
+            "description": "A" * 110,
+            "url": f"https://example.com/{idx}",
+            "channel_id": "c",
+            "message_id": f"m-{idx}",
+        }
+        for idx in range(35)
+    ]
+    path.write_text(
+        json.dumps(
+            {
+                day_key: {
+                    "items": items,
+                    "winners_state": {
+                        "message_id": "w-1",
+                        "message_ids": ["w-1", "w-2", "w-3", "w-4"],
+                        "winner_keys": [f"https://example.com/{idx}" for idx in range(35)],
+                        "winner_vote_counts": {f"https://example.com/{idx}": 1 for idx in range(35)},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payloads = {f"m-{idx}": {"reactions": [{"emoji": {"name": "👍"}, "count": (3 if idx == 0 else 2)}]} for idx in range(35)}
+    reaction_users = {f"m-{idx}": [{"id": "bot-1"}, {"id": f"u-{idx}", "username": f"user-{idx}"}] for idx in range(35)}
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert fake.posts == []
+    edited_ids = [entry[1] for entry in fake.edits]
+    assert edited_ids == ["w-1", "w-2", "w-3", "w-4"]
+    state = json.loads(path.read_text(encoding="utf-8"))[day_key]["winners_state"]
+    assert state["message_ids"] == ["w-1", "w-2", "w-3", "w-4"]


### PR DESCRIPTION
### Motivation
- The winners flow could build a single, very large message that exceeds Discord's 2000-character limit and causes HTTP 400 errors when posting to the `daily-game-picks` channel. 
- We need a low-risk fix that preserves existing ordering/formatting and existing edit/update semantics while ensuring every Discord payload stays under the limit.

### Description
- Add a chunking renderer `build_winners_message_chunks` (and helper `_build_winner_item_lines`) that preserves the exact per-section ordering and formatting, prefers splitting between sections first and then between individual winner items, and targets a safe per-message size (`WINNERS_MESSAGE_TARGET_MAX`) while enforcing the hard `DISCORD_MESSAGE_CHAR_LIMIT`.
- Replace the single-message post path with a multi-message flow that returns a `messages` list, edits existing winner messages per-chunk when possible, posts only additional chunks as needed, and clears stale extra chunks by editing them to a short moved notice.
- Add backward-compatible state handling via `normalize_winners_message_ids` and persist both `message_id` (first chunk) and `message_ids` (all chunks) so legacy single-message state continues to work while multi-message state is supported.
- Keep the compact fallback renderer in place but rely on chunking for robust posting, and add focused tests that exercise single-message, chunking, legacy-state, and multi-message update behavior.

### Testing
- Ran `pytest -q tests/test_evening_winners.py` and all tests passed (`21 passed`).
- Ran `pytest -q tests/test_build_daily_health_report.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d863a2e1a88326a6d62fbb9e5d9dab)