### PR TITLE
Add backup cron triggers for winners and weekly scheduling workflows

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -11,6 +11,7 @@ on:
     # GitHub Actions cron uses UTC only (no timezone/DST support).
     # This runs at 23:00 UTC year-round: 7:00 PM in New York during EDT, 6:00 PM during EST.
     - cron: "0 23 * * *"
+    - cron: "10 23 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -9,6 +9,7 @@ on:
         type: string
   schedule:
     - cron: '0 13 * * 6'
+    - cron: '10 13 * * 6'
 
 permissions:
   contents: write


### PR DESCRIPTION
### Motivation
- GitHub Actions scheduled runs have occasionally been missed, so add pragmatic backup cron triggers to hedge against transient scheduler misses. 
- Apply the smallest-risk change that preserves current architecture and posting behavior without adding new runtime subsystems or substantial logic changes.

### Description
- Added a second backup scheduled trigger to `Daily Game Picks Winners` keeping the original `0 23 * * *` and adding `10 23 * * *` as a fallback. 
- Added a second backup scheduled trigger to `Weekly Scheduling Bot` keeping the original `0 13 * * 6` and adding `10 13 * * 6` as a fallback. 
- Verified that `evening_winners.py` already avoids duplicate posts by skipping when winner keys/vote snapshots are unchanged and by editing/reusing prior winners messages, so no runtime guardrail was needed. 
- Verified that `scripts/post_weekly_availability.py` already reuses existing intro/day message IDs for the same `week_key` and logs/skips when everything is already posted, so no runtime guardrail was needed.

### Testing
- Successfully type-checked/compiled the modified runtime scripts with `python -m py_compile evening_winners.py scripts/post_weekly_availability.py` (no errors). 
- Confirmed the workflow YAML edits appear as expected in the repo diff and are syntactically unchanged aside from added cron entries. 
- Attempted YAML parsing validation with `yaml.safe_load` but `PyYAML` is not installed in the environment, so that validation was skipped (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88809c89c8326b8bac37b7ca5fb9f)