### PR TITLE
Strengthen daily verification artifact checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -1132,10 +1132,59 @@ def export_verification_artifact(
     day_key: str,
     run_counts: Dict[str, int],
     rerun_protection_active: bool,
+    verification_state: Optional[dict] = None,
     path: str = DAILY_VERIFICATION_FILE,
 ) -> None:
     """Write a JSON verification artifact summarizing the daily workflow run outcome."""
+    vs = verification_state or {}
+    run_state = vs.get("run_state") if isinstance(vs.get("run_state"), dict) else {}
+    items = vs.get("items") if isinstance(vs.get("items"), list) else []
+    posted_section_keys = vs.get("posted_section_keys") if isinstance(vs.get("posted_section_keys"), list) else []
+
+    intro_state = run_state.get("intro") if isinstance(run_state.get("intro"), dict) else {}
+    intro_present = bool(intro_state.get("message_id"))
+    intro_count = 1 if intro_present else 0
+
+    section_headers_state = run_state.get("section_headers") if isinstance(run_state.get("section_headers"), dict) else {}
+    section_header_counts = {
+        sk: (1 if isinstance(v, dict) and v.get("message_id") else 0)
+        for sk, v in section_headers_state.items()
+    }
+
+    item_count = len(items)
+    key_seq = [item.get("item_key") for item in items if isinstance(item, dict) and item.get("item_key")]
+    seen_keys: set = set()
+    dup_keys: List[str] = []
+    for k in key_seq:
+        if k in seen_keys and k not in dup_keys:
+            dup_keys.append(k)
+        seen_keys.add(k)
+    duplicate_item_keys = dup_keys
+
+    footer_state = run_state.get("navigation_footer") if isinstance(run_state.get("navigation_footer"), dict) else {}
+    footer_present = bool(footer_state.get("message_id"))
+
     skipped = run_counts.get("skipped", 0)
+
+    if rerun_protection_active:
+        # Run was intentionally skipped; structural checks belong to the completing run.
+        passes = skipped == 0
+    else:
+        footer_expected = bool(posted_section_keys) and bool(DISCORD_GUILD_ID)
+        footer_ok = footer_present if footer_expected else True
+        headers_ok = all(
+            sk in posted_section_keys
+            for sk, count in section_header_counts.items()
+            if count > 0
+        )
+        passes = (
+            intro_count == 1
+            and not duplicate_item_keys
+            and footer_ok
+            and headers_ok
+            and skipped == 0
+        )
+
     artifact = {
         "day_key": day_key,
         "created": run_counts.get("created", 0),
@@ -1143,7 +1192,14 @@ def export_verification_artifact(
         "reused": run_counts.get("reused", 0),
         "skipped": skipped,
         "rerun_protection_active": rerun_protection_active,
-        "pass": skipped == 0,
+        "intro_present": intro_present,
+        "intro_count": intro_count,
+        "section_header_counts": section_header_counts,
+        "item_count": item_count,
+        "duplicate_item_keys": duplicate_item_keys,
+        "footer_present": footer_present,
+        "posted_section_keys": posted_section_keys,
+        "pass": passes,
         "generated_at_utc": utc_now_iso(),
     }
     try:
@@ -1783,10 +1839,10 @@ def post_daily_pick_messages(
     *,
     force_refresh_same_day: bool = False,
 ) -> Tuple[Dict[str, int], bool]:
-    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active)."""
+    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active, verification_state)."""
     run_counts: Dict[str, int] = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
     if not (demo_playtest_items or free_items or paid_items or instagram_posts):
-        return run_counts, False
+        return run_counts, False, {}
 
     token_available = bool(DISCORD_BOT_TOKEN)
     daily_posts = load_discord_daily_posts() if token_available else {}
