### PR TITLE
Fix winners-channel late-vote state updates without cross-day reposts

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -338,6 +338,209 @@ def collect_recent_announced_winner_keys(
     return announced_keys
 
 
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _build_winners_by_section_from_entries(entries: List[dict]) -> Dict[str, List[dict]]:
+    winners_by_section: Dict[str, List[dict]] = {key: [] for key in SECTION_ORDER}
+    for entry in entries:
+        section = str(entry.get("section") or "").strip()
+        if section not in winners_by_section:
+            continue
+        winners_by_section[section].append(
+            {
+                "title": entry.get("title", "Untitled"),
+                "url": entry.get("url", ""),
+                "description": entry.get("description"),
+                "human_votes": _coerce_int(entry.get("human_votes"), 0),
+                "voter_names": entry.get("voter_names", []),
+            }
+        )
+    return winners_by_section
+
+
+def collect_recent_announced_winner_index(
+    daily_posts: Dict[str, dict],
+    *,
+    target_day_key: str,
+    lookback_days: int = WINNERS_LOOKBACK_DAYS,
+) -> Dict[str, dict]:
+    announced_index: Dict[str, dict] = {}
+    for bucket_key in get_lookback_day_keys(target_day_key, lookback_days)[1:]:
+        bucket = daily_posts.get(bucket_key, {})
+        if not isinstance(bucket, dict):
+            continue
+        winners_state = bucket.get("winners_state")
+        if not isinstance(winners_state, dict):
+            continue
+        winner_entries = winners_state.get("winner_entries")
+        if isinstance(winner_entries, list):
+            for entry in winner_entries:
+                if not isinstance(entry, dict):
+                    continue
+                winner_key = str(entry.get("winner_key") or "").strip()
+                if not winner_key or winner_key in announced_index:
+                    continue
+                announced_index[winner_key] = {
+                    "day_key": bucket_key,
+                    "human_votes": _coerce_int(entry.get("human_votes"), 0),
+                    "can_update_state": True,
+                }
+            continue
+
+        winner_keys = winners_state.get("winner_keys")
+        if not isinstance(winner_keys, list):
+            continue
+        winner_vote_counts = winners_state.get("winner_vote_counts")
+        normalized_vote_counts = winner_vote_counts if isinstance(winner_vote_counts, dict) else {}
+        for winner_key in winner_keys:
+            normalized = str(winner_key).strip()
+            if not normalized or normalized in announced_index:
+                continue
+            announced_index[normalized] = {
+                "day_key": bucket_key,
+                "human_votes": _coerce_int(normalized_vote_counts.get(normalized), 0),
+                "can_update_state": False,
+            }
+    return announced_index
+
+
+def update_existing_winner_entry_if_needed(
+    daily_posts: Dict[str, dict],
+    *,
+    key: str,
+    candidate: dict,
+    announced_info: dict,
+) -> bool:
+    if not announced_info.get("can_update_state"):
+        return False
+    if candidate["human_votes"] <= _coerce_int(announced_info.get("human_votes"), 0):
+        return False
+
+    day_key = str(announced_info.get("day_key") or "").strip()
+    if not day_key:
+        return False
+    bucket = daily_posts.get(day_key, {})
+    if not isinstance(bucket, dict):
+        return False
+    winners_state = bucket.get("winners_state")
+    if not isinstance(winners_state, dict):
+        return False
+    winner_entries = winners_state.get("winner_entries")
+    if not isinstance(winner_entries, list):
+        return False
+
+    updated = False
+    for entry in winner_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_key = str(entry.get("winner_key") or "").strip()
+        if entry_key != key:
+            continue
+        entry["section"] = candidate["section"]
+        entry["title"] = candidate["title"]
+        entry["url"] = candidate["url"]
+        entry["description"] = candidate.get("description")
+        entry["human_votes"] = candidate["human_votes"]
+        entry["voter_names"] = candidate["voter_names"]
+        updated = True
+        break
+
+    if not updated:
+        return False
+
+    winners_state["winner_vote_counts"] = {
+        str(entry.get("winner_key") or "").strip(): _coerce_int(entry.get("human_votes"), 0)
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    }
+    winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+    return True
+
+
+def upsert_winners_messages_for_day(
+    client: DiscordClient,
+    *,
+    daily_posts: Dict[str, dict],
+    day_key: str,
+    winners_channel_id: str,
+) -> bool:
+    bucket = daily_posts.get(day_key, {})
+    if not isinstance(bucket, dict):
+        return False
+    winners_state = bucket.get("winners_state")
+    if not isinstance(winners_state, dict):
+        return False
+    winner_entries = winners_state.get("winner_entries")
+    if not isinstance(winner_entries, list):
+        return False
+
+    winners_by_section = _build_winners_by_section_from_entries(winner_entries)
+    messages = build_winners_message_chunks(winners_by_section)
+    previous_message_ids = normalize_winners_message_ids(winners_state)
+    if not previous_message_ids:
+        return False
+    try:
+        for index, previous_message_id in enumerate(previous_message_ids):
+            client.get_message(
+                winners_channel_id,
+                previous_message_id,
+                context=f"verify winners message {index + 1}/{len(previous_message_ids)} for {day_key}",
+            )
+    except DiscordMessageNotFoundError:
+        previous_message_ids = []
+        print(f"RECOVER: stale/deleted winners message for {day_key}; posting replacement")
+
+    resulting_message_ids: List[str] = []
+    if previous_message_ids:
+        for index, message in enumerate(messages):
+            if index < len(previous_message_ids):
+                message_id = previous_message_ids[index]
+                client.edit_message(
+                    winners_channel_id,
+                    message_id,
+                    message,
+                    context=f"edit winners message chunk {index + 1}/{len(messages)} for {day_key}",
+                )
+                resulting_message_ids.append(message_id)
+            else:
+                resulting_message_ids.append(post_winners_message(client, winners_channel_id, message))
+        for stale_index in range(len(messages), len(previous_message_ids)):
+            stale_message_id = previous_message_ids[stale_index]
+            client.edit_message(
+                winners_channel_id,
+                stale_message_id,
+                "_(Winners content moved to earlier message chunks.)_",
+                context=f"clear stale winners chunk {stale_index + 1}/{len(previous_message_ids)} for {day_key}",
+            )
+        winners_state["last_action"] = "edit"
+        winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+        print(f"EDIT: updated winners messages for {day_key} (message_ids={resulting_message_ids})")
+    else:
+        resulting_message_ids = [post_winners_message(client, winners_channel_id, message) for message in messages]
+        winners_state["last_action"] = "create"
+        winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
+        print(f"CREATE: posted winners messages for {day_key} (message_ids={resulting_message_ids})")
+
+    winners_state["message_id"] = resulting_message_ids[0]
+    winners_state["message_ids"] = resulting_message_ids
+    winners_state["winner_keys"] = sorted(
+        str(entry.get("winner_key") or "").strip()
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    )
+    winners_state["winner_vote_counts"] = {
+        str(entry.get("winner_key") or "").strip(): _coerce_int(entry.get("human_votes"), 0)
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    }
+    return True
+
+
 def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
     payload = client.post_message(channel_id, message, context="post winners message")
     message_id = str(payload.get("id", ""))
@@ -445,15 +648,26 @@ def main() -> None:
             if existing is None or candidate["human_votes"] > existing["human_votes"]:
                 deduped_winners[dedupe_key] = candidate
 
-        previously_announced_winner_keys = collect_recent_announced_winner_keys(
+        recently_announced_winner_index = collect_recent_announced_winner_index(
             daily_posts,
             target_day_key=day_key,
         )
-        deduped_winners = {
-            key: winner
-            for key, winner in deduped_winners.items()
-            if key not in previously_announced_winner_keys
-        }
+        prior_days_requiring_updates: set[str] = set()
+        new_winners_by_key: Dict[str, dict] = {}
+        for key, winner in deduped_winners.items():
+            announced_info = recently_announced_winner_index.get(key)
+            if not announced_info:
+                new_winners_by_key[key] = winner
+                continue
+            updated = update_existing_winner_entry_if_needed(
+                daily_posts,
+                key=key,
+                candidate=winner,
+                announced_info=announced_info,
+            )
+            if updated:
+                prior_days_requiring_updates.add(str(announced_info.get("day_key") or "").strip())
+        deduped_winners = new_winners_by_key
 
         for winner in deduped_winners.values():
             section = winner["section"]
@@ -491,22 +705,76 @@ def main() -> None:
             for key, value in previous_winner_vote_counts.items()
             if str(key)
         }
+        previous_winner_entries = winners_state.get("winner_entries")
+        has_previous_winner_entries = isinstance(previous_winner_entries, list)
 
         if not current_winner_keys and not previous_message_ids:
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            if prior_days_requiring_updates:
+                save_discord_daily_posts(daily_posts)
             print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
             return
 
         keys_unchanged = sorted(str(key) for key in previous_winner_keys) == current_winner_keys
         vote_counts_unchanged = normalized_previous_vote_counts == current_winner_vote_counts
+        current_winner_entries = [
+            {
+                "winner_key": key,
+                "section": deduped_winners[key]["section"],
+                "title": deduped_winners[key]["title"],
+                "url": deduped_winners[key]["url"],
+                "description": deduped_winners[key].get("description"),
+                "human_votes": deduped_winners[key]["human_votes"],
+                "voter_names": deduped_winners[key]["voter_names"],
+            }
+            for key in current_winner_keys
+        ]
 
         if keys_unchanged and not had_previous_vote_snapshot:
             winners_state["winner_vote_counts"] = current_winner_vote_counts
+            winners_state["winner_entries"] = current_winner_entries
             winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
             save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key} (backfilled vote snapshot)")
             return
 
