### PR TITLE
Wire DISCORD_GUILD_ID into daily workflow run step

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
         run: python main.py


### PR DESCRIPTION
### Motivation
- The daily GitHub Actions job did not pass `DISCORD_GUILD_ID` into the `Run Steam script` step, so `main.py` skipped building/posting the daily navigation footer; adding this env wiring unblocks real workflow runs from rendering/posting the footer assuming the repository secret `DISCORD_GUILD_ID` is set.

### Description
- Inserted a single line `DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}` into the `env` block of the `Run Steam script` step in `/.github/workflows/daily.yml` and left all existing env vars, step order, schedule, and workflow logic unchanged.

### Testing
- Verified the minimal change with `git diff -- .github/workflows/daily.yml`, inspected the modified lines with `nl -ba .github/workflows/daily.yml | sed -n '34,52p'`, and checked repository status with `git status --short` and `git show --stat --oneline -1`, all of which succeeded and show a single insertion to the workflow file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a04a98608326bddf142d51018c6b)