@@ -1811,7 +1867,7 @@ def post_daily_pick_messages(
     if bool(run_state.get("completed")) and not force_refresh_same_day:
         print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")
         save_discord_daily_posts(daily_posts)
-        return run_counts, True
+        return run_counts, True, {}
     if bool(run_state.get("completed")) and force_refresh_same_day:
         print(f"REFRESH: daily picks already completed for {day_key}; force_refresh_same_day=true so reconciling posts")
 
@@ -2006,7 +2062,11 @@ def post_daily_pick_messages(
     run_state["completed_at_utc"] = utc_now_iso()
     save_discord_daily_posts(daily_posts)
     print(f"COMPLETE: daily picks state marked completed for {day_key}")
-    return run_counts, False
+    return run_counts, False, {
+        "run_state": run_state,
+        "items": day_entry.get("items") or [],
+        "posted_section_keys": posted_section_keys,
+    }
 
 
 def dedupe_by_app_id(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
@@ -2387,7 +2447,7 @@ def main():
     force_refresh_same_day = get_force_refresh_same_day()
     if force_refresh_same_day:
         print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
-    run_counts, rerun_protection_active = post_daily_pick_messages(
+    run_counts, rerun_protection_active, verification_state = post_daily_pick_messages(
         demo_playtest_items,
         free_items,
         paid_items,
@@ -2476,6 +2536,7 @@ def main():
         day_key=get_target_day_key(),
         run_counts=run_counts,
         rerun_protection_active=rerun_protection_active,
+        verification_state=verification_state,
     )
 
     next_start_page = get_next_start_page(start_page)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -749,6 +749,19 @@ class FakeDebugClient:
         return {"id": "debug-1", "channel_id": channel_id}
 
 
+def _make_vs(*, intro_id="intro-1", footer_id="footer-1", section_headers=None, items=None, posted_section_keys=None):
+    """Build a minimal verification_state for tests."""
+    return {
+        "run_state": {
+            "intro": {"message_id": intro_id} if intro_id else {},
+            "navigation_footer": {"message_id": footer_id} if footer_id else {},
+            "section_headers": section_headers or {},
+        },
+        "items": items or [],
+        "posted_section_keys": posted_section_keys or [],
+    }
+
+
 def test_export_verification_artifact_pass_when_no_skipped(tmp_path):
     out = tmp_path / "verification.json"
     run_counts = {"created": 4, "updated": 1, "reused": 2, "skipped": 0}
@@ -756,6 +769,7 @@ def test_export_verification_artifact_pass_when_no_skipped(tmp_path):
         day_key="2026-04-12",
         run_counts=run_counts,
         rerun_protection_active=False,
+        verification_state=_make_vs(),
         path=str(out),
     )
     artifact = json.loads(out.read_text(encoding="utf-8"))
@@ -767,6 +781,13 @@ def test_export_verification_artifact_pass_when_no_skipped(tmp_path):
     assert artifact["rerun_protection_active"] is False
     assert artifact["pass"] is True
     assert artifact["generated_at_utc"]
+    # New structural fields present
+    assert artifact["intro_present"] is True
+    assert artifact["intro_count"] == 1
+    assert artifact["item_count"] == 0
+    assert artifact["duplicate_item_keys"] == []
+    assert artifact["footer_present"] is True
+    assert artifact["posted_section_keys"] == []
 
 
 def test_export_verification_artifact_fail_when_skipped(tmp_path):
@@ -776,6 +797,7 @@ def test_export_verification_artifact_fail_when_skipped(tmp_path):
         day_key="2026-04-12",
         run_counts=run_counts,
         rerun_protection_active=False,
+        verification_state=_make_vs(),
         path=str(out),
     )
     artifact = json.loads(out.read_text(encoding="utf-8"))
@@ -810,6 +832,112 @@ def test_export_verification_artifact_fails_gracefully(monkeypatch, capsys):
     )
     captured = capsys.readouterr()
     assert "WARN: failed to write verification artifact" in captured.out
+
+
+def test_export_verification_artifact_fail_when_no_intro(tmp_path):
+    out = tmp_path / "verification.json"
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 1, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=_make_vs(intro_id=None),
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["intro_present"] is False
+    assert artifact["intro_count"] == 0
+    assert artifact["pass"] is False
+
+
+def test_export_verification_artifact_fail_when_duplicate_item_keys(tmp_path):
+    out = tmp_path / "verification.json"
+    items = [
+        {"item_key": "abc123", "title": "Game A"},
+        {"item_key": "abc123", "title": "Game A duplicate"},
+        {"item_key": "def456", "title": "Game B"},
+    ]
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 3, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=_make_vs(items=items),
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["duplicate_item_keys"] == ["abc123"]
+    assert artifact["item_count"] == 3
+    assert artifact["pass"] is False
+
+
+def test_export_verification_artifact_footer_required_when_guild_id_set(tmp_path, monkeypatch):
+    out = tmp_path / "verification.json"
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "guild-123")
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 2, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=_make_vs(footer_id=None, posted_section_keys=["free"]),
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["footer_present"] is False
+    assert artifact["pass"] is False
+
+
+def test_export_verification_artifact_footer_not_required_without_guild_id(tmp_path, monkeypatch):
+    out = tmp_path / "verification.json"
+    monkeypatch.setattr(main, "DISCORD_GUILD_ID", "")
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 2, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=_make_vs(footer_id=None, posted_section_keys=["free"]),
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["footer_present"] is False
+    assert artifact["pass"] is True
+
+
+def test_export_verification_artifact_fail_when_orphan_section_header(tmp_path):
+    # A header exists for "paid" but "paid" was not in posted_section_keys
+    out = tmp_path / "verification.json"
+    vs = _make_vs(
+        section_headers={"paid": {"message_id": "hdr-paid"}},
+        posted_section_keys=["free"],
+    )
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 2, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=vs,
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["section_header_counts"] == {"paid": 1}
+    assert artifact["pass"] is False
+
+
+def test_export_verification_artifact_section_header_counts_by_key(tmp_path):
+    out = tmp_path / "verification.json"
+    vs = _make_vs(
+        section_headers={
+            "free": {"message_id": "hdr-free"},
+            "paid": {},  # no message_id → count 0
+        },
+        posted_section_keys=["free"],
+    )
+    main.export_verification_artifact(
+        day_key="2026-04-12",
+        run_counts={"created": 2, "updated": 0, "reused": 0, "skipped": 0},
+        rerun_protection_active=False,
+        verification_state=vs,
+        path=str(out),
+    )
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["section_header_counts"] == {"free": 1, "paid": 0}
+    # paid header has count 0 so headers_ok is True (only count>0 headers are checked)
+    assert artifact["pass"] is True
 
 
 def test_post_discord_debug_summary_posts_compact_message(monkeypatch):
