### PR TITLE
Add lightweight stop/go controller around daily verification artifact

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
 FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 DAILY_VERIFICATION_FILE = "daily_verification.json"
+MAX_RETRY_ATTEMPTS = 3
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -2276,7 +2277,17 @@ def fetch_instagram_posts():
     print(f"Instagram posts found this run: {len(all_new_posts)}")
     return all_new_posts
     
-def main():
+def load_daily_verification_artifact(path: str = DAILY_VERIFICATION_FILE) -> dict:
+    return load_json_object(path, default={})
+
+
+def verification_passed_for_day(day_key: str, artifact: dict) -> bool:
+    if not isinstance(artifact, dict):
+        return False
+    return artifact.get("day_key") == day_key and bool(artifact.get("pass"))
+
+
+def run_daily_workflow(*, force_refresh_same_day: bool = False) -> None:
     state = load_state()
     print(f"Daily run target date (UTC): {get_target_day_key()}")
 
@@ -2444,7 +2455,7 @@ def main():
         f"kept={instagram_debug['deduped_count']} "
         f"removed={instagram_debug['removed_count']}"
     )
-    force_refresh_same_day = get_force_refresh_same_day()
+    force_refresh_same_day = force_refresh_same_day or get_force_refresh_same_day()
     if force_refresh_same_day:
         print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
     run_counts, rerun_protection_active, verification_state = post_daily_pick_messages(
@@ -2543,6 +2554,37 @@ def main():
     save_page_state(next_start_page)
     next_end_page = min(next_start_page + PAGE_WINDOW_SIZE - 1, MAX_PAGE_LIMIT)
     print(f"Next rotating page window saved: {next_start_page}-{next_end_page}")
+
+
+def main():
+    day_key = get_target_day_key()
+    artifact = load_daily_verification_artifact()
+    if verification_passed_for_day(day_key, artifact):
+        print(
+            "STOP_GO decision=stop "
+            f"reason=verification_pass day_key={day_key} verification_file={DAILY_VERIFICATION_FILE}"
+        )
+        return
+
+    for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
+        if attempt > 1:
+            print(
+                "STOP_GO decision=retry "
+                f"reason=verification_failed attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
+            )
+        run_daily_workflow(force_refresh_same_day=(attempt > 1))
+        artifact = load_daily_verification_artifact()
+        if verification_passed_for_day(day_key, artifact):
+            print(
+                "STOP_GO decision=stop "
+                f"reason=verification_pass attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
+            )
+            return
+
+    print(
+        "STOP_GO decision=give_up "
+        f"reason=max_retry_attempts_reached attempts={MAX_RETRY_ATTEMPTS}/{MAX_RETRY_ATTEMPTS}"
+    )
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -940,6 +940,56 @@ def test_export_verification_artifact_section_header_counts_by_key(tmp_path):
     assert artifact["pass"] is True
 
 
+def test_main_stop_go_stops_immediately_when_verification_passes(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
+    monkeypatch.setattr(
+        main,
+        "load_daily_verification_artifact",
+        lambda: {"day_key": "2026-04-12", "pass": True},
+    )
+    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
+
+    main.main()
+
+    assert calls == []
+
+
+def test_main_stop_go_retries_until_verification_passes(monkeypatch):
+    calls = []
+    artifacts = iter(
+        [
+            {"day_key": "2026-04-12", "pass": False},
+            {"day_key": "2026-04-12", "pass": False},
+            {"day_key": "2026-04-12", "pass": True},
+        ]
+    )
+    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
+    monkeypatch.setattr(main, "load_daily_verification_artifact", lambda: next(artifacts))
+    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
+
+    main.main()
+
+    assert calls == [{"force_refresh_same_day": False}, {"force_refresh_same_day": True}]
+
+
+def test_main_stop_go_gives_up_after_max_attempts(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
+    monkeypatch.setattr(
+        main,
+        "load_daily_verification_artifact",
+        lambda: {"day_key": "2026-04-12", "pass": False},
+    )
+    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
+
+    main.main()
+
+    captured = capsys.readouterr()
+    assert len(calls) == main.MAX_RETRY_ATTEMPTS
+    assert "STOP_GO decision=give_up" in captured.out
+
+
 def test_post_discord_debug_summary_posts_compact_message(monkeypatch):
     fake_client = FakeDebugClient()
     monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")


### PR DESCRIPTION
### Motivation
- Prevent unnecessary runs by consulting the existing verification artifact `daily_verification.json` before executing the daily posting workflow. 
- If the artifact indicates the run already `pass == true`, stop immediately; otherwise allow a small capped retry/repair loop to attempt reconciliation. 
- Keep this layer lightweight and compatible with existing posting/reconciliation behavior so future orchestrators can read deterministic logs.

### Description
- Added `MAX_RETRY_ATTEMPTS = 3` and a lightweight verification loader `load_daily_verification_artifact()` and checker `verification_passed_for_day()` to read `daily_verification.json` and decide pass/fail. 
- Split the prior `main()` body into `run_daily_workflow(*, force_refresh_same_day: bool = False)` to preserve the exact workflow implementation and allow reruns without redesigning posting code. 
- Implemented a controller `main()` that: stops immediately when verification passed for the current day, otherwise runs up to `MAX_RETRY_ATTEMPTS` attempts, forcing same-day reconciliation on retries, and emits explicit logs like `STOP_GO decision=stop|retry|give_up` for orchestrator consumption. 
- Files changed: `main.py` (new constants and functions, split workflow, controller) and `tests/test_main_daily_picks.py` (added targeted stop/go tests: immediate stop, retry-until-pass, give-up after max attempts). 

### Testing
- Added tests in `tests/test_main_daily_picks.py` covering `main()` stop/retry/give-up behavior and ran the targeted subset `-k "stop_go or verification_artifact"`, which completed with `13 passed, 40 deselected`. 
- Ran the full daily-picks test file `tests/test_main_daily_picks.py`, which completed with `53 passed`. 
- The new tests assert that `run_daily_workflow` is not invoked when verification already passes, that the controller retries with `force_refresh_same_day=True` on subsequent attempts, and that it gives up after `MAX_RETRY_ATTEMPTS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc57ec8300832682018f1f3dffd7fb)