### PR TITLE
chore: reduce Steam daily section caps from 10 to 5

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,9 +72,9 @@ HEADERS = {
 # - Paid is strictest overall.
 # Section caps are intentionally independent: Demo/Playtest picks are curated separately
 # from Free Picks so one noisy pool cannot crowd out the other.
-MAX_FREE_POSTS = 10
-MAX_DEMO_PLAYTEST_POSTS = 10
-MAX_PAID_POSTS = 10
+MAX_FREE_POSTS = 5
+MAX_DEMO_PLAYTEST_POSTS = 5
+MAX_PAID_POSTS = 5
 
 PAGE_WINDOW_SIZE = 10
 MAX_PAGE_LIMIT = 50


### PR DESCRIPTION
### Motivation
- Reduce the daily posting caps for the three Steam-driven daily sections to enforce a lower daily volume while keeping all existing selection and posting behavior unchanged.

### Description
- Updated three centralized cap constants in `main.py`: `MAX_DEMO_PLAYTEST_POSTS`, `MAX_FREE_POSTS`, and `MAX_PAID_POSTS` from `10` to `5`, and did not change any routing, scoring, ordering, gating, or posting logic.

### Testing
- Ran the targeted daily-picks unit tests with `pytest -q tests/test_main_daily_picks.py` and observed `24 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88d45182c8326bbd2cdff04f19369)