### PR TITLE
harden Discord-posting workflows against 2000-character message limit

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -87,32 +87,64 @@ jobs:
           DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
           HEALTH_REPORT_CONTENT: ${{ steps.build-report.outputs.content }}
         run: |
-          payload="$(python - <<'PY'
+          python - <<'PY'
           import json
           import os
-          print(json.dumps({"content": os.environ["HEALTH_REPORT_CONTENT"]}))
+          import subprocess
+          import sys
+
+          from discord_api import split_discord_content
+
+          webhook = os.environ["DISCORD_HEALTH_MONITOR_WEBHOOK_URL"]
+          report = os.environ["HEALTH_REPORT_CONTENT"]
+          chunks = split_discord_content(report)
+
+          if len(chunks) > 1:
+              labeled_chunks = []
+              for idx, chunk in enumerate(chunks, start=1):
+                  prefix = f"📋 Bot Health Report ({idx}/{len(chunks)})\n"
+                  labeled_chunks.append(f"{prefix}{chunk}")
+              chunks = labeled_chunks
+
+          for idx, chunk in enumerate(chunks, start=1):
+              payload = json.dumps({"content": chunk})
+              result = subprocess.run(
+                  [
+                      "curl",
+                      "--silent",
+                      "--show-error",
+                      "--output",
+                      "/tmp/discord-health-response.txt",
+                      "--write-out",
+                      "%{http_code}",
+                      "--header",
+                      "Content-Type: application/json",
+                      "--header",
+                      "User-Agent: steam-discord-free-games-health-monitor/1.0",
+                      "--data",
+                      payload,
+                      "--request",
+                      "POST",
+                      webhook,
+                  ],
+                  check=False,
+                  text=True,
+                  capture_output=True,
+              )
+              http_status = (result.stdout or "").strip()
+              if http_status.startswith("2"):
+                  print(f"Discord webhook POST chunk {idx}/{len(chunks)} succeeded: HTTP {http_status}")
+                  continue
+
+              print(f"Discord webhook POST chunk {idx}/{len(chunks)} failed: HTTP {http_status}", file=sys.stderr)
+              try:
+                  with open("/tmp/discord-health-response.txt", encoding="utf-8") as response_file:
+                      response_body = response_file.read()
+                  if response_body.strip():
+                      print(response_body, file=sys.stderr)
+              except OSError:
+                  pass
+              if result.stderr:
+                  print(result.stderr, file=sys.stderr)
+              sys.exit(1)
           PY
-          )"
-
-          response_file="$(mktemp)"
-          http_status="$(curl --silent --show-error \
-            --output "${response_file}" \
-            --write-out "%{http_code}" \
-            --header "Content-Type: application/json" \
-            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
-            --data "${payload}" \
-            --request POST \
-            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
-
-          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
-            echo "Discord webhook POST succeeded: HTTP ${http_status}"
-          else
-            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
-            if [[ -s "${response_file}" ]]; then
-              cat "${response_file}" >&2
-            fi
-            rm -f "${response_file}"
-            exit 1
-          fi
-
-          rm -f "${response_file}"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Use this section as the fast triage guide when a workflow or state file drifts.
   - 🟡 monitor / follow-up (informational/non-urgent only)
   - 🔴 action needed
   - Note: stale workflow freshness is classified as 🔴 with `Disposition: Action required`.
