### PR TITLE
Add channel_specs.json

### DIFF
--- a/channel_specs.json
+++ b/channel_specs.json
@@ -1,0 +1,92 @@
+{
+  "step-1-vote-on-games-to-test": {
+    "description": "Morning candidate games and voting",
+    "required": {
+      "intro": true,
+      "min_items": 1,
+      "footer": false,
+      "reactions": ["👍"],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Free Picks", "Paid Under $20", "Instagram Creator Picks", "Demos / Playtests"]
+    },
+    "broken_if": [
+      "no games posted",
+      "duplicate game messages",
+      "missing intro",
+      "bot reaction counted in votes"
+    ]
+  },
+  "step-2-test-then-vote-to-keep": {
+    "description": "Evening winners and bookmarkable final picks",
+    "required": {
+      "intro": true,
+      "min_items": 1,
+      "footer": true,
+      "reactions": ["🔖"],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Free Picks", "Paid Under $20", "Instagram Creator Picks", "Demos / Playtests"]
+    },
+    "broken_if": [
+      "no winners posted",
+      "duplicate winners",
+      "missing footer",
+      "missing intro",
+      "bot vote counted as human vote"
+    ]
+  },
+  "step-3-review-existing-games": {
+    "description": "Persistent playable backlog with live player status",
+    "required": {
+      "intro": true,
+      "min_items": 0,
+      "footer": true,
+      "reactions": ["✅", "⏸️", "❌"],
+      "no_duplicates": true
+    },
+    "optional": {},
+    "broken_if": [
+      "game entry missing name",
+      "IG Picks entry without actual game name",
+      "missing footer",
+      "duplicate library entries"
+    ]
+  },
+  "update-weekly-schedule-here": {
+    "description": "Availability overlap and session coordination",
+    "required": {
+      "intro": false,
+      "min_items": 0,
+      "footer": false,
+      "reactions": [],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Morning", "Afternoon", "Evening", "Late Night"]
+    },
+    "broken_if": [
+      "scheduling post for game not in active library",
+      "ping sent with zero player overlap",
+      "missing availability time bucket"
+    ]
+  },
+  "xiann-gpt-bot-health-monitor": {
+    "description": "Workflow health, debugging, verification, and escalation",
+    "required": {
+      "intro": false,
+      "min_items": 1,
+      "footer": false,
+      "reactions": [],
+      "no_duplicates": false
+    },
+    "optional": {},
+    "broken_if": [
+      "no health report posted after workflow run",
+      "missing workflow status",
+      "missing verification result"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `channel_specs.json` to the repo root — a machine-readable definition of what correct output looks like for each Discord channel.

Covers all 5 channels:
- `step-1-vote-on-games-to-test` — morning picks, 👍 voting
- `step-2-test-then-vote-to-keep` — evening winners, 🔖 bookmarking
- `step-3-review-existing-games` — persistent backlog, ✅/⏸️/❌ reactions
- `update-weekly-schedule-here` — session scheduling
- `xiann-gpt-bot-health-monitor` — workflow health and escalation

Each entry defines `required` fields (`intro`, `min_items`, `footer`, `reactions`, `no_duplicates`), `optional` fields, and a `broken_if` list of human-readable failure conditions.

No existing code is changed — this is a new reference file for the verification system to build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)