### PR TITLE
Support force-refresh same-day reconciliation for daily picks posts

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,11 @@ on:
         description: "Optional UTC date key (YYYY-MM-DD) for manual rerun state targeting"
         required: false
         type: string
+      force_refresh_same_day:
+        description: "When true, reconcile/edit same-day Discord posts instead of skipping completed runs"
+        required: false
+        default: false
+        type: boolean
   schedule:
     # GitHub Actions cron uses UTC only (no timezone/DST support).
     # This runs at 13:00 UTC year-round: 9:00 AM in New York during EDT, 8:00 AM during EST.
@@ -43,6 +48,7 @@ jobs:
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
+          FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
         run: python main.py
 
       - name: Save updated state files
@@ -67,13 +73,16 @@ jobs:
           JOB_NAME: run-script
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc || '' }}
+          FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
         run: |
           payload="$(python - <<'PY'
           import json
           import os
 
           target = os.environ.get("DAILY_DATE_UTC")
+          force = str(os.environ.get("FORCE_REFRESH_SAME_DAY", "")).strip().lower() in {"1", "true", "yes", "on"}
           details = f"daily_date_utc={target}" if target else "daily_date_utc=(default)"
+          details = f"{details}, force_refresh_same_day={'true' if force else 'false'}"
           print(json.dumps({
               "content": (
                   "🔴 XiannGPT Bot Failure\n\n"

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ INSTAGRAM_STATE_FILE = "instagram_seen.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
+FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 
 INSTAGRAM_CREATORS = [
@@ -1561,6 +1562,19 @@ def get_target_day_key() -> str:
     return manual_day
 
 
+def get_force_refresh_same_day() -> bool:
+    raw = (os.getenv(FORCE_REFRESH_SAME_DAY_ENV, "") or "").strip().lower()
+    if not raw:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(
+        f"{FORCE_REFRESH_SAME_DAY_ENV} must be one of: true/false, 1/0, yes/no, on/off"
+    )
+
+
 def format_daily_picks_footer_date(target_day_key: str) -> str:
     target_day = datetime.fromisoformat(target_day_key).date()
     return f"{target_day:%A, %B} {target_day.day}, {target_day:%Y}"
@@ -1701,6 +1715,8 @@ def post_daily_pick_messages(
     free_items: List[dict],
     paid_items: List[dict],
     instagram_posts: List[dict],
+    *,
+    force_refresh_same_day: bool = False,
 ) -> None:
     if not (demo_playtest_items or free_items or paid_items or instagram_posts):
         return
@@ -1725,10 +1741,12 @@ def post_daily_pick_messages(
     run_state.setdefault("section_headers", {})
     run_state["last_attempt_at_utc"] = utc_now_iso()
 
-    if bool(run_state.get("completed")):
-        print(f"SKIP: daily picks already completed for {day_key}; rerun protection active")
+    if bool(run_state.get("completed")) and not force_refresh_same_day:
+        print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")
         save_discord_daily_posts(daily_posts)
         return
+    if bool(run_state.get("completed")) and force_refresh_same_day:
+        print(f"REFRESH: daily picks already completed for {day_key}; force_refresh_same_day=true so reconciling posts")
 
     discord_client: Optional[DiscordClient] = None
     if token_available:
@@ -1741,23 +1759,42 @@ def post_daily_pick_messages(
         )
         discord_client = DiscordClient(session)
 
-    def post_or_reuse_simple(message: str, state_key: str, state_obj: dict) -> None:
+    def post_or_reconcile_simple(message: str, state_key: str, state_obj: dict) -> None:
         existing_message_id = state_obj.get("message_id")
         existing_channel_id = state_obj.get("channel_id")
+        should_attempt_edit = bool(force_refresh_same_day)
         if (
             token_available
             and discord_client
             and isinstance(existing_message_id, str)
             and isinstance(existing_channel_id, str)
-            and message_exists(
+        ):
+            if should_attempt_edit:
+                try:
+                    payload = discord_client.edit_message(
+                        existing_channel_id,
+                        existing_message_id,
+                        message,
+                        context=f"edit {state_key} for {day_key}",
+                    )
+                    state_obj["message_id"] = str(payload.get("id") or existing_message_id)
+                    state_obj["channel_id"] = str(payload.get("channel_id") or existing_channel_id)
+                    state_obj["posted_at_utc"] = utc_now_iso()
+                    print(f"REFRESH: updated {state_key} for {day_key} (message_id={state_obj['message_id']})")
+                    save_discord_daily_posts(daily_posts)
+                    return
+                except DiscordMessageNotFoundError:
+                    print(f"RECOVER: stale/deleted {state_key} for {day_key}; posting replacement")
+                except Exception as error:
+                    print(f"WARN: failed to edit {state_key} for {day_key}: {error}; falling back to create")
+            elif message_exists(
                 discord_client,
                 existing_channel_id,
                 existing_message_id,
                 context=f"verify {state_key} for {day_key}",
-            )
-        ):
-            print(f"REUSE: {state_key} for {day_key} (message_id={existing_message_id})")
-            return
+            ):
+                print(f"REUSE: {state_key} for {day_key} (message_id={existing_message_id})")
+                return
 
         metadata = post_to_discord_with_metadata(message, capture_metadata=token_available)
         if metadata and metadata.get("message_id"):
@@ -1770,7 +1807,7 @@ def post_daily_pick_messages(
         save_discord_daily_posts(daily_posts)
 
     intro_state = run_state.setdefault("intro", {})
-    post_or_reuse_simple("🎯 Daily Picks — vote with 👍 on your favorites", "intro", intro_state)
+    post_or_reconcile_simple("🎯 Daily Picks — vote with 👍 on your favorites", "intro", intro_state)
     sleep_briefly()
 
     section_items_by_key = {
@@ -1793,7 +1830,7 @@ def post_daily_pick_messages(
 
         section_headers = run_state.setdefault("section_headers", {})
         section_state = section_headers.setdefault(section_key, {})
-        post_or_reuse_simple(header_message, f"{section_key}_header", section_state)
+        post_or_reconcile_simple(header_message, f"{section_key}_header", section_state)
         sleep_briefly()
 
         existing_items = day_entry.get("items")
@@ -1810,31 +1847,57 @@ def post_daily_pick_messages(
                 None,
             )
 
+            content = (
+                format_instagram_item_message(item, idx)
+                if section_key == "instagram"
+                else format_steam_item_message(item, idx, paid=is_paid, demo_playtest=(section_key == "demo_playtest"))
+            )
+            metadata = None
+            is_new_message = False
             if (
                 token_available
                 and discord_client
                 and isinstance(existing_record, dict)
                 and isinstance(existing_record.get("channel_id"), str)
                 and isinstance(existing_record.get("message_id"), str)
-                and message_exists(
-                    discord_client,
-                    existing_record["channel_id"],
-                    existing_record["message_id"],
-                    context=f"verify {section_key} item for {day_key}",
-                )
             ):
-                print(f"REUSE: {section_key} item {title} for {day_key}")
-                continue
+                existing_channel_id = str(existing_record["channel_id"])
+                existing_message_id = str(existing_record["message_id"])
+                if force_refresh_same_day:
+                    try:
+                        payload = discord_client.edit_message(
+                            existing_channel_id,
+                            existing_message_id,
+                            content,
+                            context=f"edit {section_key} item {title} for {day_key}",
+                        )
+                        metadata = {
+                            "message_id": str(payload.get("id") or existing_message_id),
+                            "channel_id": str(payload.get("channel_id") or existing_channel_id),
+                        }
+                        print(f"REFRESH: updated {section_key} item {title} for {day_key}")
+                    except DiscordMessageNotFoundError:
+                        print(f"RECOVER: stale/deleted {section_key} item {title} for {day_key}; posting replacement")
+                    except Exception as error:
+                        print(
+                            f"WARN: failed to edit {section_key} item {title} for {day_key}: {error}; "
+                            "falling back to create"
+                        )
+                elif message_exists(
+                    discord_client,
+                    existing_channel_id,
+                    existing_message_id,
+                    context=f"verify {section_key} item for {day_key}",
+                ):
+                    metadata = {"message_id": existing_message_id, "channel_id": existing_channel_id}
+                    print(f"REUSE: {section_key} item {title} for {day_key}")
 
-            content = (
-                format_instagram_item_message(item, idx)
-                if section_key == "instagram"
-                else format_steam_item_message(item, idx, paid=is_paid, demo_playtest=(section_key == "demo_playtest"))
-            )
-            metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
+            if metadata is None:
+                metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
+                is_new_message = True
             if token_available and metadata and metadata.get("message_id") and metadata.get("channel_id"):
                 try:
-                    if discord_client:
+                    if discord_client and is_new_message:
                         add_thumbs_up_reaction(discord_client, metadata["channel_id"], metadata["message_id"])
                 except Exception as e:
                     print(f"ADD REACTION FAILED: title={title} | error={e}")
@@ -1850,7 +1913,10 @@ def post_daily_pick_messages(
                     channel_id=metadata["channel_id"],
                     description=item.get("caption") if section_key == "instagram" else item.get("description"),
                 )
-                print(f"CREATE: posted {section_key} item {title} for {day_key}")
+                if is_new_message:
+                    print(f"CREATE: posted {section_key} item {title} for {day_key}")
+                else:
+                    print(f"REUSE: persisted existing {section_key} item {title} for {day_key}")
             else:
                 print(f"WARN: missing metadata for {section_key} item title={title}")
             sleep_briefly()
@@ -1858,7 +1924,7 @@ def post_daily_pick_messages(
     footer_state = run_state.setdefault("navigation_footer", {})
     footer_content = build_daily_navigation_footer(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
     if footer_content:
-        post_or_reuse_simple(footer_content, "navigation_footer", footer_state)
+        post_or_reconcile_simple(footer_content, "navigation_footer", footer_state)
         sleep_briefly()
 
     run_state["completed"] = True
@@ -2242,7 +2308,16 @@ def main():
         f"kept={instagram_debug['deduped_count']} "
         f"removed={instagram_debug['removed_count']}"
     )
-    post_daily_pick_messages(demo_playtest_items, free_items, paid_items, instagram_posts)
+    force_refresh_same_day = get_force_refresh_same_day()
+    if force_refresh_same_day:
+        print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
+    post_daily_pick_messages(
+        demo_playtest_items,
+        free_items,
+        paid_items,
+        instagram_posts,
+        force_refresh_same_day=force_refresh_same_day,
+    )
 
     if not demo_playtest_items and not free_items and not paid_items:
         print("No qualifying games found from Steam.")

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -8,6 +8,7 @@ class FakeDiscordClient:
         self.existing_ids = set(existing_ids or [])
         self.stale_ids = set(stale_ids or [])
         self.reactions = []
+        self.edits = []
 
     def get_message(self, channel_id, message_id, *, context):
         if message_id in self.stale_ids:
@@ -15,6 +16,13 @@ class FakeDiscordClient:
         if message_id in self.existing_ids:
             return {"id": message_id}
         raise RuntimeError("missing")
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        if message_id in self.stale_ids:
+            raise main.DiscordMessageNotFoundError("gone")
+        self.existing_ids.add(message_id)
+        self.edits.append((channel_id, message_id, content, context))
+        return {"id": message_id, "channel_id": channel_id}
 
     def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
         self.reactions.append((channel_id, message_id, encoded_emoji))
@@ -396,6 +404,106 @@ def test_daily_navigation_footer_rerun_reuses_existing_message(monkeypatch, tmp_
     main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
 
     assert posted == []
+
+
+def test_daily_completed_run_skips_without_force_refresh(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-08"
+    daily_path.write_text(json.dumps({day_key: {"run_state": {"completed": True}}}), encoding="utf-8")
+    posted = []
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda message, capture_metadata=False: posted.append(message))
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
+
+    assert posted == []
+
+
+def test_daily_force_refresh_reconciles_same_day_without_duplicates(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-08"
+    free_item_key = main.hashlib.sha256("free|steam_free|https://store.steampowered.com/app/12".encode("utf-8")).hexdigest()[:16]
+    initial = {
+        day_key: {
+            "run_state": {
+                "intro": {"message_id": "intro-1", "channel_id": "chan-1"},
+                "section_headers": {"free": {"message_id": "header-free-1", "channel_id": "chan-1"}},
+                "navigation_footer": {"message_id": "footer-1", "channel_id": "chan-1"},
+                "completed": True,
+            },
+            "items": [
+                {
+                    "item_key": free_item_key,
+                    "section": "free",
+                    "title": "Free",
+                    "url": "https://store.steampowered.com/app/12",
+                    "description": "old description",
+                    "message_id": "item-1",
+                    "channel_id": "chan-1",
+                    "source_type": "steam_free",
+                    "posted_at": "2026-04-08T00:00:00+00:00",
+                }
+            ],
+        }
+    }
+    daily_path.write_text(json.dumps(initial), encoding="utf-8")
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        posted.append(message)
+        counter["i"] += 1
+        return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient(existing_ids={"intro-1", "header-free-1", "footer-1", "item-1"})
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "guild-1")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [
+        {
+            "title": "Free",
+            "url": "https://store.steampowered.com/app/12",
+            "description": "new description",
+            "score": 10,
+        },
+        {
+            "title": "Free New",
+            "url": "https://store.steampowered.com/app/13",
+            "description": "new item",
+            "score": 9,
+        },
+    ]
+    main.post_daily_pick_messages([], free_items, [], [], force_refresh_same_day=True)
+
+    assert len(posted) == 1
+    assert len(fake_client.edits) == 4  # intro + header + existing free item + footer
+    assert len(fake_client.reactions) == 1  # only brand-new item gets 👍
+
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    items = saved[day_key]["items"]
+    assert len(items) == 2
+    updated_existing = next(item for item in items if item["item_key"] == free_item_key)
+    assert updated_existing["description"] == "new description"
+
+    edits_after_first = len(fake_client.edits)
+    reactions_after_first = len(fake_client.reactions)
+    main.post_daily_pick_messages([], free_items, [], [], force_refresh_same_day=True)
+
+    assert len(posted) == 1
+    assert len(fake_client.edits) == edits_after_first + 5  # intro + header + two items + footer
+    assert len(fake_client.reactions) == reactions_after_first
+    saved_after_second = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert len(saved_after_second[day_key]["items"]) == 2
 
 
 def test_daily_navigation_footer_uses_target_day_override_for_display(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation

- Scheduled daily runs must keep rerun protection to avoid spam, but manual same-day reruns should be able to reconcile and refresh Discord posts.
- The existing early-return on `run_state["completed"] == True` prevented legitimate manual refreshes from updating messages.

### Description

- Add a workflow `workflow_dispatch` input `force_refresh_same_day` (boolean) and wire it to runtime env `FORCE_REFRESH_SAME_DAY` in `.github/workflows/daily.yml`.
- Add `FORCE_REFRESH_SAME_DAY_ENV` and `get_force_refresh_same_day()` boolean parsing in `main.py` with strict normalization and validation.
- Extend `post_daily_pick_messages(...)` to accept `force_refresh_same_day` and keep scheduled rerun protection while allowing manual reconciliation when forced.
- Implement reconciliation logic: attempt to `edit_message` for intro, section headers, items, and footer when `force_refresh_same_day=true`, fall back to repost when messages are stale/missing, and reuse verified messages otherwise; preserve one intro, optional section headers, one message per game, and one footer architecture.
- Ensure only brand-new item posts get the automatic thumbs-up reaction; edited or reused messages do not get an extra 👍.
- Improve logs to clearly distinguish skipped runs, refreshed updates, created messages, reused messages, and recovery (stale→repost) paths.
- Update tests and fake Discord client to cover edit paths and the new behavior; touched files: `main.py`, `.github/workflows/daily.yml`, `tests/test_main_daily_picks.py`.

### Testing

- Ran unit tests: `pytest -q tests/test_main_daily_picks.py` and all tests passed (`34 passed`).
- New/modified tests cover: scheduled rerun skip, manual `force_refresh_same_day=true` reconciliation, no duplicate intro/header/footer messages, adding new same-day items, updating existing items, and idempotent repeated reruns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2c91b6808326a519a957be2565ff)