+  - Long reports are now automatically split into multiple Discord messages (readable chunk boundaries, hard-capped below Discord's 2000-char content limit).
 
 ### Manual recovery / triage playbook
 
@@ -212,6 +213,7 @@ What it does:
 - Builds and stores derived summary data
 - Posts/edits weekly summary message in the scheduling channel
 - Posts reminder mentions for missing users when needed
+- Summary/reminder outputs now auto-chunk when content grows, with backward-compatible `*_message_id` + `*_message_ids` tracking for rerun-safe edits.
 
 Weekly state files (12-week retention):
 - `data/scheduling/weekly_schedule_messages.json`

--- a/discord_api.py
+++ b/discord_api.py
@@ -6,8 +6,66 @@ from typing import Any
 import requests
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
+DISCORD_MESSAGE_HARD_LIMIT = 2000
+DISCORD_MESSAGE_TARGET_LIMIT = 1900
 DEFAULT_TIMEOUT_SECONDS = 30
 RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+
+def split_discord_content(
+    content: str,
+    *,
+    target_limit: int = DISCORD_MESSAGE_TARGET_LIMIT,
+    hard_limit: int = DISCORD_MESSAGE_HARD_LIMIT,
+) -> list[str]:
+    """Split long content into Discord-safe chunks with readable boundaries."""
+    text = str(content)
+    if len(text) <= hard_limit:
+        return [text]
+
+    if target_limit <= 0 or hard_limit <= 0:
+        raise ValueError("Discord chunk limits must be positive")
+    if target_limit > hard_limit:
+        target_limit = hard_limit
+
+    chunks: list[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= hard_limit:
+            chunks.append(remaining)
+            break
+
+        window = remaining[:target_limit]
+        split_at = _best_split_index(window)
+        if split_at <= 0:
+            split_at = target_limit
+
+        chunk = remaining[:split_at].rstrip("\n")
+        if not chunk:
+            chunk = remaining[:target_limit]
+            split_at = len(chunk)
+
+        if len(chunk) > hard_limit:
+            chunk = chunk[:hard_limit]
+            split_at = len(chunk)
+
+        chunks.append(chunk)
+        remaining = remaining[split_at:].lstrip("\n")
+
+    for chunk in chunks:
+        if len(chunk) > hard_limit:
+            raise ValueError("Generated Discord chunk exceeded hard limit")
+
+    return chunks
+
+
+def _best_split_index(window: str) -> int:
+    for token in ("\n\n", "\n- ", "\n* ", "\n• ", "\n"):
+        idx = window.rfind(token)
+        if idx > 0:
+            return idx + len(token)
+    return window.rfind(" ")
 
 
 class DiscordApiError(RuntimeError):

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 
 import requests
 
-from discord_api import DiscordClient, DiscordMessageNotFoundError
+from discord_api import DiscordClient, DiscordMessageNotFoundError, split_discord_content
 from scripts.scheduling_labels import DAY_NAMES, format_day_label
 from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
 
@@ -30,6 +30,82 @@ SUMMARY_SLOT_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝"]
 SUMMARY_DISPLAY_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝", "❌"]
 MAX_SUMMARY_LINE_LENGTH = 185
 NEW_YORK_TIMEZONE = ZoneInfo("America/New_York")
+
+
+def normalize_message_ids(output_state: dict[str, Any], single_key: str, list_key: str) -> list[str]:
+    """Read message ids with backward compatibility for legacy single-id state."""
+    raw_ids = output_state.get(list_key)
+    if isinstance(raw_ids, list):
+        normalized = [str(message_id).strip() for message_id in raw_ids if str(message_id).strip()]
+        if normalized:
+            return normalized
+
+    raw_single = output_state.get(single_key)
+    if isinstance(raw_single, str) and raw_single.strip():
+        return [raw_single.strip()]
+
+    return []
+
+
+def upsert_message_chunks(
+    client: DiscordClient,
+    channel_id: str,
+    chunks: list[str],
+    previous_message_ids: list[str],
+    *,
+    context_prefix: str,
+    stale_placeholder: str,
+) -> list[str]:
+    """Create/edit chunked Discord messages while preserving idempotent reruns."""
+    valid_existing_ids: list[str] = []
+    for index, existing_message_id in enumerate(previous_message_ids, start=1):
+        try:
+            client.get_message(
+                channel_id,
+                existing_message_id,
+                context=f"verify {context_prefix} chunk {index}/{len(previous_message_ids)}",
+            )
+            valid_existing_ids.append(existing_message_id)
+        except DiscordMessageNotFoundError:
+            print(
+                f"RECOVER: stale/deleted {context_prefix} chunk "
+                f"(message_id={existing_message_id}); replacing chunk set"
+            )
+            valid_existing_ids = []
+            break
+
+    resulting_ids: list[str] = []
+    for index, chunk in enumerate(chunks):
+        if index < len(valid_existing_ids):
+            message_id = valid_existing_ids[index]
+            client.edit_message(
+                channel_id,
+                message_id,
+                chunk,
+                context=f"edit {context_prefix} chunk {index + 1}/{len(chunks)}",
+            )
+            resulting_ids.append(message_id)
+        else:
+            payload = client.post_message(
+                channel_id,
+                chunk,
+                context=f"post {context_prefix} chunk {index + 1}/{len(chunks)}",
+            )
+            message_id = str(payload.get("id", ""))
+            if not message_id:
+                fail(f"Discord response JSON did not include id for {context_prefix} chunk")
+            resulting_ids.append(message_id)
+
+    for stale_index in range(len(chunks), len(valid_existing_ids)):
+        stale_id = valid_existing_ids[stale_index]
+        client.edit_message(
+            channel_id,
+            stale_id,
+            stale_placeholder,
+            context=f"clear stale {context_prefix} chunk {stale_index + 1}/{len(valid_existing_ids)}",
+        )
+
+    return resulting_ids
 
 
 def fail(message: str) -> None:
@@ -915,11 +991,10 @@ def main() -> None:
         )
         discord_client = DiscordClient(posting_session)
 
-        previous_summary_message_id = week_outputs.get("summary_message_id")
-        summary_message_id = (
-            str(previous_summary_message_id)
-            if isinstance(previous_summary_message_id, str) and previous_summary_message_id
-            else None
+        previous_summary_message_ids = normalize_message_ids(
+            week_outputs,
+            "summary_message_id",
+            "summary_message_ids",
         )
         previous_summary_message_content = week_outputs.get("summary_message_content")
         previous_summary_data_signature = normalize_optional_text(
@@ -972,50 +1047,63 @@ def main() -> None:
 
         week_outputs["summary_data_signature"] = current_summary_data_signature
 
+        summary_chunks = split_discord_content(summary_message)
+
         if dry_run:
             print(f"DRY_RUN: summary preview for {posting_week_key}")
             print(summary_message)
             print(f"DRY_RUN: skipping Discord summary and reminder mutations for {posting_week_key}")
-        elif summary_message_id is None:
-            payload = discord_client.post_message(
-                channel_id, summary_message, context=f"post summary for {posting_week_key}"
+        elif not previous_summary_message_ids:
+            summary_message_ids = upsert_message_chunks(
+                discord_client,
+                channel_id,
+                summary_chunks,
+                [],
+                context_prefix=f"summary for {posting_week_key}",
+                stale_placeholder="_(Summary content moved to earlier message chunks.)_",
             )
-            summary_message_id = str(payload.get("id", ""))
             week_outputs["summary_posted"] = True
-            week_outputs["summary_message_id"] = summary_message_id
+            week_outputs["summary_message_id"] = summary_message_ids[0]
+            week_outputs["summary_message_ids"] = summary_message_ids
             week_outputs["summary_message_content"] = summary_message
-            print(f"CREATE: posted summary for week {posting_week_key} (message_id={summary_message_id})")
+            print(
+                f"CREATE: posted summary for week {posting_week_key} "
+                f"(message_ids={summary_message_ids})"
+            )
         elif previous_summary_message_content != summary_message:
             try:
-                discord_client.edit_message(
+                summary_message_ids = upsert_message_chunks(
+                    discord_client,
                     channel_id,
-                    summary_message_id,
-                    summary_message,
-                    context=f"edit summary for {posting_week_key}",
+                    summary_chunks,
+                    previous_summary_message_ids,
+                    context_prefix=f"summary for {posting_week_key}",
+                    stale_placeholder="_(Summary content moved to earlier message chunks.)_",
                 )
                 week_outputs["summary_posted"] = True
+                week_outputs["summary_message_id"] = summary_message_ids[0]
+                week_outputs["summary_message_ids"] = summary_message_ids
                 week_outputs["summary_message_content"] = summary_message
                 print(
                     f"EDIT: updated summary for week {posting_week_key} "
-                    f"(message_id={summary_message_id})"
+                    f"(message_ids={summary_message_ids})"
                 )
             except DiscordMessageNotFoundError:
-                print(
-                    f"RECOVER: stale/deleted summary message for week {posting_week_key} "
-                    f"(message_id={summary_message_id}); posting replacement"
-                )
-                payload = discord_client.post_message(
+                summary_message_ids = upsert_message_chunks(
+                    discord_client,
                     channel_id,
-                    summary_message,
-                    context=f"recover summary for {posting_week_key}",
+                    summary_chunks,
+                    [],
+                    context_prefix=f"recover summary for {posting_week_key}",
+                    stale_placeholder="_(Summary content moved to earlier message chunks.)_",
                 )
-                summary_message_id = str(payload.get("id", ""))
                 week_outputs["summary_posted"] = True
-                week_outputs["summary_message_id"] = summary_message_id
+                week_outputs["summary_message_id"] = summary_message_ids[0]
+                week_outputs["summary_message_ids"] = summary_message_ids
                 week_outputs["summary_message_content"] = summary_message
                 print(
                     f"RECOVER: posted replacement summary for week {posting_week_key} "
-                    f"(message_id={summary_message_id})"
+                    f"(message_ids={summary_message_ids})"
                 )
         else:
             print(f"SKIP: summary unchanged for week {posting_week_key}; skipping summary edit")
@@ -1039,15 +1127,27 @@ def main() -> None:
                         )
                     else:
                         reminder_message = format_reminder_message(date_range, missing_user_ids)
-                        reminder_message_id = post_channel_message(
-                            posting_session, channel_id, reminder_message
+                        reminder_chunks = split_discord_content(reminder_message)
+                        reminder_message_ids = normalize_message_ids(
+                            week_outputs,
+                            "reminder_message_id",
+                            "reminder_message_ids",
                         )
-                        week_outputs["reminder_message_id"] = reminder_message_id
+                        updated_reminder_ids = upsert_message_chunks(
+                            discord_client,
+                            channel_id,
+                            reminder_chunks,
+                            reminder_message_ids,
+                            context_prefix=f"reminder for {posting_week_key}",
+                            stale_placeholder="_(Reminder content moved to earlier message chunks.)_",
+                        )
+                        week_outputs["reminder_message_id"] = updated_reminder_ids[0]
+                        week_outputs["reminder_message_ids"] = updated_reminder_ids
                         week_outputs["reminder_missing_users"] = missing_user_ids
                         week_outputs["last_reminder_local_date"] = reminder_local_date
                         print(
                             f"CREATE: posted reminder for week {posting_week_key} "
-                            f"(message_id={reminder_message_id}, missing={len(missing_user_ids)}, "
+                            f"(message_ids={updated_reminder_ids}, missing={len(missing_user_ids)}, "
                             f"ny_date={reminder_local_date})"
                         )
                 else:

--- a/tests/test_discord_api_message_splitting.py
+++ b/tests/test_discord_api_message_splitting.py
@@ -1,0 +1,18 @@
+from discord_api import DISCORD_MESSAGE_HARD_LIMIT, split_discord_content
+
+
+def test_split_discord_content_keeps_short_message_single_chunk():
+    message = "Hello\n\nWorld"
+    chunks = split_discord_content(message)
+    assert chunks == [message]
+
+
+def test_split_discord_content_splits_long_message_without_exceeding_limit():
+    lines = [f"- user-{index:04d}" for index in range(1500)]
+    message = "\n".join(lines)
+    chunks = split_discord_content(message)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= DISCORD_MESSAGE_HARD_LIMIT for chunk in chunks)
+    assert "".join(chunks).replace("\n", "") in message.replace("\n", "")
+

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -25,9 +25,12 @@ class FakeDiscordClient:
         self.posts.append((channel_id, content, context, mid))
         return {"id": mid}
 
-    def edit_message(self, channel_id, message_id, content, *, context):
+    def get_message(self, channel_id, message_id, *, context):
         if self.stale_summary_id and message_id == self.stale_summary_id:
             raise sync.DiscordMessageNotFoundError("missing")
+        return {"id": message_id}
+
+    def edit_message(self, channel_id, message_id, content, *, context):
         self.edits.append((channel_id, message_id, content, context))
         return {"id": message_id}
 
@@ -315,16 +318,9 @@ def test_main_posts_only_one_reminder_per_new_york_local_day(monkeypatch, tmp_pa
         },
     )
 
-    reminder_posts = []
-
-    def fake_post_channel_message(session, channel_id, content):
-        reminder_posts.append((channel_id, content))
-        return f"rem-{len(reminder_posts)}"
-
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
-    monkeypatch.setattr(sync, "post_channel_message", fake_post_channel_message)
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -420,7 +416,8 @@ def test_weekly_pipeline_integration_happy_path(monkeypatch, tmp_path):
     assert isinstance(week_outputs.get("summary_last_synced_at_utc"), str)
     assert week_outputs["reminder_missing_users"] == ["300"]
     assert week_outputs["last_reminder_local_date"] == "2026-04-18"
-    assert len(reminder_posts) == 1
+    reminder_ids = week_outputs.get("reminder_message_ids")
+    assert isinstance(reminder_ids, list) and len(reminder_ids) == 1
 
 
 def test_main_saturday_new_week_requires_change_and_allows_single_daily_reminder(
@@ -435,16 +432,9 @@ def test_main_saturday_new_week_requires_change_and_allows_single_daily_reminder
             }
         },
     )
-    reminder_posts = []
-
-    def fake_post_channel_message(session, channel_id, content):
-        reminder_posts.append((channel_id, content))
-        return f"rem-{len(reminder_posts)}"
-
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
-    monkeypatch.setattr(sync, "post_channel_message", fake_post_channel_message)
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -459,12 +449,11 @@ def test_main_saturday_new_week_requires_change_and_allows_single_daily_reminder
 
     # First Saturday sync for newly created week posts summary + first reminder.
     sync.main()
-    assert len(fake_client.posts) == 1
-    assert len(reminder_posts) == 1
+    assert len(fake_client.posts) == 2
 
     # Later same-day Saturday syncs cannot post another reminder.
     sync.main()
-    assert len(reminder_posts) == 1
+    assert len(fake_client.posts) == 2
 
 
 def test_main_unchanged_summary_signature_skips_edit_and_keeps_timestamp(
@@ -513,7 +502,6 @@ def test_main_unchanged_summary_signature_skips_edit_and_keeps_timestamp(
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
-    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -527,7 +515,7 @@ def test_main_unchanged_summary_signature_skips_edit_and_keeps_timestamp(
     sync.main()
 
     outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
-    assert fake_client.posts == []
+    assert len(fake_client.posts) == 1
     assert fake_client.edits == []
     assert outputs[week_key]["summary_last_synced_at_utc"] == old_synced_at.isoformat()
     assert outputs[week_key]["summary_message_content"] == prior_summary_message
@@ -596,7 +584,6 @@ def test_main_changed_summary_data_updates_timestamp_and_edits_message(monkeypat
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
-    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -610,7 +597,7 @@ def test_main_changed_summary_data_updates_timestamp_and_edits_message(monkeypat
     sync.main()
 
     outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
-    assert fake_client.posts == []
+    assert len(fake_client.posts) == 1
     assert len(fake_client.edits) == 1
     assert outputs[week_key]["summary_message_content"] != baseline_content
     assert outputs[week_key]["summary_data_signature"] != baseline_signature
@@ -640,7 +627,6 @@ def test_main_legacy_summary_backfills_signature_without_noisy_edit(monkeypatch,
     fake_client = FakeDiscordClient()
     monkeypatch.setattr(sync.requests, "Session", FakeSession)
     monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
-    monkeypatch.setattr(sync, "post_channel_message", lambda session, channel_id, content: "rem-1")
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
     monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
@@ -654,8 +640,63 @@ def test_main_legacy_summary_backfills_signature_without_noisy_edit(monkeypatch,
     sync.main()
 
     outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
-    assert fake_client.posts == []
+    assert len(fake_client.posts) == 1
     assert fake_client.edits == []
     assert outputs[week_key]["summary_message_content"] == "legacy-summary-content"
     assert isinstance(outputs[week_key].get("summary_data_signature"), str)
     assert "summary_last_synced_at_utc" not in outputs[week_key]
+
+
+def test_main_summary_uses_multi_message_ids_when_content_is_long(monkeypatch, tmp_path, load_fixture_json):
+    weekly_responses = load_fixture_json("weekly_responses_named_users.json")
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(tmp_path, weekly_responses)
+    _write(outputs_p, {})
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setattr(sync, "format_summary_message", lambda *args, **kwargs: ("line\n" * 900).strip())
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    posted_ids = outputs[week_key].get("summary_message_ids")
+    assert isinstance(posted_ids, list) and len(posted_ids) >= 2
+    assert outputs[week_key]["summary_message_id"] == posted_ids[0]
+
+
+def test_main_reminder_uses_multi_message_ids_when_content_is_long(monkeypatch, tmp_path, load_fixture_json):
+    weekly_responses = load_fixture_json("weekly_responses_named_users.json")
+    week_key, messages_p, responses_p, summary_p, roster_p, outputs_p = _setup_files(tmp_path, weekly_responses)
+
+    # Inflate active roster to force a long missing-user reminder.
+    roster_users = {str(1000 + idx): {"is_active": True} for idx in range(350)}
+    _write(roster_p, {"users": roster_users})
+    _write(outputs_p, {})
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(sync.requests, "Session", FakeSession)
+    monkeypatch.setattr(sync, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_MESSAGES_FILE", str(messages_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_RESPONSES_FILE", str(responses_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_SUMMARY_FILE", str(summary_p))
+    monkeypatch.setattr(sync, "EXPECTED_SCHEDULE_ROSTER_FILE", str(roster_p))
+    monkeypatch.setattr(sync, "WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE", str(outputs_p))
+    monkeypatch.setenv("DISCORD_SCHEDULING_BOT_TOKEN", "x")
+    monkeypatch.setenv("REBUILD_SUMMARY_ONLY", "true")
+    monkeypatch.setenv("TARGET_WEEK_KEY", week_key)
+
+    sync.main()
+
+    outputs = json.loads(outputs_p.read_text(encoding="utf-8"))
+    reminder_ids = outputs[week_key].get("reminder_message_ids")
+    assert isinstance(reminder_ids, list) and len(reminder_ids) >= 2
+    assert outputs[week_key]["reminder_message_id"] == reminder_ids[0]


### PR DESCRIPTION
### Motivation
- Prevent GitHub Actions / bots from failing when posting long Discord content by enforcing a hard 2000-character ceiling and readable chunking across all Discord posting paths. 

### Description
- Added a shared, small Discord content-splitting helper `split_discord_content` in `discord_api.py` that enforces a 2000-char hard limit, prefers a ~1900-char target, and splits on readable boundaries (blank lines, list/section boundaries, line breaks, then fallback). 
- Hardened weekly summary/reminder posting in `scripts/sync_weekly_schedule_responses.py` to always split oversized content, then create/edit a sequence of chunk messages idempotently via `upsert_message_chunks`, keeping backward-compatible support for legacy single `*_message_id` and writing `*_message_ids` when chunking. 
- Hardened the Bot Health Report workflow posting (`.github/workflows/bot-health-report.yml`) to split large health reports and post them chunk-by-chunk (adds simple "x/N" prefixes for multi-chunk reports and per-chunk failure handling). 
- Added focused tests and small README operator notes: `tests/test_discord_api_message_splitting.py` and updates to `tests/test_weekly_sync_summary.py` to validate chunking, legacy compatibility and rerun-safe multi-message behavior, and updated README to document the new chunking behavior.

### Testing
- Ran the focused unit/integration test suites; all modified-path tests passed: `pytest -q tests/test_discord_api_message_splitting.py tests/test_weekly_sync_summary.py` (17 passed) and `pytest -q tests/test_evening_winners.py` (24 passed). 
- Also ran the combined suites used during development (`tests/test_discord_api_message_splitting.py tests/test_weekly_sync_summary.py tests/test_evening_winners.py`) and observed all tests covering the changed code passing.
- Tests exercise: short messages remain single-message, long messages are split without exceeding Discord limits, multi-message update/edit remains idempotent, and legacy single-message state remains supported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d870af93cc832699eddf0fdd61f3d8)