### PR TITLE
Rebase state commits before workflow push

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -53,7 +53,10 @@ jobs:
           git add seen_ids.json page_state.json instagram_seen.json
           if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
 
-          git diff --cached --quiet || git commit -m "Update bot state"
+          if ! git diff --cached --quiet; then
+            git commit -m "Update bot state"
+            git pull --rebase origin main
+          fi
           git push
 
       - name: Notify Discord health monitor on failure

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -46,7 +46,10 @@ jobs:
 
           if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
 
-          git diff --cached --quiet || git commit -m "Update winners state"
+          if ! git diff --cached --quiet; then
+            git commit -m "Update winners state"
+            git pull --rebase origin main
+          fi
           git push
 
       - name: Notify Discord health monitor on failure


### PR DESCRIPTION
### Motivation
- The scheduled workflows create a local state commit but can fail on `git push` with a non-fast-forward error when `origin/main` advances during the run (`[rejected] main -> main (fetch first)`).
- The intent is to allow the workflow-created state commit to land while preserving all existing workflow behavior and commit metadata.

### Description
- In `Save updated state files` in `.github/workflows/daily.yml` run `git pull --rebase origin main` immediately after creating the local `Update bot state` commit and before `git push`, while keeping the existing git config, staged file list, and commit message unchanged. 
- Applied the identical minimal change to `Save updated winners state` in `.github/workflows/evening-winners.yml` so the same race is handled there.
- The change only rebases when a commit was actually created (`if ! git diff --cached --quiet`), preserving current behavior when there are no staged changes.
- No other workflow behavior, schedule, environment variables, commit messages, or Python runtime code were modified.

### Testing
- There are no automated tests for these workflow push steps, and none were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b20dbf288326abc7458b9bd19000)