### PR TITLE
Wire verify_discord_output.py into daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,12 +52,28 @@ jobs:
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
         run: python main.py
 
+      - name: Verify Discord output
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
+        run: python scripts/verify_discord_output.py
+
       - name: Upload verification artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: daily-verification-${{ github.run_id }}
           path: daily_verification.json
+          if-no-files-found: ignore
+
+      - name: Upload Discord verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-verification-${{ github.run_id }}
+          path: discord_verification.json
           if-no-files-found: ignore
 
       - name: Save updated state files


### PR DESCRIPTION
## What this does

Wires `scripts/verify_discord_output.py` (added in #126) into `daily.yml` as a post-run verification step.

## New steps in `daily.yml`

**After "Run Steam script", before "Save updated state files":**

1. **Verify Discord output** — runs `scripts/verify_discord_output.py`
   - `continue-on-error: true` — never blocks the main workflow or triggers health monitor alerts
   - `PYTHONPATH: .` — required for imports
   - `DISCORD_BOT_TOKEN` from secrets
   - `DAILY_DATE_UTC` passed through for manual rerun targeting

2. **Upload Discord verification artifact** — uploads `discord_verification.json` as `discord-verification-{run_id}`
   - `if: always()` — uploads even if verify step failed
   - `if-no-files-found: ignore` — safe if main.py crashed before verify ran

## Step order

```
Run Steam script          ← main.py posts to Discord, writes discord_daily_posts.json
Verify Discord output     ← reads discord_daily_posts.json, fetches messages, writes discord_verification.json
Upload verification artifact        ← daily_verification.json (existing)
Upload Discord verification artifact ← discord_verification.json (new)
Save updated state files
Notify Discord health monitor on failure
```

## Notes

- `continue-on-error: true` means a broken verify script silently passes — worth monitoring in early runs via the uploaded artifact
- Verify step fires ~30+ Discord API calls; expect 30–60s added to workflow runtime