### PR TITLE
Gate demo/playtest picks on free-to-try access cues

### DIFF
--- a/main.py
+++ b/main.py
@@ -267,6 +267,7 @@ LOW_SIGNAL_KEYWORD_SCORES = {
 }
 
 DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES = {
+    "download demo": 1,
     "demo available": 1,
     "playtest available": 1,
     "request access": 1,
@@ -885,6 +886,11 @@ def score_demo_playtest_friend_group_fit(
     return score, friend_signal_score, freshness_bonus, hits
 
 
+def has_demo_playtest_free_to_try_signal(title: str, description: str, text: str) -> bool:
+    combined = f"{title} {description} {text}".lower()
+    return any(phrase in combined for phrase in DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES)
+
+
 def extract_diversity_tags(title: str, description: str, text: str) -> List[str]:
     combined = f"{title} {description} {text}".lower()
     tag_terms = (
@@ -1278,6 +1284,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     demo_friend_signal_score = 0
     demo_freshness_bonus = 0
     demo_hits: List[str] = []
+    demo_has_free_to_try_signal = True
     if item_type in {"demo", "playtest"}:
         demo_section_score, demo_friend_signal_score, demo_freshness_bonus, demo_hits = score_demo_playtest_friend_group_fit(
             title=title,
@@ -1286,6 +1293,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
             review_sentiment=review_sentiment,
             review_count=review_count,
         )
+        demo_has_free_to_try_signal = has_demo_playtest_free_to_try_signal(title, description, page_text)
 
     total_score = (
         multiplayer_score
@@ -1319,6 +1327,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         # Demo/Playtest has a stricter friend-group gate than full free games:
         # we only post tests that already show multiplayer viability for group nights.
         keep = (
+            demo_has_free_to_try_signal and
             has_multiplayer_signal and
             not rejected and
             not review_gate_failed and
@@ -1348,6 +1357,7 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
         "review_gate_failed": review_gate_failed,
         "demo_friend_signal_score": demo_friend_signal_score,
         "demo_freshness_bonus": demo_freshness_bonus,
+        "demo_has_free_to_try_signal": demo_has_free_to_try_signal,
         "demo_hits": demo_hits,
         "diversity_tags": extract_diversity_tags(title, description, page_text),
     }

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -147,7 +147,7 @@ def test_paid_rejects_unknown_and_mixed(monkeypatch):
 
 
 def test_demo_pick_scoring_tracks_friend_group_signals(monkeypatch):
-    shared = "Multiplayer Online Co-Op up to 6 players party game Very Positive"
+    shared = "Multiplayer Online Co-Op up to 6 players party game Very Positive Download Demo"
     full_html = build_html("Full Game", "friends", shared, "Very Positive")
     demo_html = build_html("Demo Game", "friends", shared, "Very Positive")
     stub_app_pages(monkeypatch, {"701": full_html, "702": demo_html})
@@ -176,7 +176,7 @@ def test_demo_group_play_fit_beats_solo_demo(monkeypatch):
     group_html = build_html(
         "Group Demo",
         "team up with friends",
-        "Multiplayer Online Co-Op up to 6 players squad loot runs progression",
+        "Multiplayer Online Co-Op up to 6 players squad loot runs progression Download Demo",
         "",
     )
     solo_html = build_html(
@@ -218,9 +218,10 @@ def test_demo_legit_playable_cues_help_score(monkeypatch):
 
 
 def test_demo_missing_reviews_more_tolerant_than_free_game(monkeypatch):
-    shared_text = "Multiplayer Online Co-Op up to 6 players party game loot runs"
-    demo_html = build_html("Co-op Demo", "friends", shared_text, "")
-    free_html = build_html("Co-op Full", "friends", shared_text, "")
+    demo_text = "Multiplayer Online Co-Op up to 6 players party game loot runs Demo Available"
+    free_text = "Multiplayer Online Co-Op up to 6 players party game loot runs"
+    demo_html = build_html("Co-op Demo", "friends", demo_text, "")
+    free_html = build_html("Co-op Full", "friends", free_text, "")
     stub_app_pages(monkeypatch, {"750": demo_html, "751": free_html})
 
     demo_item = main.inspect_game("steam_demo", "750")
@@ -232,8 +233,8 @@ def test_demo_missing_reviews_more_tolerant_than_free_game(monkeypatch):
 
 
 def test_demo_newness_bonus_is_small_and_optional(monkeypatch):
-    recent_text = "Release Date: Apr 01, 2026 Multiplayer Online Co-Op up to 6 players"
-    older_text = "Release Date: Jan 01, 2024 Multiplayer Online Co-Op up to 6 players squad loot runs progression"
+    recent_text = "Release Date: Apr 01, 2026 Multiplayer Online Co-Op up to 6 players Request Access"
+    older_text = "Release Date: Jan 01, 2024 Multiplayer Online Co-Op up to 6 players squad loot runs progression Join Playtest"
     recent_html = build_html("Recent Demo", "friends", recent_text, "")
     older_html = build_html("Older Strong Demo", "team up with friends", older_text, "")
     stub_app_pages(monkeypatch, {"760": recent_html, "761": older_html})
@@ -245,6 +246,65 @@ def test_demo_newness_bonus_is_small_and_optional(monkeypatch):
     assert recent_item["demo_freshness_bonus"] >= 1
     assert older_item["demo_freshness_bonus"] == 0
     assert older_item["keep"] is True
+
+
+def test_paid_game_with_download_demo_signal_allowed_in_demo_playtest(monkeypatch):
+    html = build_html(
+        "Paid Game Demo",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players Download Demo",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"900": html})
+
+    item = main.inspect_game("steam_demo", "900")
+    assert item is not None
+    assert item["type"] == "demo"
+    assert item["demo_has_free_to_try_signal"] is True
+    assert item["keep"] is True
+
+
+def test_playtest_request_access_or_join_playtest_allowed(monkeypatch):
+    request_access = build_html(
+        "Squad Test Playtest",
+        "team up",
+        "Multiplayer squad up to 6 players Request Access",
+        "",
+    )
+    join_playtest = build_html(
+        "Squad Test Playtest 2",
+        "team up",
+        "Multiplayer squad up to 6 players Join Playtest",
+        "",
+    )
+    stub_app_pages(monkeypatch, {"901": request_access, "902": join_playtest})
+
+    request_item = main.inspect_game("steam_demo", "901")
+    join_item = main.inspect_game("steam_demo", "902")
+
+    assert request_item is not None and join_item is not None
+    assert request_item["type"] == "playtest"
+    assert join_item["type"] == "playtest"
+    assert request_item["demo_has_free_to_try_signal"] is True
+    assert join_item["demo_has_free_to_try_signal"] is True
+    assert request_item["keep"] is True
+    assert join_item["keep"] is True
+
+
+def test_paid_game_with_demo_wording_but_without_access_signal_excluded(monkeypatch):
+    html = build_html(
+        "Upcoming Paid Demo",
+        "wishlist now",
+        "Multiplayer Online Co-Op up to 6 players demo coming soon",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"903": html})
+
+    item = main.inspect_game("steam_demo", "903")
+    assert item is not None
+    assert item["type"] == "demo"
+    assert item["demo_has_free_to_try_signal"] is False
+    assert item["keep"] is False
 
 
 def test_temporarily_free_bonus_requires_positive_or_better(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure the `demo_playtest` lane only includes demos/playtests that provide real free-to-try access cues (download/demo/playtest access) rather than pages that merely mention "demo" or "playtest." 
- Preserve the existing separation between `demo_playtest` and the `free` lane while reducing false positives from paid/upcoming pages that lack playable access signals.

### Description
- Added `"download demo"` to the `DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES` list so it is recognized as a legitimate free-to-try cue in scoring. (`main.py`).
- Implemented a minimal helper `has_demo_playtest_free_to_try_signal(title, description, text)` that reuses the existing cue list to detect explicit free-to-try/playable access signals. (`main.py`).
- Applied a small gate in `inspect_game(...)` to require `demo_has_free_to_try_signal` for items of type `demo`/`playtest` before they can be kept for the `demo_playtest` section, and exposed `demo_has_free_to_try_signal` on inspected items for diagnostics. (`main.py`).
- Added focused unit tests in `tests/test_main_scoring_model.py` covering: a paid game with a real demo signal, playtests with `Request Access`/`Join Playtest`, and a paid game that mentions demo text without an access signal.

### Testing
- Ran `pytest -q tests/test_main_scoring_model.py`, which completed with `24 passed` and no failures. 
- Only the narrow demo/playtest-related tests were changed/added and they passed, with no other logic/selection architecture modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d898434ad88326a0c8a59e7ead6e39)