### PR TITLE
Fix Gaming Library reaction UX, mention parsing, and idempotent promotions

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -13,6 +13,8 @@ from state_utils import load_json_object, save_json_object_atomic
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 THUMBS_UP_EMOJI = "👍"
 THUMBS_UP_EMOJI_ENCODED = quote(THUMBS_UP_EMOJI, safe="")
+BOOKMARK_EMOJI = "🔖"
+BOOKMARK_EMOJI_ENCODED = quote(BOOKMARK_EMOJI, safe="")
 
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
@@ -255,6 +257,21 @@ def format_voter_names_for_message(names: List[str]) -> str:
 
 def pick_winners_channel_id(items: List[dict]) -> Optional[str]:
     return DISCORD_WINNERS_CHANNEL_ID
+
+
+def add_bookmark_reaction(
+    client: DiscordClient,
+    *,
+    channel_id: str,
+    message_id: str,
+    context: str,
+) -> None:
+    client.put_reaction(
+        channel_id,
+        message_id,
+        BOOKMARK_EMOJI_ENCODED,
+        context=context,
+    )
 
 
 def fetch_human_voter_names(
@@ -644,9 +661,23 @@ def main() -> None:
                 "description": item.get("description"),
                 "human_votes": human_votes,
                 "voter_names": voter_names,
+                "channel_id": str(channel_id),
+                "message_id": str(message_id),
             }
             if existing is None or candidate["human_votes"] > existing["human_votes"]:
                 deduped_winners[dedupe_key] = candidate
