### PR TITLE
Fix Discord health report chunk prefix overflow

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -100,9 +100,30 @@ jobs:
           chunks = split_discord_content(report)
 
           if len(chunks) > 1:
+              # Prefixes are added after chunking, so reserve room for them and
+              # re-chunk until every labeled chunk stays within Discord's 2000-char limit.
+              while True:
+                  total_chunks = len(chunks)
+                  max_prefix_len = len(f"📋 Bot Health Report ({total_chunks}/{total_chunks})\n")
+                  reserved_hard_limit = 2000 - max_prefix_len
+                  if reserved_hard_limit <= 0:
+                      raise RuntimeError("Health report chunk label unexpectedly exceeds Discord hard limit")
+
+                  reserved_target_limit = min(1900, reserved_hard_limit)
+                  rechunked = split_discord_content(
+                      report,
+                      target_limit=reserved_target_limit,
+                      hard_limit=reserved_hard_limit,
+                  )
+                  if len(rechunked) == total_chunks:
+                      chunks = rechunked
+                      break
+                  chunks = rechunked
+
               labeled_chunks = []
+              total_chunks = len(chunks)
               for idx, chunk in enumerate(chunks, start=1):
-                  prefix = f"📋 Bot Health Report ({idx}/{len(chunks)})\n"
+                  prefix = f"📋 Bot Health Report ({idx}/{total_chunks})\n"
                   labeled_chunks.append(f"{prefix}{chunk}")
               chunks = labeled_chunks
 


### PR DESCRIPTION
### Motivation
- The health-report workflow added `📋 Bot Health Report (x/N)` prefixes after initial chunking which could push a near-limit chunk past Discord's 2000-character hard limit, causing webhook posts to fail. 
- Apply a minimal, low-risk fix restricted to the inline Python in the workflow so the existing architecture and `split_discord_content` usage remain unchanged.

### Description
- Update `.github/workflows/bot-health-report.yml` to reserve prefix space and re-chunk the report until the chunk count stabilizes, then prepend `📋 Bot Health Report (x/N)` labels so no labeled chunk can exceed Discord's 2000-char limit. 
- The change computes the worst-case prefix length for the current chunk count, adjusts `hard_limit`/`target_limit` when re-splitting via `split_discord_content`, and uses the stabilized chunks for labeling and posting. 
- No other code paths, behaviors, or configuration were modified.

### Testing
- Ran a local Python property check using `discord_api.split_discord_content` that constructs a long report and asserts every labeled chunk length is `<= 2000`, and the assertion passed. 
- Performed a repository search for `split_discord_content` and related Discord posting paths to verify the fix targets the only remaining post-prefix edge case in the health-report workflow, and the inspection confirmed the scope of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d877b2ff308326857fce1bdae7c00d)