### PR TITLE
Add navigation footer to gaming library daily post

### DIFF
--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -34,6 +34,7 @@ jobs:
           PYTHONPATH: .
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
         run: python scripts/post_daily_gaming_library.py
 

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -13,6 +13,7 @@ GAMING_LIBRARY_FILE = "gaming_library.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_GAMING_LIBRARY_CHANNEL_ID = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID")
+DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 LIBRARY_DATE_OVERRIDE_ENV = "LIBRARY_DATE_UTC"
 
 STATUS_ACTIVE = "active"
@@ -208,6 +209,36 @@ def list_visible_games_for_reminder(state: Dict[str, Any]) -> List[Dict[str, Any
     return visible
 
 
+def _discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def build_library_footer(
+    *,
+    day_key: str,
+    header_channel_id: str,
+    header_message_id: str,
+    guild_id: Optional[str],
+) -> Optional[str]:
+    """Build a navigation footer string linking back to the header.
+
+    Returns None when DISCORD_GUILD_ID is absent (footer cannot include a jump link).
+    The footer is still posted without a jump link in that case via the fallback path.
+    """
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        # Post a plain footer without a jump link when guild_id is unavailable.
+        return (
+            f"📚 Gaming Library — {day_key}\n"
+            "React ✅ active · ⏸️ paused · ❌ dropped to update your status."
+        )
+    link = _discord_message_link(guild_id, header_channel_id, header_message_id)
+    return (
+        f"📚 Gaming Library — {day_key}\n"
+        f"React ✅ active · ⏸️ paused · ❌ dropped to update your status.\n"
+        f"↑ Top of list → [Jump]({link})"
+    )
+
+
 def build_daily_library_messages(state: Dict[str, Any], target_day_key: str) -> List[Dict[str, str]]:
     visible_games = list_visible_games_for_reminder(state)
     header = f"📚 Gaming Library — {target_day_key}"
@@ -291,6 +322,51 @@ def post_daily_library_reminder(
                     context=f"add gaming library status reaction {emoji} for {day_key}",
                 )
         reconciled_messages[message_key] = {"message_id": message_id, "channel_id": str(payload.get("channel_id") or channel_id)}
+
+    # --- Footer ---
+    header_info = reconciled_messages.get("header", {})
+    header_ch_id = str(header_info.get("channel_id") or channel_id).strip()
+    header_msg_id = str(header_info.get("message_id") or "").strip()
+    footer_content = build_library_footer(
+        day_key=day_key,
+        header_channel_id=header_ch_id,
+        header_message_id=header_msg_id,
+        guild_id=DISCORD_GUILD_ID,
+    )
+    if footer_content is not None:
+        existing_footer = existing_messages.get("footer")
+        existing_footer_ch_id = str((existing_footer or {}).get("channel_id") or channel_id).strip()
+        existing_footer_msg_id = str((existing_footer or {}).get("message_id") or "").strip()
+        if existing_footer_msg_id:
+            try:
+                footer_payload = client.edit_message(
+                    existing_footer_ch_id,
+                    existing_footer_msg_id,
+                    footer_content,
+                    context=f"edit gaming library footer for {day_key}",
+                )
+                changed = True
+            except DiscordMessageNotFoundError:
+                footer_payload = client.post_message(
+                    channel_id,
+                    footer_content,
+                    context=f"repost missing gaming library footer for {day_key}",
+                )
+                changed = True
+        else:
+            footer_payload = client.post_message(
+                channel_id,
+                footer_content,
+                context=f"post gaming library footer for {day_key}",
+            )
+            changed = True
+        footer_msg_id = str(footer_payload.get("id") or "")
+        if not footer_msg_id:
+            raise RuntimeError("Discord response missing id for gaming library footer")
+        reconciled_messages["footer"] = {
+            "message_id": footer_msg_id,
+            "channel_id": str(footer_payload.get("channel_id") or channel_id),
+        }
 
     day_entry["messages"] = reconciled_messages
     day_entry["completed"] = True

--- a/scripts/verify_gaming_library.py
+++ b/scripts/verify_gaming_library.py
@@ -193,11 +193,8 @@ def detect_broken_if(
             detected[condition] = "triggered" if has_placeholder else "not_triggered"
 
         elif "missing footer" in c:
-            if result.get("footer_skipped"):
-                detected[condition] = "undetectable"
-            else:
-                triggered = not result.get("footer_found", True)
-                detected[condition] = "triggered" if triggered else "not_triggered"
+            triggered = not result.get("footer_found", True)
+            detected[condition] = "triggered" if triggered else "not_triggered"
 
         elif "duplicate" in c:
             triggered = "duplicate" in errors_text
@@ -242,9 +239,9 @@ def main() -> None:
         "messages_checked": 0,
         "messages_missing": [],
         "header_found": False,
+        "footer_found": False,
         "game_messages_found": [],
         "game_name_warnings": [],
-        "footer_skipped": True,  # footer not implemented in post_daily_library_reminder
         "errors": [],
     }
 
@@ -289,7 +286,7 @@ def main() -> None:
         print("  MISSING  header (no message_id in state)")
 
     # --- Game messages ---
-    game_keys = [k for k in messages if k not in {"header", "intro"}]
+    game_keys = [k for k in messages if k not in {"header", "intro", "footer"}]
     print(f"\n--- Game messages ({len(game_keys)} total) ---")
 
     for identity_key in game_keys:
@@ -335,19 +332,32 @@ def main() -> None:
 
     # --- Footer ---
     print("\n--- Footer ---")
-    print("  SKIPPED  footer (not posted by post_daily_library_reminder — spec aspirational)")
+    footer_info = messages.get("footer") or {}
+    footer_msg_id = str(footer_info.get("message_id") or "").strip()
+    footer_ch_id = str(footer_info.get("channel_id") or "").strip()
+
+    if footer_msg_id and footer_ch_id:
+        if footer_msg_id in seen_message_ids:
+            result["errors"].append(f"Duplicate message_id {footer_msg_id} for footer.")
+        seen_message_ids.append(footer_msg_id)
+        msg = check_message(client, footer_ch_id, footer_msg_id, "gaming library footer", result)
+        result["footer_found"] = msg is not None and bool(msg.get("content"))
+    else:
+        if spec_required["footer_required"]:
+            result["errors"].append("Footer message_id or channel_id missing from daily_posts.")
+        print("  MISSING  footer (no message_id in state)")
 
     # --- Duplicate check ---
     duplicates_found = len(seen_message_ids) != len(set(seen_message_ids))
 
     # --- Pass logic driven by spec ---
-    # footer_required is excluded: code does not post a footer yet.
     intro_ok = not spec_required["intro_required"] or result["header_found"]
+    footer_ok = not spec_required["footer_required"] or result["footer_found"]
     items_ok = result["messages_checked"] >= spec_required["min_items"]
     no_missing = len(result["messages_missing"]) == 0
     no_dupes = not spec_required["no_duplicates"] or not duplicates_found
 
-    result["pass"] = intro_ok and items_ok and no_missing and no_dupes
+    result["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_dupes
 
     # --- Broken-if detection ---
     broken_if = specs.get(CHANNEL_NAME, {}).get("broken_if", [])
@@ -367,7 +377,7 @@ def main() -> None:
     print(f"  messages_missing:      {len(result['messages_missing'])}")
     print(f"  header_found:          {result['header_found']}")
     print(f"  game_messages_found:   {len(result['game_messages_found'])}")
-    print(f"  footer_skipped:        {result['footer_skipped']}")
+    print(f"  footer_found:          {result['footer_found']}")
     if result.get("triggered_broken_if"):
         print(f"  triggered_broken_if ({len(result['triggered_broken_if'])}):")
         for cond in result["triggered_broken_if"]:


### PR DESCRIPTION
## Summary

- **`gaming_library.py`**: `post_daily_library_reminder()` now posts a footer after all game messages. Footer links back to the header with a Discord jump link when `DISCORD_GUILD_ID` is set, otherwise posts a plain instructional footer. Footer message_id stored under `daily_posts[date].messages["footer"]`. Idempotent: edits existing footer rather than reposting.
- **`gaming-library-daily.yml`**: pass `DISCORD_GUILD_ID` secret to the post step so the jump link works in production
- **`verify_gaming_library.py`**: replace `footer_skipped: True` workaround with real footer check; re-enable `footer_required` in pass logic; `detect_broken_if` for "missing footer" now uses `footer_found` directly

Closes #143

## Test plan

- [ ] On next daily run, confirm `gaming_library.json` contains `messages.footer.message_id`
- [ ] Verify the footer message is visible in the Discord channel
- [ ] Verify `gaming_library_verification.json` shows `footer_found: true` and `pass: true`
- [ ] Verify `footer_skipped` key is gone from verification output