### PR TITLE
Make gaming library daily reminder idempotent for same-day reruns

### DIFF
--- a/gaming_library.py
+++ b/gaming_library.py
@@ -242,18 +242,47 @@ def post_daily_library_reminder(
 ) -> bool:
     daily_posts = state.setdefault("daily_posts", {})
     day_entry = daily_posts.setdefault(day_key, {})
-    if bool(day_entry.get("completed")):
-        print(f"SKIP: library daily reminder already completed for {day_key}")
-        return False
+    existing_messages = day_entry.get("messages")
+    if not isinstance(existing_messages, dict):
+        existing_messages = {}
 
     messages = build_daily_library_messages(state, day_key)
-    posted: Dict[str, Dict[str, str]] = {}
+    reconciled_messages: Dict[str, Dict[str, str]] = {}
+    changed = False
     for message in messages:
-        payload = client.post_message(channel_id, message["content"], context=f"post gaming library {message['type']} for {day_key}")
+        message_key = str(message.get("identity_key", message["type"]))
+        existing_info = existing_messages.get(message_key)
+        existing_channel_id = str((existing_info or {}).get("channel_id") or channel_id).strip()
+        existing_message_id = str((existing_info or {}).get("message_id") or "").strip()
+
+        payload: Dict[str, Any]
+        is_new_message = False
+        if existing_message_id:
+            try:
+                payload = client.edit_message(
+                    existing_channel_id,
+                    existing_message_id,
+                    message["content"],
+                    context=f"edit gaming library {message['type']} for {day_key}",
+                )
+                changed = True
+            except DiscordMessageNotFoundError:
+                payload = client.post_message(
+                    channel_id,
+                    message["content"],
+                    context=f"repost missing gaming library {message['type']} for {day_key}",
+                )
+                is_new_message = True
+                changed = True
+        else:
+            payload = client.post_message(channel_id, message["content"], context=f"post gaming library {message['type']} for {day_key}")
+            is_new_message = True
+            changed = True
+
         message_id = str(payload.get("id") or "")
         if not message_id:
             raise RuntimeError("Discord response missing id for gaming library message")