@@ -909,7 +1037,7 @@ def test_post_daily_pick_messages_returns_counts(monkeypatch, tmp_path):
     monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
 
     free_items = [{"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9}]
-    run_counts, rerun_protection_active = main.post_daily_pick_messages([], free_items, [], [])
+    run_counts, rerun_protection_active, _ = main.post_daily_pick_messages([], free_items, [], [])
 
     assert rerun_protection_active is False
     # intro + free_header + 1 item = 3 created
@@ -934,7 +1062,7 @@ def test_post_daily_pick_messages_rerun_protection_returns_flag(monkeypatch, tmp
     monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
 
     free_items = [{"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9}]
-    run_counts, rerun_protection_active = main.post_daily_pick_messages([], free_items, [], [])
+    run_counts, rerun_protection_active, _ = main.post_daily_pick_messages([], free_items, [], [])
 
     assert rerun_protection_active is True
     assert run_counts["created"] == 0


### PR DESCRIPTION
## Summary
- Extend `daily_verification.json` with structural validation fields for autonomous debugging
- Add intro, section header, footer, item count, duplicate detection, and posted section tracking
- Strengthen `pass` so it only succeeds when the daily Discord layout is structurally correct

## Added verification fields
- `intro_present`
- `intro_count`
- `section_header_counts`
- `item_count`
- `duplicate_item_keys`
- `footer_present`
- `posted_section_keys`

## Updated pass behavior
`pass=true` now requires:
- exactly one intro message
- no duplicate item keys
- footer present when sections were posted and `DISCORD_GUILD_ID` is configured
- section headers only exist for sections that actually have items
- `skipped == 0`

When rerun protection is active, structural checks are skipped and `pass` continues to depend only on `skipped == 0`.

## Test plan
- [x] `pytest tests/test_main_daily_picks.py`
- [x] `pytest tests/test_main_daily_picks.py tests/test_evening_winners.py tests/test_gaming_library.py`
- [x] duplicate item keys fail verification
- [x] missing intro fails verification
- [x] missing required footer fails verification
- [x] orphan section header fails verification
- [x] rerun protection bypasses structural checks
