### PR TITLE
Add machine-readable stop/go escalation boundary artifact

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
 FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 DAILY_VERIFICATION_FILE = "daily_verification.json"
+STOP_GO_RESULT_FILE = "daily_stop_go_result.json"
 MAX_RETRY_ATTEMPTS = 3
 
 INSTAGRAM_CREATORS = [
@@ -2287,6 +2288,46 @@ def verification_passed_for_day(day_key: str, artifact: dict) -> bool:
     return artifact.get("day_key") == day_key and bool(artifact.get("pass"))
 
 
+def export_stop_go_result(
+    *,
+    day_key: str,
+    decision: str,
+    reason: str,
+    attempt: Optional[int] = None,
+    max_attempts: int = MAX_RETRY_ATTEMPTS,
+    verification_file: str = DAILY_VERIFICATION_FILE,
+    path: Optional[str] = None,
+) -> None:
+    """Write a machine-readable stop/go decision artifact for external orchestration."""
+    signal = decision
+    escalation_target = None
+    if decision == "give_up":
+        signal = "escalate_to_fixer"
+        escalation_target = "claude_code"
+
+    result = {
+        "day_key": day_key,
+        "decision": decision,
+        "signal": signal,
+        "reason": reason,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "verification_file": verification_file,
+        "orchestrator": "openhands",
+        "fixer": "claude_code",
+        "escalation_target": escalation_target,
+        "generated_at_utc": utc_now_iso(),
+    }
+    result_path = path or STOP_GO_RESULT_FILE
+    save_json_object_atomic(result_path, result)
+    print(
+        "STOP_GO_RESULT "
+        f"file={result_path} day_key={day_key} decision={decision} signal={signal} "
+        f"attempt={attempt if attempt is not None else 'na'}/{max_attempts} "
+        f"reason={reason}"
+    )
+
+
 def run_daily_workflow(*, force_refresh_same_day: bool = False) -> None:
     state = load_state()
     print(f"Daily run target date (UTC): {get_target_day_key()}")
@@ -2560,6 +2601,12 @@ def main():
     day_key = get_target_day_key()
     artifact = load_daily_verification_artifact()
     if verification_passed_for_day(day_key, artifact):
+        export_stop_go_result(
+            day_key=day_key,
+            decision="stop",
+            reason="verification_pass",
+            attempt=0,
+        )
         print(
             "STOP_GO decision=stop "
             f"reason=verification_pass day_key={day_key} verification_file={DAILY_VERIFICATION_FILE}"
@@ -2568,6 +2615,12 @@ def main():
 
     for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
         if attempt > 1:
+            export_stop_go_result(
+                day_key=day_key,
+                decision="retry",
+                reason="verification_failed",
+                attempt=attempt,
+            )
             print(
                 "STOP_GO decision=retry "
                 f"reason=verification_failed attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
@@ -2575,12 +2628,24 @@ def main():
         run_daily_workflow(force_refresh_same_day=(attempt > 1))
         artifact = load_daily_verification_artifact()
         if verification_passed_for_day(day_key, artifact):
+            export_stop_go_result(
+                day_key=day_key,
+                decision="stop",
+                reason="verification_pass",
+                attempt=attempt,
+            )
             print(
                 "STOP_GO decision=stop "
                 f"reason=verification_pass attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
             )
             return
 
+    export_stop_go_result(
+        day_key=day_key,
+        decision="give_up",
+        reason="max_retry_attempts_reached",
+        attempt=MAX_RETRY_ATTEMPTS,
+    )
     print(
         "STOP_GO decision=give_up "
         f"reason=max_retry_attempts_reached attempts={MAX_RETRY_ATTEMPTS}/{MAX_RETRY_ATTEMPTS}"

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -990,6 +990,46 @@ def test_main_stop_go_gives_up_after_max_attempts(monkeypatch, capsys):
     assert "STOP_GO decision=give_up" in captured.out
 
 
+def test_export_stop_go_result_uses_escalate_signal_for_give_up(tmp_path):
+    out = tmp_path / "stop_go.json"
+    main.export_stop_go_result(
+        day_key="2026-04-12",
+        decision="give_up",
+        reason="max_retry_attempts_reached",
+        attempt=3,
+        path=str(out),
+    )
+
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert artifact["decision"] == "give_up"
+    assert artifact["signal"] == "escalate_to_fixer"
+    assert artifact["orchestrator"] == "openhands"
+    assert artifact["fixer"] == "claude_code"
+    assert artifact["escalation_target"] == "claude_code"
+
+
+def test_main_stop_go_writes_give_up_artifact(monkeypatch, tmp_path):
+    calls = []
+    out = tmp_path / "stop_go.json"
+    monkeypatch.setattr(main, "STOP_GO_RESULT_FILE", str(out))
+    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
+    monkeypatch.setattr(
+        main,
+        "load_daily_verification_artifact",
+        lambda: {"day_key": "2026-04-12", "pass": False},
+    )
+    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
+
+    main.main()
+
+    artifact = json.loads(out.read_text(encoding="utf-8"))
+    assert len(calls) == main.MAX_RETRY_ATTEMPTS
+    assert artifact["decision"] == "give_up"
+    assert artifact["signal"] == "escalate_to_fixer"
+    assert artifact["reason"] == "max_retry_attempts_reached"
+    assert artifact["attempt"] == main.MAX_RETRY_ATTEMPTS
+
+
 def test_post_discord_debug_summary_posts_compact_message(monkeypatch):
     fake_client = FakeDebugClient()
     monkeypatch.setattr(main, "DISCORD_DEBUG_CHANNEL_ID", "debug-chan-1")


### PR DESCRIPTION
### Motivation
- Provide a lightweight, repo-native escalation boundary for the stop/go controller so a future orchestrator can detect stop/retry/give_up and escalate to a fixer without reworking the daily posting flow. 
- Keep the change minimal, avoid OpenHands runtime integration, and make the signal explicit and easy to parse for a future Claude Code fixer.

### Description
- Added a new artifact constant `STOP_GO_RESULT_FILE = "daily_stop_go_result.json"` and an `export_stop_go_result(...)` helper that atomically writes a JSON result with fields like `day_key`, `decision`, `signal`, `reason`, `attempt`, `max_attempts`, `verification_file`, `orchestrator`, `fixer`, and `escalation_target` (`main.py`).
- Mapped `give_up` to an orchestration-friendly `signal = "escalate_to_fixer"` and included `orchestrator = "openhands"` and `fixer = "claude_code"` to make an explicit, machine-readable escalation contract (`main.py`).
- Emitted `STOP_GO_RESULT ...` parseable log lines alongside existing human-facing `STOP_GO` prints to make logs easy to parse by an external system (`main.py`).
- Wired `export_stop_go_result(...)` into the main stop/go flow so `stop`/`retry`/`give_up` decisions write the artifact, and added targeted tests covering the new artifact behavior (`tests/test_main_daily_picks.py`).
- Files changed: `main.py`, `tests/test_main_daily_picks.py`.

### Testing
- Ran targeted tests: `pytest -q tests/test_main_daily_picks.py -k "stop_go or export_stop_go_result"` and observed the targeted tests passed (5 passed).
- Ran full daily picks tests: `pytest -q tests/test_main_daily_picks.py` and observed the full suite passed (`55 passed`).
- Tests added: `test_export_stop_go_result_uses_escalate_signal_for_give_up` and `test_main_stop_go_writes_give_up_artifact` in `tests/test_main_daily_picks.py`, both passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5a8840648326b44511a6e952eba2)