### PR TITLE
Document dual-cron intent in weekly-scheduling-bot.yml

### DIFF
--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
   schedule:
+    # Two cron entries are intentional: the second fires 10 minutes after the
+    # first as a reliability safety net. post_weekly_availability.py is fully
+    # idempotent — if the 13:00 run succeeds, the 13:10 run detects existing
+    # message IDs and exits early (SKIP / REUSE path). If the first run fails
+    # (e.g. transient Discord API error), the 13:10 run retries automatically.
     - cron: '0 13 * * 6'
     - cron: '10 13 * * 6'
 


### PR DESCRIPTION
## Summary

Audit of `weekly-scheduling-bot.yml` reliability (issue #144).

**Findings:**
- **Dual cron is intentional**: the 13:10 Saturday run is a safety net for transient 13:00 failures. `post_weekly_availability.py` is fully idempotent (REUSE path for existing message IDs, SKIP when the week is already complete).
- **Past failures were not scheduling bugs**: all Apr 8 failures were push-event runs on dev branches; the Apr 9 failure was the `ModuleNotFoundError: No module named 'discord_api'` bug fixed by PR #132 (`PYTHONPATH: .`).
- **Recent schedule run healthy**: `2026-04-13_to_2026-04-19` → `post_completed: True`, 7 days present.
- **No code change needed** — just a comment documenting the dual-cron intent.

Closes #144

## Test plan

- [ ] Verify weekly-scheduling-bot.yml YAML is valid
- [ ] Confirm comment accurately reflects the idempotency guarantee