### PR TITLE
Add auto-fix loop workflow (#124)

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,248 @@
+name: Auto Fix Loop
+
+on:
+  workflow_run:
+    workflows: ["Steam Free Games"]
+    types: [completed]
+
+# Only one auto-fix may run at a time. Queue rather than cancel so no fix
+# attempt is silently dropped.
+concurrency:
+  group: auto-fix-loop
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
+jobs:
+  auto-fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ------------------------------------------------------------------ #
+      # 1. Checkout the repo so the artifact lands in the workspace and
+      #    Claude has full repo context available for all fix attempts.
+      # ------------------------------------------------------------------ #
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------ #
+      # 2. Download the daily_verification.json artifact from the triggering
+      #    daily.yml run. continue-on-error so we still act on workflow
+      #    failures even when the artifact was never written (e.g. the
+      #    script crashed before export_verification_artifact ran).
+      # ------------------------------------------------------------------ #
+      - name: Download verification artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: daily-verification-*
+          merge-multiple: true
+          path: artifacts/
+
+      # ------------------------------------------------------------------ #
+      # 3. Decide whether a fix is needed:
+      #    - workflow concluded with failure, OR
+      #    - artifact exists and reports pass: false
+      # Sets should_fix and trigger_reason outputs.
+      # ------------------------------------------------------------------ #
+      - name: Evaluate fix trigger
+        id: check
+        run: |
+          conclusion="${{ github.event.workflow_run.conclusion }}"
+          pass_value="true"
+
+          if [ -f artifacts/daily_verification.json ]; then
+            pass_value="$(python3 -c "
+          import json, sys
+          try:
+              d = json.load(open('artifacts/daily_verification.json'))
+              print(str(d.get('pass', True)).lower())
+          except Exception as e:
+              print('true')
+              print(f'WARN: could not parse artifact: {e}', file=sys.stderr)
+          ")"
+          fi
+
+          echo "Daily workflow conclusion: ${conclusion}"
+          echo "Verification artifact pass value: ${pass_value}"
+
+          if [ "$conclusion" = "failure" ] || [ "$pass_value" = "false" ]; then
+            echo "should_fix=true" >> "$GITHUB_OUTPUT"
+            echo "trigger_reason=conclusion=${conclusion}, pass=${pass_value}" >> "$GITHUB_OUTPUT"
+            echo "Fix needed — proceeding with auto-fix attempts."
+          else
+            echo "should_fix=false" >> "$GITHUB_OUTPUT"
+            echo "No fix needed — conclusion=${conclusion}, pass=${pass_value}. Exiting."
+          fi
+
+      # ------------------------------------------------------------------ #
+      # Shared prompt template (inlined per-step — GitHub Actions does not
+      # support YAML anchors, so the prompt is repeated with the attempt
+      # number changed). All attempts use claude-sonnet-4-6.
+      # ------------------------------------------------------------------ #
+
+      - name: Fix attempt 1 of 3
+        id: fix_1
+        if: steps.check.outputs.should_fix == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-sonnet-4-6'
+          prompt: |
+            This is auto-fix attempt 1 of 3.
+
+            The daily Steam Free Games Discord workflow has failed or produced an
+            invalid verification artifact.
+
+            Trigger context: ${{ steps.check.outputs.trigger_reason }}
+
+            If the file artifacts/daily_verification.json exists in the workspace,
+            read it to understand exactly what failed (intro_present, section_header_counts,
+            duplicate_item_keys, footer_present, pass, etc.).
+
+            Your task:
+            1. Read CLAUDE.md first and follow all rules there.
+            2. Identify the root cause of the failure from the verification artifact
+               and from the relevant source files (main.py, discord_api.py,
+               daily_section_config.py, state_utils.py, evening_winners.py).
+            3. Fix only the root cause. Do not refactor unrelated code.
+            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-1
+               branched from main.
+            5. Commit your changes with a message that explains what failed and
+               what you changed.
+            6. Open a pull request against main with a clear description of the
+               failure and the fix.
+            7. Do not merge the PR — leave it open for human review.
+
+            Important: use model claude-sonnet-4-6, not Opus.
+
+      - name: Fix attempt 2 of 3
+        id: fix_2
+        if: steps.check.outputs.should_fix == 'true' && steps.fix_1.outcome == 'failure'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-sonnet-4-6'
+          prompt: |
+            This is auto-fix attempt 2 of 3. Attempt 1 failed.
+
+            The daily Steam Free Games Discord workflow has failed or produced an
+            invalid verification artifact.
+
+            Trigger context: ${{ steps.check.outputs.trigger_reason }}
+
+            If the file artifacts/daily_verification.json exists in the workspace,
+            read it to understand exactly what failed (intro_present, section_header_counts,
+            duplicate_item_keys, footer_present, pass, etc.).
+
+            Your task:
+            1. Read CLAUDE.md first and follow all rules there.
+            2. Identify the root cause of the failure from the verification artifact
+               and from the relevant source files (main.py, discord_api.py,
+               daily_section_config.py, state_utils.py, evening_winners.py).
+            3. Fix only the root cause. Do not refactor unrelated code.
+            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-2
+               branched from main.
+            5. Commit your changes with a message that explains what failed and
+               what you changed.
+            6. Open a pull request against main with a clear description of the
+               failure and the fix.
+            7. Do not merge the PR — leave it open for human review.
+
+            Important: use model claude-sonnet-4-6, not Opus.
+
+      - name: Fix attempt 3 of 3
+        id: fix_3
+        if: steps.check.outputs.should_fix == 'true' && steps.fix_2.outcome == 'failure'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-sonnet-4-6'
+          prompt: |
+            This is auto-fix attempt 3 of 3. Attempts 1 and 2 both failed.
+
+            The daily Steam Free Games Discord workflow has failed or produced an
+            invalid verification artifact.
+
+            Trigger context: ${{ steps.check.outputs.trigger_reason }}
+
+            If the file artifacts/daily_verification.json exists in the workspace,
+            read it to understand exactly what failed (intro_present, section_header_counts,
+            duplicate_item_keys, footer_present, pass, etc.).
+
+            Your task:
+            1. Read CLAUDE.md first and follow all rules there.
+            2. Identify the root cause of the failure from the verification artifact
+               and from the relevant source files (main.py, discord_api.py,
+               daily_section_config.py, state_utils.py, evening_winners.py).
+            3. Fix only the root cause. Do not refactor unrelated code.
+            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-3
+               branched from main.
+            5. Commit your changes with a message that explains what failed and
+               what you changed.
+            6. Open a pull request against main with a clear description of the
+               failure and the fix.
+            7. Do not merge the PR — leave it open for human review.
+
+            Important: use model claude-sonnet-4-6, not Opus.
+
+      # ------------------------------------------------------------------ #
+      # Give up after 3 failed attempts — notify the health monitor channel.
+      # ------------------------------------------------------------------ #
+      - name: Give up — notify Discord health monitor
+        if: |
+          steps.check.outputs.should_fix == 'true' &&
+          steps.fix_3.outcome == 'failure'
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DAILY_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          TRIGGER_REASON: ${{ steps.check.outputs.trigger_reason }}
+        run: |
+          payload="$(python3 - <<'PY'
+          import json, os
+          print(json.dumps({
+              "content": (
+                  "🔴 Auto Fix Loop — Human Help Required\n\n"
+                  "The daily Steam Free Games workflow failed and all 3 automated "
+                  "fix attempts were unsuccessful.\n\n"
+                  f"Trigger: {os.environ.get('TRIGGER_REASON', '(see run)')}\n"
+                  f"Failed daily run: {os.environ['DAILY_RUN_URL']}\n"
+                  f"Auto-fix run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-auto-fix/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Give-up alert posted to Discord: HTTP ${http_status}"
+          else
+            echo "Failed to post give-up alert: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Misc
+*.log
+.DS_Store


### PR DESCRIPTION
## What this does
- Triggers automatically when `daily.yml` fails OR `daily_verification.json` shows `pass: false`
- Attempts up to 3 auto-fixes using Claude Code (Sonnet, not Opus)
- Each attempt creates a traceable branch: `fix/auto-fix-{daily-run-id}-{attempt}`
- On give-up: posts alert to health monitor Discord channel
- Concurrency lock prevents parallel runs

## Permissions updated
- `claude.yml`: `contents` and `pull-requests` upgraded to `write`

## Notes
- Only activates after merging to main (workflow_run limitation)
- Does NOT auto-merge — leaves PRs open for human review (auto-merge comes in a later task)
- Requires `CLAUDE_CODE_OAUTH_TOKEN` and `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` in repo secrets ✅