-        if message.get("type") == "game":
+        if message.get("type") == "game" and is_new_message:
             for emoji in ("✅", "⏸️", "❌"):
                 client.put_reaction(
                     str(payload.get("channel_id") or channel_id),
@@ -261,12 +290,12 @@ def post_daily_library_reminder(
                     quote(emoji, safe=""),
                     context=f"add gaming library status reaction {emoji} for {day_key}",
                 )
-        posted[message.get("identity_key", message["type"])] = {"message_id": message_id, "channel_id": str(payload.get("channel_id") or channel_id)}
+        reconciled_messages[message_key] = {"message_id": message_id, "channel_id": str(payload.get("channel_id") or channel_id)}
 
-    day_entry["messages"] = posted
+    day_entry["messages"] = reconciled_messages
     day_entry["completed"] = True
     day_entry["completed_at_utc"] = utc_now_iso()
-    return True
+    return changed
 
 
 def _build_winner_identity_key(item: Dict[str, Any]) -> str:

--- a/tests/test_gaming_library.py
+++ b/tests/test_gaming_library.py
@@ -6,7 +6,9 @@ class FakeDiscordClient:
     def __init__(self, reactions=None):
         self.reactions = reactions or {}
         self.posts = []
+        self.edits = []
         self.put_reactions = []
+        self.not_found_edits = set()
 
     def get_reaction_users(self, channel_id, message_id, encoded_emoji, *, context, limit=100, after=None):
         return self.reactions.get((channel_id, message_id, encoded_emoji), [])
@@ -18,6 +20,12 @@ class FakeDiscordClient:
 
     def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
         self.put_reactions.append((channel_id, message_id, encoded_emoji, context))
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        if (channel_id, message_id) in self.not_found_edits:
+            raise lib.DiscordMessageNotFoundError("not found")
+        self.edits.append((channel_id, message_id, content, context))
+        return {"id": message_id, "channel_id": channel_id}
 
 
 def _seed_daily_posts_with_winner():
@@ -183,6 +191,76 @@ def test_daily_library_post_records_message_metadata_and_status_sync():
     assert updates >= 2
     assert game["assignments"]["u1"]["status"] == lib.STATUS_ACTIVE
     assert game["assignments"]["u2"]["status"] == lib.STATUS_DROPPED
+
+
+def test_daily_library_rerun_after_promotions_reuses_header_and_adds_missing_games():
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    client = FakeDiscordClient()
+
+    first_posted = lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+
+    assert first_posted is True
+    assert len(client.posts) == 1
+    assert "No active library games for today" in client.posts[0][1]
+
+    game = lib.ensure_game_entry(state, canonical_name="Core Keeper", url="https://store.steampowered.com/app/1621690/")
+    lib.assign_user(game, "u1", lib.STATUS_ACTIVE)
+
+    second_posted = lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+
+    assert second_posted is True
+    assert len(client.posts) == 2
+    assert len(client.edits) == 1
+    edited_header = client.edits[0]
+    assert edited_header[1] == "m-1"
+    assert "React on each game" in edited_header[2]
+    assert state["daily_posts"]["2026-04-10"]["messages"]["header"]["message_id"] == "m-1"
+    assert "steam:1621690" in state["daily_posts"]["2026-04-10"]["messages"]
+    assert client.put_reactions == [
+        ("lib-chan", "m-2", lib.quote("✅", safe=""), "add gaming library status reaction ✅ for 2026-04-10"),
+        ("lib-chan", "m-2", lib.quote("⏸️", safe=""), "add gaming library status reaction ⏸️ for 2026-04-10"),
+        ("lib-chan", "m-2", lib.quote("❌", safe=""), "add gaming library status reaction ❌ for 2026-04-10"),
+    ]
+
+
+def test_daily_library_rerun_updates_existing_game_message_without_duplicate_post():
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    game = lib.ensure_game_entry(state, canonical_name="Status Game", url="https://store.steampowered.com/app/200/status/")
+    lib.assign_user(game, "u1", lib.STATUS_ACTIVE)
+    client = FakeDiscordClient()
+
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+    assert len(client.posts) == 2
+    assert len(client.put_reactions) == 3
+
+    lib.set_user_status(game, "u1", lib.STATUS_PAUSED)
+    posted_again = lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+
+    assert posted_again is True
+    assert len(client.posts) == 2
+    assert len(client.put_reactions) == 3
+    assert len(client.edits) == 2
+    game_edit = client.edits[1]
+    assert game_edit[1] == "m-2"
+    assert "(paused)" in game_edit[2]
+
+
+def test_daily_library_reruns_converge_without_duplicate_headers_or_games():
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    game = lib.ensure_game_entry(state, canonical_name="Converge", url="https://store.steampowered.com/app/300/converge/")
+    lib.assign_user(game, "u1", lib.STATUS_ACTIVE)
+    client = FakeDiscordClient()
+
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+
+    assert len(client.posts) == 2
+    assert len(client.edits) == 4
+    messages = state["daily_posts"]["2026-04-10"]["messages"]
+    assert sorted(messages.keys()) == ["header", "steam:300"]
+    assert messages["header"]["message_id"] == "m-1"
+    assert messages["steam:300"]["message_id"] == "m-2"
 
 
 def test_manage_library_normalizes_mention_user_ids(tmp_path):


### PR DESCRIPTION
### Motivation
- The previous `completed` guard in `post_daily_library_reminder` acted as a hard terminal state for the whole day and prevented legitimate same-day updates (e.g., the empty-header case where `Daily Reminder` runs before `Sync` and later promotions are ignored). 

### Description
- Replace the rigid early-return with reconciliation logic that reads `daily_posts[day_key]["messages"]`, attempts to `edit_message` existing header/game messages, and `post_message` only when a stored message is missing. 
- Seed status reactions only for newly created game messages and write back a single `messages` map per day so message IDs are reused when possible. 
- Preserve the header + per-game message structure and continue to set `day_entry["completed"]` and `completed_at_utc`, while returning a `changed` boolean to indicate whether the run made modifications. 
- Add support to the test fake Discord client for `edit_message` and add focused tests in `tests/test_gaming_library.py` that exercise empty-first-run then same-day promotions, header reuse, adding missing game messages without duplicates, updating existing game messages, and repeated reruns converging to a stable state. 

### Testing
- Ran `pytest -q tests/test_gaming_library.py` and the suite passed: `12 passed`.
- The new rerun-safety tests and all existing gaming library tests succeeded locally with the updated `gaming_library.py` and `tests/test_gaming_library.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c85887a8832682dd777ddc950864)