### PR TITLE
Strengthen Instagram creator-pick dedupe keys in daily voting flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,30 @@ INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS = [
     r"\bout\s+now\b",
     r"\blink\s+in\s+bio\b",
 ]
+INSTAGRAM_GAME_KEY_FALLBACK_BOUNDARY_PATTERNS = [
+    r"\bdemo\b",
+    r"\bplaytest\b",
+    r"\bfree\b",
+    r"\bsteam\b",
+    r"\bwishlist\b",
+    r"\bout\s+now\b",
+    r"\blink\s+in\s+bio\b",
+]
+INSTAGRAM_GAME_KEY_GENERIC_PREFIX_TOKENS = {
+    "check",
+    "this",
+    "that",
+    "out",
+    "pick",
+    "picks",
+    "today",
+    "game",
+    "games",
+    "new",
+    "my",
+    "our",
+    "you",
+}
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0"
@@ -1855,6 +1879,13 @@ def _normalize_instagram_game_key_fragment(text: str) -> str:
     return normalized
 
 
+def _is_low_confidence_instagram_title_candidate(key: str) -> bool:
+    tokens = key.split()
+    if len(tokens) > 6:
+        return True
+    return any(token in INSTAGRAM_GAME_KEY_GENERIC_PREFIX_TOKENS for token in tokens)
+
+
 def derive_instagram_game_key(caption: str) -> Optional[str]:
     if not caption:
         return None
@@ -1876,18 +1907,28 @@ def derive_instagram_game_key(caption: str) -> Optional[str]:
                 return key
 
     separator_match = re.search(r"\s[-|:]\s", raw_caption)
-    if not separator_match:
-        return None
+    if separator_match:
+        candidate = raw_caption[:separator_match.start()].strip()
+        key = _normalize_instagram_game_key_fragment(candidate)
+        if key and len(key) >= 3 and re.search(r"[a-z]", key):
+            return key
 
-    candidate = raw_caption[:separator_match.start()].strip()
-    key = _normalize_instagram_game_key_fragment(candidate)
-    if not key:
-        return None
+    boundary_start = None
+    for pattern in INSTAGRAM_GAME_KEY_FALLBACK_BOUNDARY_PATTERNS:
+        match = re.search(pattern, raw_caption, flags=re.IGNORECASE)
+        if not match:
+            continue
+        if boundary_start is None or match.start() < boundary_start:
+            boundary_start = match.start()
 
-    if len(key) < 3 or not re.search(r"[a-z]", key):
-        return None
+    if boundary_start is not None:
+        candidate = raw_caption[:boundary_start].strip(" -|:–—•")
+        key = _normalize_instagram_game_key_fragment(candidate)
+        if key and len(key) >= 3 and re.search(r"[a-z]", key):
+            if not _is_low_confidence_instagram_title_candidate(key):
+                return key
 
-    return key
+    return None
 
 
 def dedupe_instagram_posts(posts: List[dict]) -> List[dict]:

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -215,6 +215,36 @@ def test_dedupe_instagram_posts_keeps_low_confidence_boilerplate_only_captions()
     assert [post["url"] for post in deduped] == ["u1", "u2"]
 
 
+def test_dedupe_instagram_posts_merges_same_game_without_separator_when_boilerplate_differs():
+    posts = [
+        {"username": "creator_a", "caption": "Star Drift free on Steam now", "url": "u1"},
+        {"username": "creator_b", "caption": "STAR DRIFT wishlist link in bio", "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1"]
+
+
+def test_dedupe_instagram_posts_keeps_low_confidence_non_title_prefixes_conservative():
+    posts = [
+        {"username": "creator_a", "caption": "Check this out link in bio", "url": "u1"},
+        {"username": "creator_b", "caption": "Check this out on Steam", "url": "u2"},
+    ]
+
+    deduped = main.dedupe_instagram_posts(posts)
+
+    assert [post["url"] for post in deduped] == ["u1", "u2"]
+
+
+def test_derive_instagram_game_key_extracts_prefix_before_boilerplate_boundary():
+    assert main.derive_instagram_game_key("Neon Harbor wishlist now on steam") == "neon harbor"
+
+
+def test_derive_instagram_game_key_rejects_generic_prefix_candidates():
+    assert main.derive_instagram_game_key("Check this out link in bio") is None
+
+
 def test_instagram_dedupe_debug_summary_counts_and_samples():
     posts = [
         {"username": "creator_a", "caption": '"Nova Hex" - out now', "url": "u1"},


### PR DESCRIPTION
### Motivation
- Instagram creator picks in the DAILY VOTING list should be deduped by underlying game identity so the same game posted by multiple creators is not posted twice. 
- Existing heuristics relied on quoted/bracketed titles or explicit ` - | : ` separators and missed cases where creators used only promo boilerplate words (e.g., “wishlist”, “steam”, “link in bio”).
- The change must be minimal, preserve the current pipeline/section order/limits, and avoid impacting winners logic or posting format.

### Description
- Added a conservative fallback to `derive_instagram_game_key(...)` that finds the earliest promo-boundary phrase from `INSTAGRAM_GAME_KEY_FALLBACK_BOUNDARY_PATTERNS` and treats the caption prefix before that boundary as the candidate title.
- Introduced `_is_low_confidence_instagram_title_candidate(...)` and `INSTAGRAM_GAME_KEY_GENERIC_PREFIX_TOKENS` to reject generic/boilerplate prefixes (e.g., "check this out") and overly long token sequences to avoid false merges.
- Kept existing quoted/bracketed and separator-based extraction logic intact and preserved first-survivor ordering in dedupe behavior.
- Tests updated/added in `tests/test_main_daily_picks.py` to cover the new fallback and conservative behavior, while preserving other Instagram dedupe tests.

### Testing
- Ran focused Instagram tests with `pytest -q tests/test_main_daily_picks.py -k instagram` and observed the Instagram-related tests pass.
- Ran the full daily-picks tests with `pytest -q tests/test_main_daily_picks.py` and observed `31 passed` for that file.
- The added tests specifically validate: same-game collapse across creators with different formatting, same-game collapse when promo boilerplate differs, survival of clearly different games, and conservative behavior for low-confidence captions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a598e2408326889929171a7add27)