### PR TITLE
Add target-day date line to daily picks navigation footer

### DIFF
--- a/main.py
+++ b/main.py
@@ -1561,6 +1561,11 @@ def get_target_day_key() -> str:
     return manual_day
 
 
+def format_daily_picks_footer_date(target_day_key: str) -> str:
+    target_day = datetime.fromisoformat(target_day_key).date()
+    return f"{target_day:%A, %B} {target_day.day}, {target_day:%Y}"
+
+
 def add_thumbs_up_reaction(client: DiscordClient, channel_id: str, message_id: str) -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
@@ -1640,6 +1645,7 @@ def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) 
 def build_daily_navigation_footer(
     run_state: dict,
     guild_id: Optional[str],
+    target_day_key: str,
     posted_section_keys: List[str],
 ) -> Optional[str]:
     if not isinstance(guild_id, str) or not guild_id.strip():
@@ -1665,7 +1671,9 @@ def build_daily_navigation_footer(
     }
     section_headers = run_state.get("section_headers", {})
     lines = [
-        f"🎯 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})"
+        f"🗓️ Daily Picks for {format_daily_picks_footer_date(target_day_key)}",
+        "",
+        f"🎯 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
     ]
 
     for section_key in DAILY_SECTION_ORDER:
@@ -1848,7 +1856,7 @@ def post_daily_pick_messages(
             sleep_briefly()
 
     footer_state = run_state.setdefault("navigation_footer", {})
-    footer_content = build_daily_navigation_footer(run_state, DISCORD_GUILD_ID, posted_section_keys)
+    footer_content = build_daily_navigation_footer(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
     if footer_content:
         post_or_reuse_simple(footer_content, "navigation_footer", footer_state)
         sleep_briefly()

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -337,6 +337,8 @@ def test_daily_navigation_footer_is_posted_last_with_expected_links(monkeypatch,
 
     expected_footer = "\n".join(
         [
+            "🗓️ Daily Picks for Wednesday, April 8, 2026",
+            "",
             "🎯 Intro / Top of Post → [Jump](https://discord.com/channels/guild-1/chan-1/m-1)",
             "🧪 Demo & Playtest Picks → [Jump](https://discord.com/channels/guild-1/chan-1/m-2)",
             "🎮 Free Picks → [Jump](https://discord.com/channels/guild-1/chan-1/m-4)",
@@ -394,6 +396,33 @@ def test_daily_navigation_footer_rerun_reuses_existing_message(monkeypatch, tmp_
     main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
 
     assert posted == []
+
+
+def test_daily_navigation_footer_uses_target_day_override_for_display(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-10"
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        counter["i"] += 1
+        return {"message_id": f"m-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "guild-1")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
+
+    assert posted[-1].splitlines()[0] == "🗓️ Daily Picks for Friday, April 10, 2026"
 
 
 def test_daily_navigation_footer_skips_safely_when_guild_or_metadata_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Make the daily navigation footer show which day's picks users are viewing while preserving rerun stability and existing footer behavior.

### Description
- Add `format_daily_picks_footer_date(target_day_key)` to render a human-friendly date string from the existing target-day key.
- Change `build_daily_navigation_footer` to accept `target_day_key` and prepend the first lines:
  - `🗓️ Daily Picks for <Weekday, Month D, YYYY>`
  - a single blank line
  and then the unchanged jump-link list; jump labels, Discord markdown links, section order, and posting order remain the same.
- Pass the existing `day_key` (from `get_target_day_key()`) into footer generation so the displayed date is derived from the daily picks target day (including manual override), ensuring rerun-safe, stable display.
- No changes were made to winners logic, Instagram dedupe logic, or section ordering.

### Testing
- Ran `pytest -q tests/test_main_daily_picks.py`, all tests passed (`32 passed`).
- Updated tests to assert the footer includes the formatted target date as the first line, that a blank line separates the date from jump links, that missing sections are omitted cleanly, that rerun reuse behavior remains idempotent, and that a manual `DAILY_DATE_UTC` override is reflected in the displayed footer date; these tests succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a9a11dd48326b97ee0c10410c304)