### PR TITLE
suppress repeat winners across consecutive day outputs

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -268,6 +268,46 @@ def fetch_human_voter_names(
     return names
 
 
+
+
+def build_winner_identity_key(item: dict) -> str:
+    dedupe_key = str(item.get("url") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+
+    dedupe_key = str(item.get("item_key") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+
+    channel_id = str(item.get("channel_id") or "").strip()
+    message_id = str(item.get("message_id") or "").strip()
+    return f"{channel_id}:{message_id}"
+
+
+def collect_recent_announced_winner_keys(
+    daily_posts: Dict[str, dict],
+    *,
+    target_day_key: str,
+    lookback_days: int = WINNERS_LOOKBACK_DAYS,
+) -> set[str]:
+    announced_keys: set[str] = set()
+    for bucket_key in get_lookback_day_keys(target_day_key, lookback_days)[1:]:
+        bucket = daily_posts.get(bucket_key, {})
+        if not isinstance(bucket, dict):
+            continue
+        winners_state = bucket.get("winners_state")
+        if not isinstance(winners_state, dict):
+            continue
+        winner_keys = winners_state.get("winner_keys")
+        if not isinstance(winner_keys, list):
+            continue
+        for winner_key in winner_keys:
+            normalized = str(winner_key).strip()
+            if normalized:
+                announced_keys.add(normalized)
+    return announced_keys
+
+
 def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
     payload = client.post_message(channel_id, message, context="post winners message")
     message_id = str(payload.get("id", ""))
@@ -333,11 +373,7 @@ def main() -> None:
             section = item.get("section")
             channel_id = item.get("channel_id")
             message_id = item.get("message_id")
-            dedupe_key = str(item.get("url") or "").strip()
-            if not dedupe_key:
-                dedupe_key = str(item.get("item_key") or "").strip()
-            if not dedupe_key:
-                dedupe_key = f"{channel_id}:{message_id}"
+            dedupe_key = build_winner_identity_key(item)
 
             if section not in SECTION_CONFIG:
                 continue
@@ -378,6 +414,16 @@ def main() -> None:
             }
             if existing is None or candidate["human_votes"] > existing["human_votes"]:
                 deduped_winners[dedupe_key] = candidate
+
+        previously_announced_winner_keys = collect_recent_announced_winner_keys(
+            daily_posts,
+            target_day_key=day_key,
+        )
+        deduped_winners = {
+            key: winner
+            for key, winner in deduped_winners.items()
+            if key not in previously_announced_winner_keys
+        }
 
         for winner in deduped_winners.values():
             section = winner["section"]

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -502,6 +502,117 @@ def test_winners_pipeline_integration_late_votes_dedupe_and_coherent_edit(monkey
     assert "👍 2 votes" in edit_content
 
 
+def test_cross_day_winner_suppression_hides_previously_announced_game(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        "2026-04-07": {
+            "items": [],
+            "winners_state": {
+                "message_id": "w-prev",
+                "winner_keys": ["shared-dupe"],
+                "winner_vote_counts": {"shared-dupe": 2},
+            },
+        },
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Intruder", "url": "shared-dupe", "channel_id": "c", "message_id": "m-intruder"},
+                {"section": "paid", "title": "Fresh Arrival", "url": "fresh-win", "channel_id": "c", "message_id": "m-fresh"},
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    payloads = {
+        "m-intruder": {"reactions": [{"emoji": {"name": "👍"}, "count": 4}]},
+        "m-fresh": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+    }
+    reaction_users = {
+        "m-intruder": [{"id": "bot-1"}, {"id": "u1", "username": "repeat"}, {"id": "u2", "username": "again"}, {"id": "u3", "username": "again2"}],
+        "m-fresh": [{"id": "bot-1"}, {"id": "u9", "username": "new-user"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) == 1
+    content = fake.posts[0][1]
+    assert "Intruder" not in content
+    assert "Fresh Arrival" in content
+    state = json.loads(path.read_text(encoding="utf-8"))[day_key]["winners_state"]
+    assert state["winner_keys"] == ["fresh-win"]
+
+
+def test_cross_day_winner_suppression_checks_multiple_recent_days(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        "2026-04-05": {
+            "items": [],
+            "winners_state": {"message_id": "w-older", "winner_keys": ["older-repeat"]},
+        },
+        "2026-04-07": {
+            "items": [],
+            "winners_state": {"message_id": "w-prev", "winner_keys": ["newer-repeat"]},
+        },
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Older Repeat", "url": "older-repeat", "channel_id": "c", "message_id": "m-older-repeat"},
+                {"section": "free", "title": "Newer Repeat", "url": "newer-repeat", "channel_id": "c", "message_id": "m-newer-repeat"},
+                {"section": "free", "title": "Only New Winner", "url": "brand-new", "channel_id": "c", "message_id": "m-brand-new"},
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    payloads = {
+        "m-older-repeat": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-newer-repeat": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+        "m-brand-new": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+    }
+    reaction_users = {
+        "m-older-repeat": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}],
+        "m-newer-repeat": [{"id": "bot-1"}, {"id": "u2", "username": "u2"}],
+        "m-brand-new": [{"id": "bot-1"}, {"id": "u3", "username": "u3"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    content = fake.posts[0][1]
+    assert "Older Repeat" not in content
+    assert "Newer Repeat" not in content
+    assert "Only New Winner" in content
+
+
+def test_cross_day_suppression_keeps_legacy_states_readable(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        "2026-04-07": {
+            "items": [],
+            "winners_state": {
+                "message_id": "w-prev",
+            },
+        },
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Legacy Compatible Winner", "url": "legacy-new", "channel_id": "c", "message_id": "m-legacy"},
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    payloads = {"m-legacy": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]}}
+    reaction_users = {"m-legacy": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}]}
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert len(fake.posts) == 1
+    assert "Legacy Compatible Winner" in fake.posts[0][1]
+
+
 def test_winners_main_chunked_create_posts_multiple_messages(monkeypatch, tmp_path):
     day_key = "2026-04-08"
     path = tmp_path / "daily.json"


### PR DESCRIPTION
### Motivation
- Prevent the same game from being re-announced on multiple consecutive days by treating games already posted in recent winners outputs as already announced. 
- Keep the existing 10-day vote lookback, per-run dedupe, ordering, chunking, and post/edit semantics unchanged while only changing which winners are rendered for the target day.

### Description
- Added a stable identity helper `build_winner_identity_key(item: dict)` that returns a consistent key using `url` → `item_key` → `channel_id:message_id` so same-run dedupe and cross-day suppression share the same identity logic. 
- Added `collect_recent_announced_winner_keys(daily_posts, *, target_day_key, lookback_days)` which reads prior days' `winners_state.winner_keys` within the existing 10-day lookback (excluding the target day) and returns a set of previously announced keys. 
- Applied cross-day suppression by filtering `deduped_winners` to remove any keys present in the announced set before assembling `winners_by_section` and rendering/posting for the target day. 
- Kept existing state update behavior and preserved backward compatibility with legacy `winners_state` records that may lack `winner_keys`.

### Testing
- Added focused tests in `tests/test_evening_winners.py` for suppression of a previously announced winner, ensuring genuinely new winners still appear, suppression across multiple in-window days, and legacy `winners_state` compatibility. 
- Ran `pytest -q tests/test_evening_winners.py` which succeeded with all tests passing (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86bf4a0c083268406d44f60351fa5)