### PR TITLE
Add lightweight debug summary for daily Discord workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -46,6 +46,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_DEBUG_CHANNEL_ID: ${{ secrets.DISCORD_DEBUG_CHANNEL_ID }}
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from state_utils import (
 WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+DISCORD_DEBUG_CHANNEL_ID = os.getenv("DISCORD_DEBUG_CHANNEL_ID")
 STATE_FILE = "seen_ids.json"
 PAGE_STATE_FILE = "page_state.json"
 INSTAGRAM_STATE_FILE = "instagram_seen.json"
@@ -1126,6 +1127,43 @@ def export_daily_debug_summary(
         print(f"WARN: failed to write debug summary ({path}): {e}")
 
 
+def post_discord_debug_summary(
+    day_key: str,
+    run_counts: Dict[str, int],
+    rerun_protection_active: bool,
+    force_refresh_same_day: bool,
+) -> None:
+    """Post a compact debug summary message to DISCORD_DEBUG_CHANNEL_ID after a daily workflow run."""
+    if not DISCORD_DEBUG_CHANNEL_ID or not DISCORD_BOT_TOKEN:
+        return
+    try:
+        day_label = datetime.strptime(day_key, "%Y-%m-%d").strftime("%Y-%m-%d (%a)")
+    except ValueError:
+        day_label = day_key
+    created = run_counts.get("created", 0)
+    updated = run_counts.get("updated", 0)
+    reused = run_counts.get("reused", 0)
+    skipped = run_counts.get("skipped", 0)
+    lines = [
+        f"🛠 Debug | Daily Picks | {day_label}",
+        f"Created: {created} | Updated: {updated} | Reused: {reused} | Skipped: {skipped}",
+        f"Rerun protection: {'active' if rerun_protection_active else 'inactive'}"
+        + (" | Force refresh: on" if force_refresh_same_day else ""),
+    ]
+    content = "\n".join(lines)
+    try:
+        session = requests.Session()
+        session.headers.update({
+            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+            "Content-Type": "application/json",
+        })
+        client = DiscordClient(session)
+        client.post_message(DISCORD_DEBUG_CHANNEL_ID, content, context="daily picks debug summary")
+        print(f"DEBUG SUMMARY: posted to channel {DISCORD_DEBUG_CHANNEL_ID}")
+    except Exception as e:
+        print(f"WARN: failed to post debug summary to Discord: {e}")
+
+
 def score_quality_refinements(
     title: str,
     description: str,
@@ -1717,9 +1755,11 @@ def post_daily_pick_messages(
     instagram_posts: List[dict],
     *,
     force_refresh_same_day: bool = False,
-) -> None:
+) -> Tuple[Dict[str, int], bool]:
+    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active)."""
+    run_counts: Dict[str, int] = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
     if not (demo_playtest_items or free_items or paid_items or instagram_posts):
-        return
+        return run_counts, False
 
     token_available = bool(DISCORD_BOT_TOKEN)
     daily_posts = load_discord_daily_posts() if token_available else {}
@@ -1744,7 +1784,7 @@ def post_daily_pick_messages(
     if bool(run_state.get("completed")) and not force_refresh_same_day:
         print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")
         save_discord_daily_posts(daily_posts)
-        return
+        return run_counts, True
     if bool(run_state.get("completed")) and force_refresh_same_day:
         print(f"REFRESH: daily picks already completed for {day_key}; force_refresh_same_day=true so reconciling posts")
 
@@ -1781,6 +1821,7 @@ def post_daily_pick_messages(
                     state_obj["channel_id"] = str(payload.get("channel_id") or existing_channel_id)
                     state_obj["posted_at_utc"] = utc_now_iso()
                     print(f"REFRESH: updated {state_key} for {day_key} (message_id={state_obj['message_id']})")
+                    run_counts["updated"] += 1
                     save_discord_daily_posts(daily_posts)
                     return
                 except DiscordMessageNotFoundError:
@@ -1794,6 +1835,7 @@ def post_daily_pick_messages(
                 context=f"verify {state_key} for {day_key}",
             ):
                 print(f"REUSE: {state_key} for {day_key} (message_id={existing_message_id})")
+                run_counts["reused"] += 1
                 return
 
         metadata = post_to_discord_with_metadata(message, capture_metadata=token_available)
@@ -1802,8 +1844,10 @@ def post_daily_pick_messages(
             state_obj["channel_id"] = metadata.get("channel_id")
             state_obj["posted_at_utc"] = utc_now_iso()
             print(f"CREATE: posted {state_key} for {day_key} (message_id={metadata['message_id']})")
+            run_counts["created"] += 1
         else:
             print(f"WARN: missing metadata for {state_key} on {day_key}")
+            run_counts["skipped"] += 1
         save_discord_daily_posts(daily_posts)
 
     intro_state = run_state.setdefault("intro", {})
@@ -1876,6 +1920,7 @@ def post_daily_pick_messages(
                             "channel_id": str(payload.get("channel_id") or existing_channel_id),
                         }
                         print(f"REFRESH: updated {section_key} item {title} for {day_key}")
+                        run_counts["updated"] += 1
                     except DiscordMessageNotFoundError:
                         print(f"RECOVER: stale/deleted {section_key} item {title} for {day_key}; posting replacement")
                     except Exception as error:
@@ -1891,6 +1936,7 @@ def post_daily_pick_messages(
                 ):
                     metadata = {"message_id": existing_message_id, "channel_id": existing_channel_id}
                     print(f"REUSE: {section_key} item {title} for {day_key}")
+                    run_counts["reused"] += 1
 
             if metadata is None:
                 metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
@@ -1915,10 +1961,12 @@ def post_daily_pick_messages(
                 )
                 if is_new_message:
                     print(f"CREATE: posted {section_key} item {title} for {day_key}")
+                    run_counts["created"] += 1
                 else:
                     print(f"REUSE: persisted existing {section_key} item {title} for {day_key}")
             else:
                 print(f"WARN: missing metadata for {section_key} item title={title}")
+                run_counts["skipped"] += 1
             sleep_briefly()
 
     footer_state = run_state.setdefault("navigation_footer", {})
@@ -1931,6 +1979,7 @@ def post_daily_pick_messages(
     run_state["completed_at_utc"] = utc_now_iso()
     save_discord_daily_posts(daily_posts)
     print(f"COMPLETE: daily picks state marked completed for {day_key}")
+    return run_counts, False
 
 
 def dedupe_by_app_id(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
@@ -2311,7 +2360,7 @@ def main():
     force_refresh_same_day = get_force_refresh_same_day()
     if force_refresh_same_day:
         print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
-    post_daily_pick_messages(
+    run_counts, rerun_protection_active = post_daily_pick_messages(
         demo_playtest_items,
         free_items,
         paid_items,
@@ -2389,6 +2438,12 @@ def main():
         run_summary_lines,
         target_day_key=get_target_day_key(),
         instagram_debug=instagram_debug,
+    )
+    post_discord_debug_summary(
+        day_key=get_target_day_key(),
+        run_counts=run_counts,
+        rerun_protection_active=rerun_protection_active,
+        force_refresh_same_day=force_refresh_same_day,
     )
 
     next_start_page = get_next_start_page(start_page)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -738,3 +738,140 @@ def test_debug_export_fails_gracefully(monkeypatch, capsys):
     main.export_daily_debug_summary([], ["RUN SUMMARY"], path="ignored.json")
     captured = capsys.readouterr()
     assert "WARN: failed to write debug summary" in captured.out
+
+
+class FakeDebugClient:
+    def __init__(self):
+        self.posts = []
+
+    def post_message(self, channel_id, content, *, context):
+        self.posts.append((channel_id, content, context))
+        return {"id": "debug-1", "channel_id": channel_id}
+
+
+def test_post_discord_debug_summary_posts_compact_message(monkeypatch):
+    fake_client = FakeDebugClient()
+    monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+
+    run_counts = {"created": 3, "updated": 1, "reused": 2, "skipped": 0}
+    main.post_discord_debug_summary(
+        day_key="2026-04-12",
+        run_counts=run_counts,
+        rerun_protection_active=False,
+        force_refresh_same_day=False,
+    )
+
+    assert len(fake_client.posts) == 1
+    channel_id, content, _ctx = fake_client.posts[0]
+    assert channel_id == "debug-chan-1"
+    assert "2026-04-12" in content
+    assert "Created: 3" in content
+    assert "Updated: 1" in content
+    assert "Reused: 2" in content
+    assert "Skipped: 0" in content
+    assert "inactive" in content
+
+
+def test_post_discord_debug_summary_rerun_protection_active(monkeypatch):
+    fake_client = FakeDebugClient()
+    monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+
+    run_counts = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
+    main.post_discord_debug_summary(
+        day_key="2026-04-12",
+        run_counts=run_counts,
+        rerun_protection_active=True,
+        force_refresh_same_day=False,
+    )
+
+    assert len(fake_client.posts) == 1
+    _, content, _ = fake_client.posts[0]
+    assert "active" in content
+
+
+def test_post_discord_debug_summary_skips_when_no_channel(monkeypatch):
+    fake_client = FakeDebugClient()
+    monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "")
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+
+    main.post_discord_debug_summary(
+        day_key="2026-04-12",
+        run_counts={"created": 1, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        force_refresh_same_day=False,
+    )
+
+    assert len(fake_client.posts) == 0
+
+
+def test_post_discord_debug_summary_skips_when_no_token(monkeypatch):
+    fake_client = FakeDebugClient()
+    monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+
+    main.post_discord_debug_summary(
+        day_key="2026-04-12",
+        run_counts={"created": 1, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        force_refresh_same_day=False,
+    )
+
+    assert len(fake_client.posts) == 0
+
+
+def test_post_daily_pick_messages_returns_counts(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-12"
+
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        counter["i"] += 1
+        return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
+
+    fake_client = FakeDiscordClient()
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [{"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9}]
+    run_counts, rerun_protection_active = main.post_daily_pick_messages([], free_items, [], [])
+
+    assert rerun_protection_active is False
+    # intro + free_header + 1 item = 3 created
+    assert run_counts["created"] == 3
+    assert run_counts["updated"] == 0
+    assert run_counts["reused"] == 0
+
+
+def test_post_daily_pick_messages_rerun_protection_returns_flag(monkeypatch, tmp_path):
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-12"
+    daily_path.write_text(
+        __import__("json").dumps({day_key: {"run_state": {"completed": True}, "items": []}}),
+        encoding="utf-8",
+    )
+
+    fake_client = FakeDiscordClient()
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [{"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9}]
+    run_counts, rerun_protection_active = main.post_daily_pick_messages([], free_items, [], [])
+
+    assert rerun_protection_active is True
+    assert run_counts["created"] == 0


### PR DESCRIPTION
## Summary
- Posts a compact one-message debug summary to `DISCORD_DEBUG_CHANNEL_ID` after each daily workflow run
- Tracks created/updated/reused/skipped message counts inside `post_daily_pick_messages()` and surfaces rerun protection status
- Silently no-ops when `DISCORD_DEBUG_CHANNEL_ID` or `DISCORD_BOT_TOKEN` are unset; failure is caught and logged, never aborts the workflow

## Example message
```
🛠 Debug | Daily Picks | 2026-04-12 (Sun)
Created: 5 | Updated: 0 | Reused: 3 | Skipped: 0
Rerun protection: inactive
```

## Test plan
- [x] `pytest -q tests/test_main_daily_picks.py tests/test_evening_winners.py tests/test_gaming_library.py` → 59 passed
- [x] New tests: summary posts correct content, rerun protection flag in content, silently skips when channel/token missing, counts returned correctly on fresh run and when rerun protection fires
- [ ] Add `DISCORD_DEBUG_CHANNEL_ID` secret to GitHub repo settings to activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)