### PR TITLE
Fix DLC filtering in paid section

### DIFF
--- a/main.py
+++ b/main.py
@@ -714,11 +714,11 @@ def is_vr_content(title: str, description: str, text: str, tags: List[str]) -> b
     return False
 
 
-def get_price_info(app_id: str) -> Tuple[Optional[float], bool, Optional[int]]:
+def get_price_info(app_id: str) -> Tuple[Optional[float], bool, Optional[int], Optional[str]]:
     try:
         url = (
             f"https://store.steampowered.com/api/appdetails"
-            f"?appids={app_id}&cc=us&filters=price_overview,is_free"
+            f"?appids={app_id}&cc=us"
         )
         response = requests.get(url, headers=HEADERS, timeout=30)
         response.raise_for_status()
@@ -726,26 +726,26 @@ def get_price_info(app_id: str) -> Tuple[Optional[float], bool, Optional[int]]:
 
         app_data = data.get(str(app_id), {})
         if not app_data.get("success"):
-            return None, False, None
+            return None, False, None, None
 
         info = app_data.get("data", {})
 
         if info.get("is_free") is True:
-            return 0.0, True, None
+            return 0.0, True, None, info.get("type")
 
         price_info = info.get("price_overview")
         if not price_info:
-            return None, False, None
+            return None, False, None, info.get("type")
 
         final_price_cents = price_info.get("final")
         if final_price_cents is None:
-            return None, False, None
+            return None, False, None, info.get("type")
 
         discount_percent = price_info.get("discount_percent", 0)
-        return round(final_price_cents / 100.0, 2), False, discount_percent
+        return round(final_price_cents / 100.0, 2), False, discount_percent, info.get("type")
     except Exception as e:
         print(f"PRICE API FAILED: app_id={app_id} | error={e}")
-        return None, False, None
+        return None, False, None, None
 
 
 def detect_item_type(source: str, app_id: str, title: str, text: str) -> str:
@@ -762,7 +762,10 @@ def detect_item_type(source: str, app_id: str, title: str, text: str) -> str:
         return "demo"
 
     if source == "paid_candidate":
-        price, is_free, _ = get_price_info(app_id)
+        price, is_free, _, item_type = get_price_info(app_id)
+
+        if item_type == "dlc":
+            return "ignore"
 
         if is_free:
             return "ignore"
@@ -1437,8 +1440,8 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
     item_type = detect_item_type(source, app_id, title, page_text)
 
     if source == "paid_candidate":
-        price, is_free, discount_percent = get_price_info(app_id)
-        print(f"PAID CHECK: {title} | price={price} | is_free={is_free} | discount={discount_percent}% | type={item_type}")
+        price, is_free, discount_percent, api_type = get_price_info(app_id)
+        print(f"PAID CHECK: {title} | price={price} | is_free={is_free} | discount={discount_percent}% | api_type={api_type} | item_type={item_type}")
 
     if item_type == "ignore":
         return None

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -42,7 +42,7 @@ def test_unknown_review_sentiment_penalized_and_blocked_for_paid(monkeypatch):
     free_html = build_html("Unknown Free", "friends game", base_text, review_sentiment="")
     paid_html = build_html("Unknown Paid", "friends game", base_text, review_sentiment="")
     stub_app_pages(monkeypatch, {"101": free_html, "102": paid_html})
-    monkeypatch.setattr(main, "get_price_info", lambda app_id: (9.99, False, 0))
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (9.99, False, 0, "game"))
 
     free_item = main.inspect_game("steam_free", "101")
     paid_item = main.inspect_game("paid_candidate", "102")
@@ -137,7 +137,7 @@ def test_paid_rejects_unknown_and_mixed(monkeypatch):
     unknown = build_html("Paid Unknown", "friends", "Multiplayer Online Co-Op up to 6 players")
     mixed = build_html("Paid Mixed", "friends", "Multiplayer Online Co-Op up to 6 players", "Mixed")
     stub_app_pages(monkeypatch, {"601": unknown, "602": mixed})
-    monkeypatch.setattr(main, "get_price_info", lambda app_id: (15.0, False, 0))
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (15.0, False, 0, "game"))
 
     unknown_item = main.inspect_game("paid_candidate", "601")
     mixed_item = main.inspect_game("paid_candidate", "602")
@@ -487,10 +487,26 @@ def test_discount_scoring_boosts_paid_games(monkeypatch):
     stub_app_pages(monkeypatch, {"1301": html, "1302": html})
 
     # 50% discount -> +3
-    monkeypatch.setattr(main, "get_price_info", lambda app_id: (10.0, False, 50) if app_id == "1301" else (10.0, False, 0))
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (10.0, False, 50, "game") if app_id == "1301" else (10.0, False, 0, "game"))
 
     discounted_item = main.inspect_game("paid_candidate", "1301")
     regular_item = main.inspect_game("paid_candidate", "1302")
 
     assert discounted_item is not None and regular_item is not None
     assert discounted_item["score"] == regular_item["score"] + 3
+
+
+def test_dlc_hard_excluded_from_paid_section(monkeypatch):
+    html = build_html(
+        "DLC Pack",
+        "expansion content",
+        "Multiplayer Online Co-Op up to 6 players",
+        "Very Positive",
+    )
+    stub_app_pages(monkeypatch, {"1401": html})
+
+    # DLC type should be excluded
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (15.0, False, 0, "dlc"))
+
+    item = main.inspect_game("paid_candidate", "1401")
+    assert item is None  # DLC should be excluded


### PR DESCRIPTION
Fixes #159: DLCs were appearing in paid section despite -8 penalty. Added hard exclusion by checking Steam API 'type' field for 'dlc'. Modified get_price_info to fetch full app details, added exclusion in detect_item_type. Tested against example DLC URL logic. All existing tests pass, added regression test for DLC exclusion.