### PR TITLE
add scheduling diagnostics to bot health report

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -37,12 +37,23 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: workflow.file,
-                per_page: 1,
+                per_page: 20,
                 exclude_pull_requests: true,
               });
+              const runs = response.data.workflow_runs || [];
               output.push({
                 ...workflow,
-                run: response.data.workflow_runs[0] || null,
+                run: runs[0] || null,
+                recentRuns: runs.slice(0, 20).map((run) => ({
+                  id: run.id,
+                  event: run.event,
+                  status: run.status,
+                  conclusion: run.conclusion,
+                  created_at: run.created_at,
+                  updated_at: run.updated_at,
+                  run_started_at: run.run_started_at,
+                  html_url: run.html_url,
+                })),
               });
             }
 
@@ -54,12 +65,21 @@ jobs:
           WORKFLOW_RUNS_JSON: ${{ steps.collect-workflows.outputs.workflows }}
         run: |
           printf '%s' "${WORKFLOW_RUNS_JSON}" > workflow-runs.json
-          python scripts/build_daily_health_report.py --workflow-runs-json workflow-runs.json > health-report.txt
+          python scripts/build_daily_health_report.py \
+            --workflow-runs-json workflow-runs.json \
+            --schedule-diagnostics-out workflow-schedule-diagnostics.json \
+            > health-report.txt
           {
             echo "content<<EOF"
             cat health-report.txt
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Upload scheduling diagnostics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-schedule-diagnostics
+          path: workflow-schedule-diagnostics.json
 
       - name: Post health report to Discord
         if: ${{ env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Operational alerts are now centralized in `xiann-gpt-bot-health-monitor`.
 - **Daily health report:** `bot-health-report.yml` posts one summary per day with:
   - A top-level **Overall** block (`🟢/🟡/🔴`) that tells operators if action is needed.
   - Workflow and state sections that include `Disposition` and `Next step` on yellow/red items.
+  - Workflow schedule observability fields for monitored cron workflows:
+    - latest trigger/event (`schedule`, `workflow_dispatch`, etc.)
+    - expected cadence + expected latest scheduled window
+    - schedule diagnosis code/message (for example `workflow.latest_manual_run`, `workflow.expected_scheduled_run_missing`)
+    - manual-recovery context when a dispatch run appears to have been used as a repair path
   - Informational warnings that can explicitly be `No action needed`.
   - Action meaning:
     - 🟢 = no action needed
@@ -105,6 +110,7 @@ Manual rerun quick commands (GitHub CLI):
 - **What it does:** posts a once-daily Discord health summary across core workflows.
 - **Schedule:** `10 3 * * *` (03:10 UTC daily; ~11:10 PM New York during EDT).
 - **Workflow freshness thresholds:** Weekly Scheduling Bot `168h`, Weekly Scheduling Responses Sync `6h`, Daily Steam Picks `20h`, Evening Winners `12h`.
+- **Scheduling diagnostics artifact:** uploads `workflow-schedule-diagnostics.json` each run with compact expected-vs-actual schedule evidence (latest run metadata, expected window classification, and diagnosis code per monitored workflow).
 - **Manual rerun:** `gh workflow run bot-health-report.yml`
 
 ## Operator Runbook (Consolidated)
@@ -131,6 +137,7 @@ Use this section as the fast triage guide when a workflow or state file drifts.
 ### What the daily health report checks
 
 - Workflow freshness/status (stale, failure, missing recent run).
+- Workflow schedule diagnostics (scheduled-window evidence, latest trigger context, manual-recovery detection, and explicit diagnosis codes for missing/late expected scheduled runs).
 - State/artifact consistency (missing or malformed files, missing summary/output links, winners-state coherence).
 - Roster/config integrity (missing/malformed/empty expected roster).
 - Winners + weekly scheduling sanity (expected week/day entries, summary freshness, picks↔winners coherence).

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -21,6 +21,41 @@ WEEKLY_PATHS = {
 DAILY_POSTS_PATH = ROOT / "discord_daily_posts.json"
 
 NEW_YORK_TZ = ZoneInfo("America/New_York")
+SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
+    "Weekly Scheduling Bot": {
+        "kind": "weekly",
+        "cron": "0 13 * * 6",
+        "cadence": "weekly Saturday 13:00 UTC",
+        "hour": 13,
+        "minute": 0,
+        "weekday": 5,
+        "window_before_minutes": 90,
+    },
+    "Weekly Scheduling Responses Sync": {
+        "kind": "interval",
+        "cron": "0 */3 * * *",
+        "cadence": "every 3 hours (UTC)",
+        "interval_hours": 3,
+        "minute": 0,
+        "window_before_minutes": 90,
+    },
+    "Daily Steam Picks": {
+        "kind": "daily",
+        "cron": "0 13 * * *",
+        "cadence": "daily 13:00 UTC",
+        "hour": 13,
+        "minute": 0,
+        "window_before_minutes": 90,
+    },
+    "Evening Winners": {
+        "kind": "daily",
+        "cron": "0 23 * * *",
+        "cadence": "daily 23:00 UTC",
+        "hour": 23,
+        "minute": 0,
+        "window_before_minutes": 90,
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -42,6 +77,24 @@ class OverallHealthSummary:
     icon: str
     headline: str
     detail: str
+
+
+@dataclass(frozen=True)
+class WorkflowScheduleDiagnostics:
+    code: str
+    message: str
+    expected_cadence: str
+    expected_schedule_time_utc: datetime | None
+    expected_window_start_utc: datetime | None
+    found_scheduled_run_in_window: bool
+    latest_run_is_manual_recovery: bool
+    latest_run_event: str | None
+    latest_run_created_at: datetime | None
+    latest_run_updated_at: datetime | None
+    latest_run_id: int | None
+    latest_run_conclusion: str | None
+    scheduled_run_in_window_id: int | None
+    scheduled_run_in_window_created_at: datetime | None
 
 
 def _load_json(path: Path) -> Any | None:
@@ -101,6 +154,110 @@ def evaluate_workflow_status(run: dict[str, Any] | None, stale_hours: int) -> tu
     if conclusion in {"failure", "timed_out", "startup_failure", "action_required"}:
         return "🔴", f"{conclusion} ({recency})", True, "failed"
     return "🟡", f"{conclusion} ({recency})", True, "non_success"
+
+
+def _latest_expected_schedule_time(now_utc: datetime, expectation: dict[str, Any]) -> datetime | None:
+    kind = expectation.get("kind")
+    if kind == "daily":
+        candidate = now_utc.replace(
+            hour=int(expectation["hour"]),
+            minute=int(expectation.get("minute", 0)),
+            second=0,
+            microsecond=0,
+        )
+        if candidate > now_utc:
+            candidate -= timedelta(days=1)
+        return candidate
+    if kind == "weekly":
+        candidate = now_utc.replace(
+            hour=int(expectation["hour"]),
+            minute=int(expectation.get("minute", 0)),
+            second=0,
+            microsecond=0,
+        )
+        target_weekday = int(expectation["weekday"])
+        days_back = (candidate.weekday() - target_weekday) % 7
+        candidate -= timedelta(days=days_back)
+        if candidate > now_utc:
+            candidate -= timedelta(days=7)
+        return candidate
+    if kind == "interval":
+        interval_hours = int(expectation["interval_hours"])
+        minute = int(expectation.get("minute", 0))
+        aligned = now_utc.replace(minute=minute, second=0, microsecond=0)
+        aligned = aligned.replace(hour=(aligned.hour // interval_hours) * interval_hours)
+        if aligned > now_utc:
+            aligned -= timedelta(hours=interval_hours)
+        return aligned
+    return None
+
+
+def build_schedule_diagnostics(
+    workflow_name: str,
+    *,
+    latest_run: dict[str, Any] | None,
+    recent_runs: list[dict[str, Any]],
+    now_utc: datetime,
+) -> WorkflowScheduleDiagnostics | None:
+    expectation = SCHEDULE_EXPECTATIONS.get(workflow_name)
+    if not expectation:
+        return None
+    expected_time = _latest_expected_schedule_time(now_utc, expectation)
+    if expected_time is None:
+        return None
+    window_start = expected_time - timedelta(minutes=int(expectation.get("window_before_minutes", 60)))
+
+    scheduled_in_window = None
+    for run in recent_runs:
+        if run.get("event") != "schedule":
+            continue
+        created_at = _parse_iso_utc(run.get("created_at") or run.get("run_started_at") or run.get("updated_at"))
+        if created_at is None:
+            continue
+        if created_at >= window_start:
+            scheduled_in_window = run
+            break
+
+    latest_event = latest_run.get("event") if isinstance(latest_run, dict) and isinstance(latest_run.get("event"), str) else None
+    found_scheduled = scheduled_in_window is not None
+    latest_manual_recovery = bool(latest_event and latest_event != "schedule" and found_scheduled)
+
+    if found_scheduled and latest_event == "schedule":
+        code = "workflow.scheduled_window_satisfied"
+        message = "Scheduled run found in expected window."
+    elif found_scheduled and latest_event != "schedule":
+        code = "workflow.latest_manual_run"
+        message = "Latest run was manual/non-scheduled; expected scheduled run was still found in window."
+    elif latest_event and latest_event != "schedule":
+        code = "workflow.expected_scheduled_run_missing"
+        message = "Latest run was manual/non-scheduled and no scheduled run was found in the expected window."
+    elif latest_event == "schedule":
+        code = "workflow.latest_scheduled_but_outside_expected_window"
+        message = "Latest run is scheduled but appears older than the most recent expected schedule window."
+    else:
+        code = "workflow.expected_scheduled_run_missing"
+        message = "No scheduled run found in the most recent expected window."
+
+    return WorkflowScheduleDiagnostics(
+        code=code,
+        message=message,
+        expected_cadence=f"{expectation['cadence']} (cron: {expectation['cron']})",
+        expected_schedule_time_utc=expected_time,
+        expected_window_start_utc=window_start,
+        found_scheduled_run_in_window=found_scheduled,
+        latest_run_is_manual_recovery=latest_manual_recovery,
+        latest_run_event=latest_event,
+        latest_run_created_at=_parse_iso_utc(latest_run.get("created_at")) if isinstance(latest_run, dict) else None,
+        latest_run_updated_at=_parse_iso_utc(latest_run.get("updated_at")) if isinstance(latest_run, dict) else None,
+        latest_run_id=latest_run.get("id") if isinstance(latest_run, dict) and isinstance(latest_run.get("id"), int) else None,
+        latest_run_conclusion=str(latest_run.get("conclusion") or latest_run.get("status")) if isinstance(latest_run, dict) else None,
+        scheduled_run_in_window_id=scheduled_in_window.get("id")
+        if isinstance(scheduled_in_window, dict) and isinstance(scheduled_in_window.get("id"), int)
+        else None,
+        scheduled_run_in_window_created_at=_parse_iso_utc(scheduled_in_window.get("created_at"))
+        if isinstance(scheduled_in_window, dict)
+        else None,
+    )
 
 
 def _week_keys(payload: Any) -> set[str]:
@@ -592,12 +749,51 @@ def _render_section(title: str, content_lines: list[str]) -> list[str]:
     return section
 
 
-def build_workflow_status_lines(workflow_runs: list[dict[str, Any]]) -> list[str]:
+def _serialize_schedule_diagnostics(
+    workflow_name: str,
+    stale_hours: int,
+    diagnostics: WorkflowScheduleDiagnostics | None,
+) -> dict[str, Any] | None:
+    if diagnostics is None:
+        return None
+    payload = asdict(diagnostics)
+    for key in (
+        "expected_schedule_time_utc",
+        "expected_window_start_utc",
+        "latest_run_created_at",
+        "latest_run_updated_at",
+        "scheduled_run_in_window_created_at",
+    ):
+        value = payload.get(key)
+        if isinstance(value, datetime):
+            payload[key] = value.isoformat()
+    payload["workflow_name"] = workflow_name
+    payload["stale_hours"] = stale_hours
+    return payload
+
+
+def build_workflow_status_lines(
+    workflow_runs: list[dict[str, Any]], *, now_utc: datetime | None = None
+) -> tuple[list[str], list[dict[str, Any]]]:
+    now_utc = now_utc or datetime.now(timezone.utc)
     lines: list[str] = []
+    diagnostics_payload: list[dict[str, Any]] = []
     for workflow in workflow_runs:
         stale_hours = int(workflow["staleHours"])
+        recent_runs = workflow.get("recentRuns")
         run = workflow.get("run")
+        if not isinstance(run, dict):
+            run = recent_runs[0] if isinstance(recent_runs, list) and recent_runs and isinstance(recent_runs[0], dict) else None
         icon, status_text, include_details, status_reason = evaluate_workflow_status(run, stale_hours)
+        schedule_diagnostics = build_schedule_diagnostics(
+            workflow["name"],
+            latest_run=run if isinstance(run, dict) else None,
+            recent_runs=recent_runs if isinstance(recent_runs, list) else ([run] if isinstance(run, dict) else []),
+            now_utc=now_utc,
+        )
+        serialized = _serialize_schedule_diagnostics(workflow["name"], stale_hours, schedule_diagnostics)
+        if serialized:
+            diagnostics_payload.append(serialized)
         lines.append(f"{icon} {workflow['name']}")
         lines.append(f"Last run: {status_text}")
 
@@ -611,6 +807,20 @@ def build_workflow_status_lines(workflow_runs: list[dict[str, Any]]) -> list[str
                 lines.append(f"Last run time: {timestamp_text}")
             if run.get("html_url"):
                 lines.append(f"Run: {run['html_url']}")
+        if schedule_diagnostics:
+            lines.append(f"Expected cadence: {schedule_diagnostics.expected_cadence}")
+            expected_time_text = _format_ny_timestamp(schedule_diagnostics.expected_schedule_time_utc.isoformat())
+            if expected_time_text:
+                lines.append(f"Expected latest schedule (ET): {expected_time_text}")
+            lines.append(
+                f"Schedule check: {schedule_diagnostics.message} [{schedule_diagnostics.code}]"
+            )
+            if schedule_diagnostics.latest_run_is_manual_recovery:
+                lines.append("Latest context: manual recovery run detected after scheduled execution.")
+            elif schedule_diagnostics.latest_run_event and schedule_diagnostics.latest_run_event != "schedule":
+                lines.append("Latest context: latest run trigger is manual/non-scheduled.")
+            if not schedule_diagnostics.found_scheduled_run_in_window:
+                lines.append("Scheduled window evidence: no scheduled run found in expected window.")
         guidance = _workflow_guidance(
             status_reason=status_reason,
             icon=icon,
@@ -622,7 +832,7 @@ def build_workflow_status_lines(workflow_runs: list[dict[str, Any]]) -> list[str
             lines.append(f"Disposition: {disposition}")
             lines.append(f"Next step: {next_step}")
         lines.append("")
-    return lines
+    return lines, diagnostics_payload
 
 
 def _report_date_new_york(now_utc: datetime) -> str:
@@ -633,19 +843,29 @@ def _report_date_new_york(now_utc: datetime) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workflow-runs-json", required=True, help="Path to workflow run metadata JSON")
+    parser.add_argument(
+        "--schedule-diagnostics-out",
+        default="",
+        help="Optional path to write compact workflow schedule diagnostics JSON.",
+    )
     args = parser.parse_args()
 
     payload = _load_json(Path(args.workflow_runs_json))
     workflow_runs = payload if isinstance(payload, list) else []
 
     now_utc = datetime.now(timezone.utc)
-    workflow_lines = build_workflow_status_lines(workflow_runs)
+    workflow_lines, diagnostics_payload = build_workflow_status_lines(workflow_runs, now_utc=now_utc)
     state_issues = compute_state_issues(now_utc=now_utc)
     report = render_report(
         workflow_status_lines=workflow_lines,
         state_issues=state_issues,
         report_date=_report_date_new_york(now_utc),
     )
+    if args.schedule_diagnostics_out:
+        Path(args.schedule_diagnostics_out).write_text(
+            json.dumps({"generated_at_utc": now_utc.isoformat(), "workflows": diagnostics_payload}, indent=2),
+            encoding="utf-8",
+        )
     print(report)
 
 

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -71,7 +71,7 @@ def test_healthy_state_has_all_clear_message(tmp_path, monkeypatch):
     assert issues == []
 
     rendered = report.render_report(
-        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", ""],
+        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", "Expected cadence: daily 13:00 UTC (cron: 0 13 * * *)", ""],
         state_issues=issues,
         report_date="Apr 9, 2026",
     )
@@ -87,10 +87,13 @@ def test_stale_workflow_includes_triage_metadata():
         "event": "schedule",
         "html_url": "https://example.test/run/1",
     }
-    lines = report.build_workflow_status_lines(
-        [{"name": "Weekly Scheduling Responses Sync", "staleHours": 2, "run": run}]
+    lines, diagnostics = report.build_workflow_status_lines(
+        [{"name": "Weekly Scheduling Responses Sync", "staleHours": 2, "run": run}],
+        now_utc=datetime(2026, 1, 1, 4, 0, tzinfo=timezone.utc),
     )
     rendered = "\n".join(lines)
+
+    assert diagnostics
 
     assert "🔴 Weekly Scheduling Responses Sync" in rendered
     assert "Expected freshness: ≤2h" in rendered
@@ -377,6 +380,7 @@ def test_error_rendering_uses_action_required():
         )
     )
     rendered = "\n".join(lines)
+
     assert "Disposition: Action required" in rendered
     assert "Next step: Inspect discord_daily_posts.json" in rendered
 
@@ -387,15 +391,20 @@ def test_green_workflow_output_has_no_guidance_lines():
         "created_at": datetime.now(timezone.utc).isoformat(),
         "conclusion": "success",
     }
-    lines = report.build_workflow_status_lines([{"name": "Daily Steam Picks", "staleHours": 6, "run": run}])
+    lines, diagnostics = report.build_workflow_status_lines(
+        [{"name": "Daily Steam Picks", "staleHours": 6, "run": run}],
+        now_utc=datetime.now(timezone.utc),
+    )
     rendered = "\n".join(lines)
+
+    assert diagnostics
     assert "Disposition:" not in rendered
     assert "Next step:" not in rendered
 
 
 def test_overall_summary_is_green_when_only_no_action_needed_warnings():
     rendered = report.render_report(
-        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", ""],
+        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", "Expected cadence: daily 13:00 UTC (cron: 0 13 * * *)", ""],
         state_issues=[
             report.Issue(
                 code="weekly.summary_freshness_missing",
@@ -411,6 +420,74 @@ def test_overall_summary_is_green_when_only_no_action_needed_warnings():
 
     assert "🟢 Overall: Healthy with informational warnings" in rendered
     assert "1 low-priority warning detected. No action needed." in rendered
+
+
+def test_schedule_diagnostics_detects_latest_manual_recovery_when_scheduled_exists():
+    now_utc = datetime(2026, 4, 10, 23, 30, tzinfo=timezone.utc)
+    latest_manual = {
+        "id": 100,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T23:20:00+00:00",
+        "updated_at": "2026-04-10T23:21:00+00:00",
+        "conclusion": "success",
+    }
+    recent_runs = [
+        latest_manual,
+        {"id": 99, "event": "schedule", "created_at": "2026-04-10T23:01:00+00:00", "updated_at": "2026-04-10T23:05:00+00:00"},
+    ]
+    diagnostics = report.build_schedule_diagnostics(
+        "Evening Winners",
+        latest_run=latest_manual,
+        recent_runs=recent_runs,
+        now_utc=now_utc,
+    )
+
+    assert diagnostics is not None
+    assert diagnostics.code == "workflow.latest_manual_run"
+    assert diagnostics.latest_run_is_manual_recovery is True
+    assert diagnostics.found_scheduled_run_in_window is True
+
+
+def test_schedule_diagnostics_flags_missing_scheduled_window_when_only_manual_exists():
+    now_utc = datetime(2026, 4, 10, 23, 30, tzinfo=timezone.utc)
+    latest_manual = {
+        "id": 120,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T22:40:00+00:00",
+        "updated_at": "2026-04-10T22:45:00+00:00",
+        "conclusion": "success",
+    }
+    diagnostics = report.build_schedule_diagnostics(
+        "Evening Winners",
+        latest_run=latest_manual,
+        recent_runs=[latest_manual],
+        now_utc=now_utc,
+    )
+
+    assert diagnostics is not None
+    assert diagnostics.code == "workflow.expected_scheduled_run_missing"
+    assert diagnostics.found_scheduled_run_in_window is False
+
+
+def test_schedule_diagnostics_flags_old_scheduled_run_outside_expected_window():
+    now_utc = datetime(2026, 4, 10, 23, 30, tzinfo=timezone.utc)
+    latest_schedule = {
+        "id": 140,
+        "event": "schedule",
+        "created_at": "2026-04-09T22:30:00+00:00",
+        "updated_at": "2026-04-09T22:35:00+00:00",
+        "conclusion": "success",
+    }
+    diagnostics = report.build_schedule_diagnostics(
+        "Evening Winners",
+        latest_run=latest_schedule,
+        recent_runs=[latest_schedule],
+        now_utc=now_utc,
+    )
+
+    assert diagnostics is not None
+    assert diagnostics.code == "workflow.latest_scheduled_but_outside_expected_window"
+    assert diagnostics.found_scheduled_run_in_window is False
 
 
 def test_overall_summary_is_red_when_stale_workflow_is_action_required():
@@ -465,7 +542,7 @@ def test_overall_summary_is_red_when_action_required_or_error_exists():
 
 def test_overall_summary_is_green_when_fully_healthy():
     rendered = report.render_report(
-        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", ""],
+        workflow_status_lines=["🟢 Daily Steam Picks", "Last run: success (1h ago)", "Expected cadence: daily 13:00 UTC (cron: 0 13 * * *)", ""],
         state_issues=[],
         report_date="Apr 9, 2026",
     )


### PR DESCRIPTION
### Motivation
- The daily health report lacked actionable evidence to tell whether a cron-triggered workflow actually missed its scheduled run or if the latest run was manual/recovery, making triage slow for jobs like `Evening Winners`.
- Add lightweight, repository-scoped scheduling diagnostics so operators can quickly determine expected-vs-actual schedule behavior without adding a generic cron parser or changing schedules.

### Description
- Added explicit per-workflow schedule expectation metadata (small `SCHEDULE_EXPECTATIONS` map) and a `WorkflowScheduleDiagnostics` model to represent expected cadence, expected schedule window, and diagnosis results in `scripts/build_daily_health_report.py`.
- Implemented `build_schedule_diagnostics` to inspect the latest + recent runs and emit concrete diagnosis codes/messages (for example `workflow.scheduled_window_satisfied`, `workflow.latest_manual_run`, `workflow.expected_scheduled_run_missing`, `workflow.latest_scheduled_but_outside_expected_window`) and flags like `latest_run_is_manual_recovery` and `found_scheduled_run_in_window`.
- Enriched workflow status rendering (`build_workflow_status_lines`) to include human-friendly scheduling context lines (expected cadence, expected latest scheduled time in ET, schedule check message and code, manual-recovery context) and to return both rendered lines and a compact diagnostics payload.
- Added an optional CLI flag `--schedule-diagnostics-out` so the health report can persist a compact JSON artifact of per-workflow schedule diagnostics for operator/debug use, and updated `bot-health-report.yml` to fetch up to 20 recent runs per monitored workflow, pass them to the script, and upload `workflow-schedule-diagnostics.json` as an artifact.
- Updated operator docs in `README.md` to document the new scheduling observability fields and artifact, and extended tests in `tests/test_build_daily_health_report.py` to cover scheduled/manual/missing-window scenarios and the updated builder return shape.
- Key files changed: `scripts/build_daily_health_report.py`, `.github/workflows/bot-health-report.yml`, `tests/test_build_daily_health_report.py`, and `README.md`.

### Testing
- Ran unit tests: `pytest -q tests/test_build_daily_health_report.py` and all tests passed (`21 passed`).
- Added focused tests verifying detection of: latest manual recovery when scheduled run exists, manual run with no scheduled run in the expected window, and scheduled run outside the expected window; those tests passed as part of the run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d867e6e5bc8326a3fa122e675d296d)