+        if keys_unchanged and vote_counts_unchanged and has_previous_winner_entries:
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            if prior_days_requiring_updates:
+                save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no newly eligible winners for {day_key}")
+            return
+
         if keys_unchanged and vote_counts_unchanged:
+            winners_state["winner_entries"] = current_winner_entries
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key}")
             return
 
@@ -557,6 +825,14 @@ def main() -> None:
         winners_state["message_ids"] = resulting_message_ids
         winners_state["winner_keys"] = current_winner_keys
         winners_state["winner_vote_counts"] = current_winner_vote_counts
+        winners_state["winner_entries"] = current_winner_entries
+        for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+            upsert_winners_messages_for_day(
+                client,
+                daily_posts=daily_posts,
+                day_key=prior_day,
+                winners_channel_id=winners_channel_id,
+            )
         save_discord_daily_posts(daily_posts)
 
 

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -607,6 +607,60 @@ def test_cross_day_winner_suppression_hides_previously_announced_game(monkeypatc
     assert state["winner_keys"] == ["fresh-win"]
 
 
+def test_cross_day_late_vote_updates_previously_announced_winner_without_repost(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        "2026-04-07": {
+            "items": [],
+            "winners_state": {
+                "message_id": "w-prev",
+                "message_ids": ["w-prev"],
+                "winner_keys": ["shared-dupe"],
+                "winner_vote_counts": {"shared-dupe": 2},
+                "winner_entries": [
+                    {
+                        "winner_key": "shared-dupe",
+                        "section": "free",
+                        "title": "Original Winner",
+                        "url": "shared-dupe",
+                        "human_votes": 2,
+                        "voter_names": ["jan", "jerry"],
+                    }
+                ],
+            },
+        },
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Same Game Repost", "url": "shared-dupe", "channel_id": "c", "message_id": "m-late"},
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    payloads = {
+        "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 4}]},
+    }
+    reaction_users = {
+        "m-late": [{"id": "bot-1"}, {"id": "u1", "username": "jan"}, {"id": "u2", "username": "jerry"}, {"id": "u3", "username": "akhil"}],
+    }
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert fake.posts == []
+    assert len(fake.edits) == 1
+    assert fake.edits[0][1] == "w-prev"
+    assert "Same Game Repost" in fake.edits[0][2]
+    assert "👍 3 votes" in fake.edits[0][2]
+
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    prior_state = updated["2026-04-07"]["winners_state"]
+    assert prior_state["winner_vote_counts"]["shared-dupe"] == 3
+    assert prior_state["winner_entries"][0]["human_votes"] == 3
+    assert updated[day_key].get("winners_state", {}) == {}
+
+
 def test_cross_day_winner_suppression_checks_multiple_recent_days(monkeypatch, tmp_path):
     day_key = "2026-04-08"
     path = tmp_path / "daily.json"
@@ -675,6 +729,38 @@ def test_cross_day_suppression_keeps_legacy_states_readable(monkeypatch, tmp_pat
 
     assert len(fake.posts) == 1
     assert "Legacy Compatible Winner" in fake.posts[0][1]
+
+
+def test_cross_day_late_vote_with_legacy_state_still_suppresses_without_breaking(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        "2026-04-07": {
+            "items": [],
+            "winners_state": {
+                "message_id": "w-prev",
+                "winner_keys": ["shared-dupe"],
+                "winner_vote_counts": {"shared-dupe": 2},
+            },
+        },
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Same Game Repost", "url": "shared-dupe", "channel_id": "c", "message_id": "m-late"},
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    payloads = {"m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 4}]}}
+    reaction_users = {"m-late": [{"id": "bot-1"}, {"id": "u1", "username": "jan"}, {"id": "u2", "username": "jerry"}, {"id": "u3", "username": "akhil"}]}
+    fake = FakeDiscordClient(payloads, reaction_users)
+    _patch_common(monkeypatch, path, fake, day_key)
+
+    winners.main()
+
+    assert fake.posts == []
+    assert fake.edits == []
+    state = json.loads(path.read_text(encoding="utf-8"))["2026-04-07"]["winners_state"]
+    assert state["winner_vote_counts"]["shared-dupe"] == 2
 
 
 def test_winners_main_chunked_create_posts_multiple_messages(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Close a gap where winners were suppressed across days but lacked a persistent cross-day winner identity, causing late votes to produce duplicate later-day winner entries instead of updating the original announcement. 

### Description
- Add a persistent per-winner snapshot list `winners_state.winner_entries` to store `winner_key`, `section`, `title`, `url`, `description`, `human_votes`, and `voter_names` for each announced winner. 
- Build a recent announced-winner index (`collect_recent_announced_winner_index`) that reads both new `winner_entries` (updateable) and legacy `winner_keys`/`winner_vote_counts` (suppression-only) for backward compatibility. 
- When a later run sees higher votes for an already-announced winner, update that prior day’s `winner_entries` (via `update_existing_winner_entry_if_needed`) and refresh the prior day’s winners message(s) in place (via `upsert_winners_messages_for_day`) instead of creating a new winner entry on the current day. 
- Preserve existing same-day idempotency, stale/deleted message recovery, section ordering, and Instagram dedupe behavior while backfilling `winner_entries` for current-day snapshots. 
- Files changed: `evening_winners.py` (logic and helpers added) and `tests/test_evening_winners.py` (two focused tests added). 

### Testing
- Ran `pytest -q tests/test_evening_winners.py` and all tests passed: `29 passed`. 
- Added tests: `test_cross_day_late_vote_updates_previously_announced_winner_without_repost` and `test_cross_day_late_vote_with_legacy_state_still_suppresses_without_breaking`, which validate cross-day late-vote updates without reposts and legacy-state compatibility respectively. 
- Existing winners behavior tests (same-day no-op/edit, multi-message state, stale/deleted recovery, and cross-day suppression) continue to pass, proving no regression to prior invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a70796648326ba894cba6484ee0a)