### PR TITLE
Surface check_state_sanity.py results to health monitor

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -27,6 +27,34 @@ jobs:
       - name: Install packages
         run: pip install -r requirements.txt
 
+      - name: Find latest daily.yml run ID
+        id: find-daily-run
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "daily.yml",
+              per_page: 5,
+              exclude_pull_requests: true,
+            });
+            const run = (runs.data.workflow_runs || []).find(r => r.status === "completed");
+            if (!run) { core.warning("No completed daily.yml run found"); return; }
+            core.setOutput("run_id", String(run.id));
+
+      - name: Download state sanity artifact
+        id: download-state-sanity
+        continue-on-error: true
+        if: steps.find-daily-run.outputs.run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.find-daily-run.outputs.run_id }}
+          pattern: state-sanity-*
+          merge-multiple: true
+
       - name: Collect workflow run status
         id: collect-workflows
         uses: actions/github-script@v7

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -47,6 +47,14 @@ jobs:
           PYTHONPATH: .
         run: python scripts/check_state_sanity.py
 
+      - name: Upload state sanity artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: state-sanity-${{ github.run_id }}
+          path: state_sanity.json
+          if-no-files-found: ignore
+
       - name: Run Steam script
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -856,6 +856,37 @@ def _report_date_new_york(now_utc: datetime) -> str:
     return f"{ny_time.strftime('%b')} {ny_time.day}, {ny_time.year}"
 
 
+def load_state_sanity_issues(path: Path) -> list[Issue]:
+    """Read state_sanity.json and convert errors/warnings to Issue objects."""
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    issues: list[Issue] = []
+    for msg in data.get("errors") or []:
+        issues.append(Issue(
+            code="STATE_SANITY_ERROR",
+            severity="error",
+            title="State sanity check error",
+            context=str(msg),
+            file_path=None,
+        ))
+    for msg in data.get("warnings") or []:
+        issues.append(Issue(
+            code="STATE_SANITY_WARNING",
+            severity="warning",
+            title="State sanity check warning",
+            context=str(msg),
+            file_path=None,
+        ))
+    return issues
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workflow-runs-json", required=True, help="Path to workflow run metadata JSON")
@@ -863,6 +894,11 @@ def main() -> None:
         "--schedule-diagnostics-out",
         default="",
         help="Optional path to write compact workflow schedule diagnostics JSON.",
+    )
+    parser.add_argument(
+        "--state-sanity-json",
+        default="",
+        help="Optional path to state_sanity.json; errors/warnings are surfaced in the report.",
     )
     args = parser.parse_args()
 
@@ -872,6 +908,10 @@ def main() -> None:
     now_utc = datetime.now(timezone.utc)
     workflow_lines, diagnostics_payload = build_workflow_status_lines(workflow_runs, now_utc=now_utc)
     state_issues = compute_state_issues(now_utc=now_utc)
+    if args.state_sanity_json:
+        state_issues.extend(load_state_sanity_issues(Path(args.state_sanity_json)))
+    elif Path("state_sanity.json").exists():
+        state_issues.extend(load_state_sanity_issues(Path("state_sanity.json")))
     report = render_report(
         workflow_status_lines=workflow_lines,
         state_issues=state_issues,

--- a/scripts/check_state_sanity.py
+++ b/scripts/check_state_sanity.py
@@ -6,10 +6,12 @@ import argparse
 import json
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_FILE = ROOT / "state_sanity.json"
 WEEK_KEY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_to_\d{4}-\d{2}-\d{2}$")
 DATE_KEY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -114,7 +116,9 @@ def build_summary(report: SanityReport) -> dict[str, Any]:
     else:
         status = "passed"
     return {
+        "pass": not bool(report.errors),
         "status": status,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "warnings": report.warnings,
         "errors": report.errors,
     }
@@ -131,6 +135,10 @@ def run_checks(*, json_output: bool = False) -> int:
     check_daily_posts(report)
 
     summary = build_summary(report)
+
+    # Always write machine-readable output for artifact upload and health report.
+    with OUTPUT_FILE.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
 
     if json_output:
         print(json.dumps(summary))


### PR DESCRIPTION
## Summary

- **`check_state_sanity.py`**: always writes `state_sanity.json` (with `pass`, `status`, `timestamp`, `errors`, `warnings`) regardless of `--json` flag, so the artifact is always available for upload
- **`daily.yml`**: new "Upload state sanity artifact" step (`state-sanity-{run_id}`) with `if: always()` so it uploads even when the sanity check fails via `continue-on-error`
- **`bot-health-report.yml`**: two new steps — find the latest completed `daily.yml` run ID (via github-script), then download its `state-sanity-*` artifact so `state_sanity.json` lands in the workspace
- **`build_daily_health_report.py`**: `load_state_sanity_issues()` converts sanity errors/warnings to `Issue` objects; `--state-sanity-json` flag; falls back to `state_sanity.json` in CWD if present

Closes #142

## Test plan

- [ ] Verify `check_state_sanity.py` writes `state_sanity.json` to repo root when run locally
- [ ] Verify `state_sanity.json` has `pass`, `timestamp`, `errors`, `warnings` keys
- [ ] Confirm `daily.yml` YAML is valid and artifact step is in the right position
- [ ] Confirm `bot-health-report.yml` YAML is valid
- [ ] Sanity errors from next daily run should appear in next health report