### PR TITLE
improve Instagram winner fallback descriptions for legacy state

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 from urllib.parse import quote
@@ -72,7 +73,7 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
         lines.append(SECTION_CONFIG[section])
         for item in items:
             lines.append(item["title"])
-            description = normalize_winner_description_for_message(item.get("description"))
+            description = resolve_winner_description_for_message(item, section=section)
             if description:
                 lines.append(description)
             lines.append(item["url"])
@@ -87,9 +88,9 @@ def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
     return "\n".join(lines).strip()
 
 
-def _build_winner_item_lines(item: dict) -> List[str]:
+def _build_winner_item_lines(item: dict, *, section: str) -> List[str]:
     lines = [item["title"]]
-    description = normalize_winner_description_for_message(item.get("description"))
+    description = resolve_winner_description_for_message(item, section=section)
     if description:
         lines.append(description)
     lines.append(item["url"])
@@ -136,7 +137,7 @@ def build_winners_message_chunks(
         section_header_lines = [SECTION_CONFIG[section]]
         section_full_lines = section_header_lines[:]
         for item in items:
-            section_full_lines.extend(_build_winner_item_lines(item))
+            section_full_lines.extend(_build_winner_item_lines(item, section=section))
 
         if can_fit(current_lines, section_full_lines):
             current_lines.extend(section_full_lines)
@@ -148,7 +149,7 @@ def build_winners_message_chunks(
 
         current_lines.extend(section_header_lines)
         for item in items:
-            item_lines = _build_winner_item_lines(item)
+            item_lines = _build_winner_item_lines(item, section=section)
             if not can_fit(current_lines, item_lines):
                 finalize_current_chunk()
                 current_lines = [SECTION_CONFIG[section]]
@@ -195,6 +196,35 @@ def normalize_winner_description_for_message(
     if len(cleaned) <= max_length:
         return cleaned
     return f"{cleaned[:max_length - 3].rstrip()}..."
+
+
+def build_instagram_legacy_description_fallback(item: dict) -> str:
+    title = str(item.get("title") or "").strip()
+    if title and not re.fullmatch(r"@[A-Za-z0-9._]+", title):
+        return title
+
+    creator = title if title else str(item.get("username") or "").strip()
+    url = str(item.get("url") or "").strip()
+    shortcode_match = re.search(r"instagram\.com/p/([^/?#]+)/?", url)
+    shortcode = shortcode_match.group(1) if shortcode_match else ""
+    if creator:
+        if shortcode:
+            return f"Instagram post from {creator} · post {shortcode} (caption unavailable in legacy state)"
+        return f"Instagram post from {creator} (caption unavailable in legacy state)"
+    return ""
+
+
+def resolve_winner_description_for_message(item: dict, *, section: Optional[str] = None) -> str:
+    normalized_description = normalize_winner_description_for_message(item.get("description"))
+    if normalized_description:
+        return normalized_description
+
+    resolved_section = section or str(item.get("section") or "").strip()
+    if resolved_section != "instagram":
+        return ""
+
+    fallback = build_instagram_legacy_description_fallback(item)
+    return normalize_winner_description_for_message(fallback)
 
 
 def resolve_display_name(user: dict) -> str:

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -318,6 +318,46 @@ def test_build_winners_message_includes_description_when_present():
     assert "u-a" in content
 
 
+def test_instagram_winner_description_present_remains_unchanged():
+    winners_by_section = {
+        "demo_playtest": [],
+        "free": [],
+        "paid": [],
+        "instagram": [
+            {
+                "title": "@creator",
+                "description": "Big co-op giveaway this weekend",
+                "url": "https://www.instagram.com/p/ABC123/",
+                "human_votes": 3,
+                "voter_names": ["Jan", "Jerry", "Akhil"],
+            }
+        ],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert "Big co-op giveaway this weekend" in content
+    assert "caption unavailable in legacy state" not in content
+
+
+def test_instagram_winner_missing_description_uses_fallback():
+    winners_by_section = {
+        "demo_playtest": [],
+        "free": [],
+        "paid": [],
+        "instagram": [
+            {
+                "title": "@creator",
+                "url": "https://www.instagram.com/p/ABC123/",
+                "human_votes": 2,
+                "voter_names": ["Jan", "Jerry"],
+            }
+        ],
+    }
+    content = winners.build_winners_message(winners_by_section)
+    assert "Instagram post from @creator" in content
+    assert "caption unavailable in legacy state" in content
+    assert "ABC123" in content
+
+
 def test_build_winners_message_omits_description_when_absent_or_empty():
     winners_by_section = {
         "demo_playtest": [],
@@ -343,6 +383,7 @@ def test_build_winners_message_omits_description_when_absent_or_empty():
     assert " \n\t " not in content
     assert "Voters — Jan" in content
     assert "Voters — Jerry" in content
+    assert "caption unavailable in legacy state" not in content
 
 
 def test_normalize_winner_description_truncates_long_text():
@@ -419,6 +460,29 @@ def test_build_winners_message_chunks_splits_over_limit_without_exceeding_discor
     assert chunks[0].startswith("🏆 Daily Game Picks — Winners")
     for chunk in chunks:
         assert len(chunk) <= winners.DISCORD_MESSAGE_CHAR_LIMIT
+
+
+def test_build_winners_message_chunks_include_instagram_fallback_for_legacy_records():
+    winners_by_section = {
+        "demo_playtest": [],
+        "free": [],
+        "paid": [],
+        "instagram": [
+            {
+                "title": "@creator",
+                "url": "https://www.instagram.com/p/LEGACY001/",
+                "human_votes": 2,
+                "voter_names": ["Jan", "Jerry"],
+            }
+            for _ in range(20)
+        ],
+    }
+
+    chunks = winners.build_winners_message_chunks(winners_by_section, target_max=400, hard_limit=winners.DISCORD_MESSAGE_CHAR_LIMIT)
+    assert len(chunks) > 1
+    joined = "\n".join(chunks)
+    assert "Instagram post from @creator" in joined
+    assert "caption unavailable in legacy state" in joined
 
 
 def test_build_winners_message_supports_demo_playtest_section():


### PR DESCRIPTION
### Motivation
- Legacy Instagram entries in `discord_daily_posts.json` sometimes lack a persisted `description`/caption which made Instagram winners hard to identify in the evening winners output.
- Provide a low-risk, rendering-only fallback for Instagram winners so legacy records show a concise identifying label without changing selection, dedupe, or network behavior.

### Description
- Add `resolve_winner_description_for_message` which prefers the existing description and only applies a fallback when the section is `instagram` and no real description exists.
- Implement `build_instagram_legacy_description_fallback` to derive a short label from `title`/`username` and extract an Instagram shortcode from the `url` when available, and keep the fallback concise and normalized.
- Wire the resolver into `build_winners_message`, `_build_winner_item_lines`, and the chunking path so single and chunked outputs behave consistently while preserving chunking rules and message limits.
- Keep all changes rendering-only (no network requests, no persisted-state writes, and no changes to winner selection/dedupe/routing logic) and adjust function signatures minimally to pass `section` through.

### Testing
- Ran `pytest -q tests/test_evening_winners.py` which completed successfully with `27 passed`.
- Added focused tests covering an Instagram winner with an existing description, an Instagram winner missing `description` (fallback appears), and chunked output including legacy-like Instagram records.
- Existing winner behavior for non-Instagram sections and other winner pipeline tests remains unchanged and continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8734767508326b9a1fd359f969edb)