### PR TITLE
Add gaming library workflows to bot-health-report.yml monitoring

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -37,6 +37,8 @@ jobs:
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
               { file: "daily.yml", name: "Daily Steam Picks", staleHours: 20 },
               { file: "evening-winners.yml", name: "Evening Winners", staleHours: 12 },
+              { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 20 },
+              { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 2 },
             ];
 
             const output = [];

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -55,6 +55,22 @@ SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
         "minute": 0,
         "window_before_minutes": 90,
     },
+    "Gaming Library Daily Reminder": {
+        "kind": "daily",
+        "cron": "0 14 * * *",
+        "cadence": "daily 14:00 UTC",
+        "hour": 14,
+        "minute": 0,
+        "window_before_minutes": 90,
+    },
+    "Gaming Library Sync": {
+        "kind": "interval",
+        "cron": "15 * * * *",
+        "cadence": "every hour at :15 UTC",
+        "interval_hours": 1,
+        "minute": 15,
+        "window_before_minutes": 30,
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Add `gaming-library-daily.yml` (`staleHours: 20`) and `gaming-library-sync.yml` (`staleHours: 2`) to the monitored workflows array in `bot-health-report.yml`
- Add `SCHEDULE_EXPECTATIONS` entries in `build_daily_health_report.py` for both: Gaming Library Daily Reminder (daily 14:00 UTC) and Gaming Library Sync (every hour at :15)
- `gaming-library-manage.yml` excluded — it's manual-only with no expected cadence

Closes #141

## Test plan

- [ ] Verify bot-health-report.yml YAML is valid
- [ ] Confirm `SCHEDULE_EXPECTATIONS` keys match the `name` fields in the workflows array exactly
- [ ] Confirm `staleHours` / `interval_hours` are consistent with each workflow's actual schedule