### PR TITLE
add regression test for health report chunk prefix limit

### DIFF
--- a/tests/test_discord_api_message_splitting.py
+++ b/tests/test_discord_api_message_splitting.py
@@ -16,3 +16,36 @@ def test_split_discord_content_splits_long_message_without_exceeding_limit():
     assert all(len(chunk) <= DISCORD_MESSAGE_HARD_LIMIT for chunk in chunks)
     assert "".join(chunks).replace("\n", "") in message.replace("\n", "")
 
+
+def test_health_report_labels_stay_within_discord_limit_after_rechunking():
+    lines = [f"- check-{index:04d}: {'x' * 32}" for index in range(1000)]
+    report = "\n".join(lines)
+    chunks = split_discord_content(report)
+
+    assert len(chunks) > 1
+
+    while True:
+        total_chunks = len(chunks)
+        max_prefix_len = len(f"📋 Bot Health Report ({total_chunks}/{total_chunks})\n")
+        reserved_hard_limit = DISCORD_MESSAGE_HARD_LIMIT - max_prefix_len
+        assert reserved_hard_limit > 0
+
+        reserved_target_limit = min(1900, reserved_hard_limit)
+        rechunked = split_discord_content(
+            report,
+            target_limit=reserved_target_limit,
+            hard_limit=reserved_hard_limit,
+        )
+        if len(rechunked) == total_chunks:
+            chunks = rechunked
+            break
+        chunks = rechunked
+
+    total_chunks = len(chunks)
+    labeled_chunks = [
+        f"📋 Bot Health Report ({index}/{total_chunks})\n{chunk}"
+        for index, chunk in enumerate(chunks, start=1)
+    ]
+
+    assert len(labeled_chunks) > 1
+    assert all(len(chunk) <= DISCORD_MESSAGE_HARD_LIMIT for chunk in labeled_chunks)


### PR DESCRIPTION
### Motivation

* Add a minimal automated regression to cover the edge case fixed in PR #98 so the workflow prefix-reservation re-chunking behavior is tested without touching runtime code.

### Description

* Add `test_health_report_labels_stay_within_discord_limit_after_rechunking` to `tests/test_discord_api_message_splitting.py` which reproduces the workflow logic that reserves room for the `📋 Bot Health Report (x/N)` prefix and re-chunks until the chunk count stabilizes.
* The test uses `split_discord_content` and `DISCORD_MESSAGE_HARD_LIMIT` and asserts that every final labeled chunk remains `<= 2000` characters and is resilient to changes in the number of chunks.

### Testing

* Ran `pytest -q tests/test_discord_api_message_splitting.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87b31b03c83268574a5919879c86b)