### PR TITLE
Add verification artifact for daily Discord workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,6 +52,14 @@ jobs:
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
         run: python main.py
 
+      - name: Upload verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-verification-${{ github.run_id }}
+          path: daily_verification.json
+          if-no-files-found: ignore
+
       - name: Save updated state files
         run: |
           git config user.name "github-actions[bot]"

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
 FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
+DAILY_VERIFICATION_FILE = "daily_verification.json"
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -1125,6 +1126,32 @@ def export_daily_debug_summary(
         print(f"DEBUG EXPORT: wrote {path} ({len(records)} records)")
     except Exception as e:
         print(f"WARN: failed to write debug summary ({path}): {e}")
+
+
+def export_verification_artifact(
+    day_key: str,
+    run_counts: Dict[str, int],
+    rerun_protection_active: bool,
+    path: str = DAILY_VERIFICATION_FILE,
+) -> None:
+    """Write a JSON verification artifact summarizing the daily workflow run outcome."""
+    skipped = run_counts.get("skipped", 0)
+    artifact = {
+        "day_key": day_key,
+        "created": run_counts.get("created", 0),
+        "updated": run_counts.get("updated", 0),
+        "reused": run_counts.get("reused", 0),
+        "skipped": skipped,
+        "rerun_protection_active": rerun_protection_active,
+        "pass": skipped == 0,
+        "generated_at_utc": utc_now_iso(),
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(artifact, f, indent=2, ensure_ascii=False)
+        print(f"VERIFICATION: wrote {path}")
+    except Exception as e:
+        print(f"WARN: failed to write verification artifact ({path}): {e}")
 
 
 def post_discord_debug_summary(
@@ -2444,6 +2471,11 @@ def main():
         run_counts=run_counts,
         rerun_protection_active=rerun_protection_active,
         force_refresh_same_day=force_refresh_same_day,
+    )
+    export_verification_artifact(
+        day_key=get_target_day_key(),
+        run_counts=run_counts,
+        rerun_protection_active=rerun_protection_active,
     )
 
     next_start_page = get_next_start_page(start_page)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -749,6 +749,69 @@ class FakeDebugClient:
         return {"id": "debug-1", "channel_id": channel_id}
 
 
+def test_export_verification_artifact_pass_when_no_skipped(tmp_path):
+    out = tmp_path / "verification.json"
+    run_counts = {"created": 4, "updated": 1, "reused": 2, "skipped": 0}
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts=run_counts,
+        rerun_protection_active=False,
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["day_key"] == "2026-04-12"
+    assert artifact["created"] == 4
+    assert artifact["updated"] == 1
+    assert artifact["reused"] == 2
+    assert artifact["skipped"] == 0
+    assert artifact["rerun_protection_active"] is False
+    assert artifact["pass"] is True
+    assert artifact["generated_at_utc"]
+
+
+def test_export_verification_artifact_fail_when_skipped(tmp_path):
+    out = tmp_path / "verification.json"
+    run_counts = {"created": 2, "updated": 0, "reused": 1, "skipped": 1}
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts=run_counts,
+        rerun_protection_active=False,
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["pass"] is False
+    assert artifact["skipped"] == 1
+
+
+def test_export_verification_artifact_pass_when_rerun_protection_active(tmp_path):
+    out = tmp_path / "verification.json"
+    run_counts = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts=run_counts,
+        rerun_protection_active=True,
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["rerun_protection_active"] is True
+    assert artifact["pass"] is True
+
+
+def test_export_verification_artifact_fails_gracefully(monkeypatch, capsys):
+    def fake_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 1, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        path="ignored.json",
+    )
+    captured = capsys.readouterr()
+    assert "WARN: failed to write verification artifact" in captured.out
+
+
 def test_post_discord_debug_summary_posts_compact_message(monkeypatch):
     fake_client = FakeDebugClient()
     monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")


### PR DESCRIPTION
## Summary
- Writes `daily_verification.json` to the workspace after each daily workflow run with: `day_key`, `created`, `updated`, `reused`, `skipped`, `rerun_protection_active`, `pass`, `generated_at_utc`
- `pass=true` when `skipped==0` (no WARN/missing-metadata posting errors); rerun protection correctly yields `pass=true` since `skipped` stays 0
- Uploads the file as a GitHub Actions artifact (`daily-verification-<run_id>`) with `if-no-files-found: ignore` — silently absent if the script never reached the write
- Write failure is caught and logged; never aborts the workflow

## Example artifact
```json
{
  "day_key": "2026-04-12",
  "created": 5,
  "updated": 0,
  "reused": 3,
  "skipped": 0,
  "rerun_protection_active": false,
  "pass": true,
  "generated_at_utc": "2026-04-12T13:02:14Z"
}
```

## Test plan
- [x] `pytest -q tests/test_main_daily_picks.py tests/test_evening_winners.py tests/test_gaming_library.py` → 63 passed
- [x] `pass=true` when no skipped items
- [x] `pass=false` when any item skipped (WARN/missing metadata)
- [x] `pass=true` when rerun protection active (skipped stays 0)
- [x] Graceful failure on write error (WARN logged, no exception raised)

> Stacked on #119 (debug summary counts), which provides the `run_counts` and `rerun_protection_active` values consumed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)