### PR TITLE
Add regression tests for health-report chunk label overflow guardrails

### DIFF
--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from discord_api import split_discord_content
 from scripts import build_daily_health_report as report
 
 
@@ -270,6 +271,51 @@ def test_health_report_cleanup_removes_state_sanity_check_references_from_workfl
     assert "## State / Artifact Health" in rendered
     assert "🟢 No state inconsistencies detected" in rendered
     assert "State Sanity Check" not in rendered
+
+
+def _label_health_report_chunks(report_text: str) -> list[str]:
+    chunks = split_discord_content(report_text)
+    if len(chunks) <= 1:
+        return chunks
+
+    while True:
+        total_chunks = len(chunks)
+        max_prefix_len = len(f"📋 Bot Health Report ({total_chunks}/{total_chunks})\n")
+        reserved_hard_limit = 2000 - max_prefix_len
+        if reserved_hard_limit <= 0:
+            raise RuntimeError("Health report chunk label unexpectedly exceeds Discord hard limit")
+
+        reserved_target_limit = min(1900, reserved_hard_limit)
+        rechunked = split_discord_content(
+            report_text,
+            target_limit=reserved_target_limit,
+            hard_limit=reserved_hard_limit,
+        )
+        if len(rechunked) == total_chunks:
+            chunks = rechunked
+            break
+        chunks = rechunked
+
+    total_chunks = len(chunks)
+    return [f"📋 Bot Health Report ({idx}/{total_chunks})\n{chunk}" for idx, chunk in enumerate(chunks, start=1)]
+
+
+def test_health_report_chunk_labels_never_push_labeled_chunks_past_discord_limit():
+    long_report = "\n".join([f"- health line {idx}: {'x' * 180}" for idx in range(1, 260)])
+    labeled_chunks = _label_health_report_chunks(long_report)
+
+    assert len(labeled_chunks) > 1
+    assert all(len(chunk) <= 2000 for chunk in labeled_chunks)
+    assert labeled_chunks[0].startswith("📋 Bot Health Report (1/")
+
+
+def test_health_report_workflow_keeps_post_chunk_label_overflow_guardrails():
+    workflow_file = Path(".github/workflows/bot-health-report.yml").read_text(encoding="utf-8")
+
+    assert "max_prefix_len = len(f\"📋 Bot Health Report ({total_chunks}/{total_chunks})\\n\")" in workflow_file
+    assert "reserved_hard_limit = 2000 - max_prefix_len" in workflow_file
+    assert "if reserved_hard_limit <= 0:" in workflow_file
+    assert "rechunked = split_discord_content(" in workflow_file
 
 
 def test_report_date_new_york_format_is_portable_and_unpadded_day():


### PR DESCRIPTION
### Motivation
- PR #98 added inline workflow logic to avoid pushing labeled health-report chunks past Discord's 2000-char limit, but there was no direct automated regression test protecting that exact post-chunk labeling flow.

### Description
- Added focused tests in `tests/test_build_daily_health_report.py` that simulate the workflow's "label added after chunking" flow via `split_discord_content` and a local helper `_label_health_report_chunks` to assert labeled chunks never exceed Discord's 2000-char hard limit.
- Added a small test that asserts the workflow file `.github/workflows/bot-health-report.yml` still contains the key overflow-guard lines (`max_prefix_len` reservation, `reserved_hard_limit` check, and the `rechunked = split_discord_content(...)` loop).
- This is a test-only change and does not modify production behavior or architecture.

### Testing
- Ran `pytest -q tests/test_build_daily_health_report.py tests/test_discord_api_message_splitting.py`; this run failed due to an existing unrelated test (`test_healthy_state_has_all_clear_message`) returning a pre-existing `weekly.summary_stale` issue, unrelated to the new tests.
- Ran the targeted suite `pytest -q tests/test_build_daily_health_report.py -k "chunk_labels or overflow_guardrails"`; the new regression tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8792015f88326a023a159bec78ba4)