+
+        for winner_key, winner in deduped_winners.items():
+            winner_channel_id = str(winner.get("channel_id") or "").strip()
+            winner_message_id = str(winner.get("message_id") or "").strip()
+            if not winner_channel_id or not winner_message_id:
+                continue
+            add_bookmark_reaction(
+                client,
+                channel_id=winner_channel_id,
+                message_id=winner_message_id,
+                context=f"add bookmark reaction for winner {winner_key}",
+            )
 
         recently_announced_winner_index = collect_recent_announced_winner_index(
             daily_posts,

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -29,6 +29,7 @@ STATUS_TO_EMOJI = {
 }
 EMOJI_TO_STATUS = {emoji: status for status, emoji in STATUS_TO_EMOJI.items()}
 EMOJI_TO_STATUS_ENCODED = {quote(emoji, safe=""): status for emoji, status in EMOJI_TO_STATUS.items()}
+MENTION_USER_ID_PATTERN = re.compile(r"^<@!?(\d+)>$")
 
 
 def utc_now_iso() -> str:
@@ -137,6 +138,15 @@ def assign_user(game: Dict[str, Any], user_id: str, status: str = STATUS_ACTIVE)
     game["updated_at_utc"] = utc_now_iso()
 
 
+def assign_user_if_changed(game: Dict[str, Any], user_id: str, status: str = STATUS_ACTIVE) -> bool:
+    assignments = game.setdefault("assignments", {})
+    existing = assignments.get(str(user_id))
+    if isinstance(existing, dict) and str(existing.get("status") or "") == status:
+        return False
+    assign_user(game, user_id, status)
+    return True
+
+
 def unassign_user(game: Dict[str, Any], user_id: str) -> None:
     assignments = game.setdefault("assignments", {})
     assignments.pop(str(user_id), None)
@@ -243,6 +253,14 @@ def post_daily_library_reminder(
         message_id = str(payload.get("id") or "")
         if not message_id:
             raise RuntimeError("Discord response missing id for gaming library message")
+        if message.get("type") == "game":
+            for emoji in ("✅", "⏸️", "❌"):
+                client.put_reaction(
+                    str(payload.get("channel_id") or channel_id),
+                    message_id,
+                    quote(emoji, safe=""),
+                    context=f"add gaming library status reaction {emoji} for {day_key}",
+                )
         posted[message.get("identity_key", message["type"])] = {"message_id": message_id, "channel_id": str(payload.get("channel_id") or channel_id)}
 
     day_entry["messages"] = posted
@@ -316,6 +334,8 @@ def sync_promotions_from_winners(state: Dict[str, Any], daily_posts: Dict[str, A
                 "description": winner.get("description") or source_item.get("description"),
                 "daily_section": source_item.get("section"),
             }
+            identity_key = build_identity_key(canonical_name, url)
+            game_preexisted = identity_key in state.setdefault("games", {})
             game = ensure_game_entry(
                 state,
                 canonical_name=canonical_name,
@@ -324,12 +344,27 @@ def sync_promotions_from_winners(state: Dict[str, Any], daily_posts: Dict[str, A
                 source_section=str(source_item.get("section") or ""),
                 source_metadata=source_metadata,
             )
+            assignment_changed = False
             for user_id in human_user_ids:
-                assign_user(game, user_id, STATUS_ACTIVE)
+                if assign_user_if_changed(game, user_id, STATUS_ACTIVE):
+                    assignment_changed = True
             game["archived"] = False
             refresh_archive_state(game)
-            promoted_count += 1
+            if (not game_preexisted) or assignment_changed:
+                promoted_count += 1
     return promoted_count
+
+
+def normalize_user_id_token(user_id_like: str) -> str:
+    token = str(user_id_like or "").strip()
+    if not token:
+        return ""
+    if token.isdigit():
+        return token
+    mention_match = MENTION_USER_ID_PATTERN.fullmatch(token)
+    if mention_match:
+        return mention_match.group(1)
+    return ""
 
 
 def sync_statuses_from_library_posts(state: Dict[str, Any], client: DiscordClient, bot_user_id: Optional[str]) -> int:
@@ -443,7 +478,12 @@ def manage_library(
     state_path: str = GAMING_LIBRARY_FILE,
 ) -> bool:
     state = load_gaming_library(state_path)
-    user_ids = [uid for uid in (user_ids or []) if uid]
+    normalized_user_ids: List[str] = []
+    for user_id_like in user_ids or []:
+        normalized = normalize_user_id_token(str(user_id_like))
+        if normalized:
+            normalized_user_ids.append(normalized)
+    user_ids = normalized_user_ids
 
     if operation == "add":
         game = ensure_game_entry(

--- a/scripts/manage_gaming_library.py
+++ b/scripts/manage_gaming_library.py
@@ -1,12 +1,29 @@
 import argparse
 
-from gaming_library import manage_library
+from gaming_library import manage_library, normalize_user_id_token
 
 
 def _parse_users(value: str) -> list[str]:
     if not value:
         return []
-    return [token.strip() for token in value.split(",") if token.strip()]
+    normalized: list[str] = []
+    invalid_tokens: list[str] = []
+    for token in value.split(","):
+        raw = token.strip()
+        if not raw:
+            continue
+        user_id = normalize_user_id_token(raw)
+        if user_id:
+            normalized.append(user_id)
+        else:
+            invalid_tokens.append(raw)
+    if invalid_tokens:
+        invalid_display = ", ".join(invalid_tokens)
+        raise RuntimeError(
+            "Unsupported --user-ids token(s): "
+            f"{invalid_display}. Use raw IDs or <@123...>/<@!123...> mention format."
+        )
+    return normalized
 
 
 if __name__ == "__main__":

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -22,6 +22,7 @@ class FakeDiscordClient:
         self.posts = []
         self.edits = []
         self.reaction_calls = []
+        self.put_reactions = []
 
     def get_message(self, channel_id, message_id, *, context):
         if self.stale_winner_id and message_id == self.stale_winner_id:
@@ -45,6 +46,9 @@ class FakeDiscordClient:
         mid = f"w-{len(self.posts)+1}"
         self.posts.append((channel_id, content, mid))
         return {"id": mid}
+
+    def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
+        self.put_reactions.append((channel_id, message_id, encoded_emoji, context))
 
 
 def _patch_common(monkeypatch, path, fake, day_key):
@@ -127,6 +131,8 @@ def test_winner_vote_rules_and_message_content(monkeypatch, tmp_path):
     assert "Voters — Jan, LateFan" in content
     assert "Voters — Jerry, akhil_user" in content
     assert "Bot Name" not in content
+    assert ("c", "m-late", winners.BOOKMARK_EMOJI_ENCODED, "add bookmark reaction for winner shared-dupe") in fake.put_reactions
+    assert ("c", "m-paid", winners.BOOKMARK_EMOJI_ENCODED, "add bookmark reaction for winner paid-win") in fake.put_reactions
 
 
 def test_winners_rerun_skip_then_edit_for_newly_eligible_winner(monkeypatch, tmp_path):

--- a/tests/test_gaming_library.py
+++ b/tests/test_gaming_library.py
@@ -1,10 +1,12 @@
 import gaming_library as lib
+from scripts.manage_gaming_library import _parse_users
 
 
 class FakeDiscordClient:
     def __init__(self, reactions=None):
         self.reactions = reactions or {}
         self.posts = []
+        self.put_reactions = []
 
     def get_reaction_users(self, channel_id, message_id, encoded_emoji, *, context, limit=100, after=None):
         return self.reactions.get((channel_id, message_id, encoded_emoji), [])
@@ -13,6 +15,9 @@ class FakeDiscordClient:
         message_id = f"m-{len(self.posts)+1}"
         self.posts.append((channel_id, content, context))
         return {"id": message_id, "channel_id": channel_id}
+
+    def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
+        self.put_reactions.append((channel_id, message_id, encoded_emoji, context))
 
 
 def _seed_daily_posts_with_winner():
@@ -69,10 +74,12 @@ def test_promotions_do_not_duplicate_library_entries_for_same_game():
         reactions={("daily-1", "item-1", lib.BOOKMARK_EMOJI_ENCODED): [{"id": "u-1"}]}
     )
 
-    lib.sync_promotions_from_winners(state, daily_posts, client, bot_user_id=None)
-    lib.sync_promotions_from_winners(state, daily_posts, client, bot_user_id=None)
+    first_promotions = lib.sync_promotions_from_winners(state, daily_posts, client, bot_user_id=None)
+    second_promotions = lib.sync_promotions_from_winners(state, daily_posts, client, bot_user_id=None)
 
     assert list(state["games"].keys()) == ["steam:12345"]
+    assert first_promotions == 1
+    assert second_promotions == 0
 
 
 def test_manual_add_with_canonical_name_and_instagram_metadata_preserved():
@@ -145,8 +152,33 @@ def test_daily_library_post_records_message_metadata_and_status_sync():
     assert posted is True
     assert state["daily_posts"]["2026-04-10"]["completed"] is True
     assert len(client.posts) == 2
+    assert client.put_reactions == [
+        ("lib-chan", "m-2", lib.quote("✅", safe=""), "add gaming library status reaction ✅ for 2026-04-10"),
+        ("lib-chan", "m-2", lib.quote("⏸️", safe=""), "add gaming library status reaction ⏸️ for 2026-04-10"),
+        ("lib-chan", "m-2", lib.quote("❌", safe=""), "add gaming library status reaction ❌ for 2026-04-10"),
+    ]
 
     updates = lib.sync_statuses_from_library_posts(state, client, bot_user_id=None)
     assert updates >= 2
     assert game["assignments"]["u1"]["status"] == lib.STATUS_ACTIVE
     assert game["assignments"]["u2"]["status"] == lib.STATUS_DROPPED
+
+
+def test_manage_library_normalizes_mention_user_ids(tmp_path):
+    state = {"games": {}, "daily_posts": {}, "version": 1}
+    path = tmp_path / "gaming_library.json"
+    lib.save_gaming_library(state, str(path))
+    lib.manage_library(
+        operation="add",
+        canonical_name="Mention Parse",
+        url="https://store.steampowered.com/app/777/mention/",
+        user_ids=["<@123>", "<@!456>", "789"],
+        state_path=str(path),
+    )
+    updated = lib.load_gaming_library(str(path))
+    assignments = updated["games"]["steam:777"]["assignments"]
+    assert sorted(assignments.keys()) == ["123", "456", "789"]
+
+
+def test_manage_script_user_parser_accepts_discord_mentions():
+    assert _parse_users("123,<@456>,<@!789>") == ["123", "456", "789"]


### PR DESCRIPTION
### Motivation

- The Gaming Library feature was missing key UX niceties for reaction-driven flows and had a promotion count that could inflate on repeated syncs.
- Daily per-game posts needed seeded status reactions so users can update their library status via reactions, and winners-origin posts needed the bookmark opt-in reaction to be auto-added.
- Manual management UX should accept common Discord mention formats instead of only raw IDs.

### Description

- Auto-seed status reactions (`✅`, `⏸️`, `❌`) on each per-game message posted by `post_daily_library_reminder`, while explicitly skipping the header message (changes in `gaming_library.py`).
- Auto-add the bookmark reaction (`🔖`) to eligible winners source posts in the winners flow by seeding reactions on deduped winner source messages (changes in `evening_winners.py`).
- Make promotion sync idempotent by only incrementing the promotion count when a game is newly created or at least one assignment actually changes during promotion; introduced `assign_user_if_changed` to detect real changes (changes in `gaming_library.py`).
- Normalize mention-format user input for manual management via `normalize_user_id_token`, support raw IDs plus `<@123...>` and `<@!123...>` formats, wire it into `manage_library`, and update the CLI parser `_parse_users` to validate/normalize tokens (changes in `gaming_library.py` and `scripts/manage_gaming_library.py`).
- Added/updated focused tests to cover bookmark seeding, status reaction seeding, header exclusion, mention-format parsing, and promotion idempotency (changes in `tests/test_gaming_library.py` and `tests/test_evening_winners.py`).

### Testing

- Ran the focused test suite with `pytest -q tests/test_gaming_library.py tests/test_evening_winners.py` and all tests passed.
- Test summary: `37 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ba048c8083268613d269bffcc607)