### PR TITLE
Persist winners state updates from evening workflow runs

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -14,7 +14,7 @@ on:
     - cron: "10 23 * * *"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   run-evening-winners:
@@ -38,6 +38,16 @@ jobs:
           DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python evening_winners.py
+
+      - name: Save updated winners state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
+
+          git diff --cached --quiet || git commit -m "Update winners state"
+          git push
 
       - name: Notify Discord health monitor on failure
         if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}


### PR DESCRIPTION
### Motivation
- PR #108 added persistent cross-day winner identity and late-vote update behavior by writing `winner_entries` into `discord_daily_posts.json`, but the evening workflow was not persisting that file back to the repo, preventing cross-run persistence. 
- The goal is to minimally enable the evening workflow to save updated `discord_daily_posts.json` without changing any winners logic, schedules, or environment variables. 

### Description
- Change workflow permissions from `contents: read` to `contents: write` in `.github/workflows/evening-winners.yml`. 
- Add a `Save updated winners state` step after `Run evening winners script` that configures the git user/email to `github-actions[bot]`, conditionally stages `discord_daily_posts.json` if present, commits only when there are staged changes with the message `Update winners state`, and pushes the commit. 
- The new step mirrors the existing state-save pattern used in `.github/workflows/daily.yml` and does not modify any other workflow behavior. 

### Testing
- Ran the existing test suite for winners logic with `python -m pytest tests/test_evening_winners.py -q`. 
- All tests passed: `29 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8accc787c8326a725e424cc4a6600)