### PR TITLE
Add daily picks navigation footer links

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from state_utils import (
 
 WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 STATE_FILE = "seen_ids.json"
 PAGE_STATE_FILE = "page_state.json"
 INSTAGRAM_STATE_FILE = "instagram_seen.json"
@@ -1608,6 +1609,59 @@ def post_message_chunks(chunks: List[str]) -> None:
         sleep_briefly()
 
 
+def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def build_daily_navigation_footer(
+    run_state: dict,
+    guild_id: Optional[str],
+    posted_section_keys: List[str],
+) -> Optional[str]:
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        print("WARN: DISCORD_GUILD_ID missing; skipping daily navigation footer.")
+        return None
+
+    intro_state = run_state.get("intro")
+    if not isinstance(intro_state, dict):
+        print("WARN: intro state missing; skipping daily navigation footer.")
+        return None
+
+    intro_channel_id = intro_state.get("channel_id")
+    intro_message_id = intro_state.get("message_id")
+    if not (isinstance(intro_channel_id, str) and isinstance(intro_message_id, str)):
+        print("WARN: intro message metadata missing; skipping daily navigation footer.")
+        return None
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Picks",
+        "free": "🎮 Free Picks",
+        "paid": "💸 Paid Picks",
+        "instagram": "📸 Creator Picks",
+    }
+    section_headers = run_state.get("section_headers", {})
+    lines = [f"🎯 Intro / Top of Post → {build_discord_message_link(guild_id, intro_channel_id, intro_message_id)}"]
+
+    for section_key in DAILY_SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            print(f"WARN: {section_key} header state missing; skipping daily navigation footer.")
+            return None
+        channel_id = section_state.get("channel_id")
+        message_id = section_state.get("message_id")
+        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
+            print(f"WARN: {section_key} header metadata missing; skipping daily navigation footer.")
+            return None
+        section_label = section_labels.get(section_key)
+        if not section_label:
+            continue
+        lines.append(f"{section_label} → {build_discord_message_link(guild_id, channel_id, message_id)}")
+
+    return "\n".join(lines)
+
+
 def post_daily_pick_messages(
     demo_playtest_items: List[dict],
     free_items: List[dict],
@@ -1691,6 +1745,7 @@ def post_daily_pick_messages(
         "paid": paid_items,
         "instagram": instagram_posts,
     }
+    posted_section_keys = [section_key for section_key in DAILY_SECTION_ORDER if section_items_by_key.get(section_key)]
     section_paid_flags = {"demo_playtest": False, "free": False, "paid": True, "instagram": False}
 
     for section in DAILY_SECTION_CONFIG:
@@ -1765,6 +1820,12 @@ def post_daily_pick_messages(
             else:
                 print(f"WARN: missing metadata for {section_key} item title={title}")
             sleep_briefly()
+
+    footer_state = run_state.setdefault("navigation_footer", {})
+    footer_content = build_daily_navigation_footer(run_state, DISCORD_GUILD_ID, posted_section_keys)
+    if footer_content:
+        post_or_reuse_simple(footer_content, "navigation_footer", footer_state)
+        sleep_briefly()
 
     run_state["completed"] = True
     run_state["completed_at_utc"] = utc_now_iso()

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -276,6 +276,128 @@ def test_daily_sections_post_in_new_order(monkeypatch, tmp_path):
     ]
 
 
+def test_daily_navigation_footer_is_posted_last_with_expected_links(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-08"
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        counter["i"] += 1
+        return {"message_id": f"m-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "guild-1")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages(
+        [{"title": "Demo", "url": "https://store.steampowered.com/app/11", "score": 10}],
+        [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}],
+        [],
+        [],
+    )
+
+    expected_footer = "\n".join(
+        [
+            "🎯 Intro / Top of Post → https://discord.com/channels/guild-1/chan-1/m-1",
+            "🧪 Demo & Playtest Picks → https://discord.com/channels/guild-1/chan-1/m-2",
+            "🎮 Free Picks → https://discord.com/channels/guild-1/chan-1/m-4",
+        ]
+    )
+    assert posted[-1] == expected_footer
+    assert any("Demo Pick #1" in message for message in posted[:-1])
+    assert any("Free Pick #1" in message for message in posted[:-1])
+
+
+def test_daily_navigation_footer_rerun_reuses_existing_message(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-08"
+    initial = {
+        day_key: {
+            "run_state": {
+                "intro": {"message_id": "intro-1", "channel_id": "chan-1"},
+                "section_headers": {"free": {"message_id": "header-free-1", "channel_id": "chan-1"}},
+                "navigation_footer": {"message_id": "footer-1", "channel_id": "chan-1"},
+                "completed": False,
+            },
+            "items": [
+                {
+                    "item_key": main.hashlib.sha256(
+                        "free|steam_free|https://store.steampowered.com/app/12".encode("utf-8")
+                    ).hexdigest()[:16],
+                    "section": "free",
+                    "title": "Free",
+                    "url": "https://store.steampowered.com/app/12",
+                    "message_id": "item-1",
+                    "channel_id": "chan-1",
+                    "source_type": "steam_free",
+                    "posted_at": "2026-04-08T00:00:00+00:00",
+                }
+            ],
+        }
+    }
+    daily_path.write_text(json.dumps(initial), encoding="utf-8")
+    posted = []
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        return {"message_id": "new-message", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient(existing_ids={"intro-1", "header-free-1", "footer-1", "item-1"})
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "guild-1")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
+
+    assert posted == []
+
+
+def test_daily_navigation_footer_skips_safely_when_guild_or_metadata_missing(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-08"
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        counter["i"] += 1
+        if counter["i"] == 2:
+            return {"message_id": f"m-{counter['i']}", "channel_id": None}
+        return {"message_id": f"m-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages([{"title": "Demo", "url": "https://store.steampowered.com/app/11", "score": 10}], [], [], [])
+
+    assert any("Demo Pick #1" in message for message in posted)
+    assert not any("Intro / Top of Post" in message for message in posted)
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"]["completed"] is True
+
+
 def test_daily_section_order_is_product_invariant():
     assert main.DAILY_SECTION_ORDER == ["demo_playtest", "free", "paid", "instagram"]
     assert [entry["header"] for entry in main.DAILY_SECTION_CONFIG] == [


### PR DESCRIPTION
### Motivation
- Provide a small UX improvement so users landing on the newest message can jump directly to the intro or any section header posted that day.
- Keep the change minimal and low-risk by adding only a post-run navigation footer and preserving all existing posting, tracking, rerun, and reaction behavior.

### Description
- Add `DISCORD_GUILD_ID` env usage and a helper `build_discord_message_link(guild_id, channel_id, message_id)` to construct Discord deep links in the `https://discord.com/channels/<guild>/<channel>/<message>` format.
- Add `build_daily_navigation_footer(run_state, guild_id, posted_section_keys)` which builds the footer text including the intro and only the section headers posted that day, and returns `None` to safely skip when guild or metadata is missing.
- Post the footer after all intro/header/item posts in `post_daily_pick_messages(...)`, storing state under `run_state['navigation_footer']` and reusing the existing `post_or_reuse_simple` pattern to preserve rerun/idempotency.
- Do not change section ordering, per-item posting, auto-👍 behavior, `discord_daily_posts.json` tracking, winners logic, selection/routing, or scheduling logic.

### Testing
- Added focused tests in `tests/test_main_daily_picks.py` to cover: footer is posted last with correct links, footer contains intro + sections that were posted, rerun reuses existing footer, and missing guild/metadata safely skips footer.
- Ran `pytest -q tests/test_main_daily_picks.py -k 'daily_navigation_footer or daily_sections_post_in_new_order or daily_pick_rerun_and_partial_recovery'`, which completed successfully: `5 passed, 22 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89bf7adb88326b615fc35bdc54719)