### PR TITLE
Set PYTHONPATH in Gaming Library workflows to fix ModuleNotFoundError

### DIFF
--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Post daily gaming library reminder
         env:
+          PYTHONPATH: .
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
           LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}

--- a/.github/workflows/gaming-library-manage.yml
+++ b/.github/workflows/gaming-library-manage.yml
@@ -77,6 +77,8 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Apply manual gaming library operation
+        env:
+          PYTHONPATH: .
         run: |
           python scripts/manage_gaming_library.py \
             --operation "${{ inputs.operation }}" \

--- a/.github/workflows/gaming-library-sync.yml
+++ b/.github/workflows/gaming-library-sync.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Sync gaming library from Discord reactions
         env:
+          PYTHONPATH: .
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         run: python scripts/sync_gaming_library.py
 


### PR DESCRIPTION
### Motivation
- The workflows running `python scripts/...` failed with `ModuleNotFoundError: No module named 'gaming_library'` because the repo root is not guaranteed to be on Python's import path when executing from the `scripts/` directory. 
- Apply a minimal, production-safe fix so root-level imports like `from gaming_library import ...` resolve in GitHub Actions without changing Python package layout or workflow behavior.

### Description
- Added `PYTHONPATH: .` to the environment of the script execution steps that run `python scripts/post_daily_gaming_library.py`, `python scripts/sync_gaming_library.py`, and `python scripts/manage_gaming_library.py ...` so the repository root is explicitly on `sys.path` in Actions. 
- Files modified: `.github/workflows/gaming-library-daily.yml`, `.github/workflows/gaming-library-sync.yml`, and `.github/workflows/gaming-library-manage.yml`.
- Preserved all schedules, inputs, secrets, state commit/push and rebase logic, and Discord-related code; no refactor of Python modules was performed.

### Testing
- Confirmed the failure mode by running the scripts from `scripts/` without root on the path, which produced `ModuleNotFoundError: No module named 'gaming_library'` (failure observed). 
- Verified that running the scripts from the repository root succeeds (imports resolve) by executing the script modules directly from the repo root (success). 
- Verified that adding the repo root to the import path (`PYTHONPATH=.` / `PYTHONPATH=..` when running from `scripts/`) fixes all three scripts (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c3be5af08326b643f4343bb9dcaa)