### PR TITLE
Render Discord markdown 'Jump' links in daily navigation footer

### DIFF
--- a/main.py
+++ b/main.py
@@ -1640,7 +1640,9 @@ def build_daily_navigation_footer(
         "instagram": "📸 Creator Picks",
     }
     section_headers = run_state.get("section_headers", {})
-    lines = [f"🎯 Intro / Top of Post → {build_discord_message_link(guild_id, intro_channel_id, intro_message_id)}"]
+    lines = [
+        f"🎯 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})"
+    ]
 
     for section_key in DAILY_SECTION_ORDER:
         if section_key not in posted_section_keys:
@@ -1657,7 +1659,7 @@ def build_daily_navigation_footer(
         section_label = section_labels.get(section_key)
         if not section_label:
             continue
-        lines.append(f"{section_label} → {build_discord_message_link(guild_id, channel_id, message_id)}")
+        lines.append(f"{section_label} → [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
 
     return "\n".join(lines)
 

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -307,9 +307,9 @@ def test_daily_navigation_footer_is_posted_last_with_expected_links(monkeypatch,
 
     expected_footer = "\n".join(
         [
-            "🎯 Intro / Top of Post → https://discord.com/channels/guild-1/chan-1/m-1",
-            "🧪 Demo & Playtest Picks → https://discord.com/channels/guild-1/chan-1/m-2",
-            "🎮 Free Picks → https://discord.com/channels/guild-1/chan-1/m-4",
+            "🎯 Intro / Top of Post → [Jump](https://discord.com/channels/guild-1/chan-1/m-1)",
+            "🧪 Demo & Playtest Picks → [Jump](https://discord.com/channels/guild-1/chan-1/m-2)",
+            "🎮 Free Picks → [Jump](https://discord.com/channels/guild-1/chan-1/m-4)",
         ]
     )
     assert posted[-1] == expected_footer


### PR DESCRIPTION
### Motivation
- Improve UX by rendering footer links as Discord markdown links (`[Jump](...)`) instead of raw URLs while preserving existing footer semantics and behavior.

### Description
- Modify `build_daily_navigation_footer(...)` to format the intro and section lines as `→ [Jump](...)` while keeping `build_discord_message_link(...)` unchanged and preserving section-omission and rerun/idempotency logic; update the focused expectation in `tests/test_main_daily_picks.py` to match the new format.

### Testing
- Ran `pytest -q tests/test_main_daily_picks.py -k navigation_footer` which succeeded with `3 passed, 24 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89dbb2df08326806f40be15e0893d)