### PR TITLE
feat: dynamic header and footer for Step 2 winners channel

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -72,14 +72,61 @@ def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) 
     return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
 
 
-def build_winners_intro_message() -> str:
+def build_winners_header_placeholder(target_day_key: str) -> str:
+    date_str = format_winners_footer_date(target_day_key)
     return "\n".join(
         [
-            "🏆 Daily Game Picks — Winners",
-            "",
-            "React with 🔖 on individual winners to promote them into Gaming Library.",
+            f"🏆 Daily Winners - {date_str}",
+            "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
         ]
     )
+
+
+def build_winners_navigation_header(
+    winners_state: dict,
+    *,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> str:
+    date_str = format_winners_footer_date(target_day_key)
+    lines = [
+        f"🏆 Daily Winners - {date_str}",
+        "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
+    ]
+
+    if not isinstance(guild_id, str) or not guild_id.strip() or not posted_section_keys:
+        return "\n".join(lines)
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Winners",
+        "free": "🎮 Free Winners",
+        "paid": "💸 Paid Winners",
+        "instagram": "📸 Creator Winners",
+    }
+    section_headers = winners_state.get("section_headers", {})
+    jump_lines = []
+    for section_key in SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            continue
+        channel_id = str(section_state.get("channel_id") or "").strip()
+        message_id = str(section_state.get("message_id") or "").strip()
+        if not channel_id or not message_id:
+            continue
+        section_label = section_labels.get(section_key)
+        if section_label:
+            jump_lines.append(
+                f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})"
+            )
+
+    if jump_lines:
+        lines.append("")
+        lines.extend(jump_lines)
+
+    return "\n".join(lines)
 
 
 def build_winners_section_header(section: str) -> str:
@@ -129,10 +176,11 @@ def build_winners_navigation_footer(
         "instagram": "📸 Creator Winners",
     }
     section_headers = winners_state.get("section_headers", {})
+    date_str = format_winners_footer_date(target_day_key)
     lines = [
-        f"🗓️ Daily Winners for {format_winners_footer_date(target_day_key)}",
+        f"🏆 Daily Winners - {date_str}",
         "",
-        f"🏆 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
+        f"🏆 Top of Post ⟹ [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
     ]
     for section_key in SECTION_ORDER:
         if section_key not in posted_section_keys:
@@ -146,7 +194,7 @@ def build_winners_navigation_footer(
             return None
         section_label = section_labels.get(section_key)
         if section_label:
-            lines.append(f"{section_label} → [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
+            lines.append(f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
     return "\n".join(lines)
 
 
@@ -678,11 +726,12 @@ def publish_winners_for_entries(
         winner_messages = {}
         winners_state["winner_messages"] = winner_messages
 
+    # Post header placeholder first (without jump links) — edited after sections post
     _ensure_post_or_edit_message(
         client,
         channel_id=winners_channel_id,
         state_entry=intro_state,
-        content=build_winners_intro_message(),
+        content=build_winners_header_placeholder(day_key),
         context_prefix=f"winners intro for {day_key}",
     )
 
@@ -739,6 +788,28 @@ def publish_winners_for_entries(
                     )
                 except DiscordMessageNotFoundError:
                     pass
+
+    # Edit header to add jump links now that all section messages exist
+    header_content = build_winners_navigation_header(
+        winners_state,
+        guild_id=DISCORD_GUILD_ID,
+        target_day_key=day_key,
+        posted_section_keys=posted_section_keys,
+    )
+    intro_message_id = str(intro_state.get("message_id") or "").strip()
+    intro_channel_id = str(intro_state.get("channel_id") or winners_channel_id).strip()
+    if intro_message_id and intro_channel_id:
+        try:
+            client.edit_message(
+                intro_channel_id,
+                intro_message_id,
+                header_content,
+                context=f"edit winners header with jump links for {day_key}",
+            )
+        except DiscordMessageNotFoundError:
+            print(f"WARN: winners header message missing; skip header jump-link edit for {day_key}")
+        except Exception as e:
+            print(f"WARN: failed to edit winners header for {day_key}: {e}")
 
     footer_content = build_winners_navigation_footer(
         winners_state,

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -101,17 +101,28 @@ def test_winners_channel_posts_intro_sections_games_and_footer_in_order(monkeypa
     winners.main()
 
     posted = [content for _, content, _, _ in fake.posts]
-    assert posted[0].startswith("🏆 Daily Game Picks — Winners")
+    # Header placeholder posted first (date + subtitle, no jump links yet)
+    assert posted[0].startswith("🏆 Daily Winners - ")
+    assert "bookmark to keep permanently" in posted[0]
     assert posted[1] == "🧪 Demo & Playtest Winners"
     assert "Demo Winner" in posted[2]
     assert posted[3] == "🎮 Free Winners"
     assert "Late Voted Earlier Day" in posted[4]
     assert posted[5] == "💸 Paid Winners"
     assert "Current Paid Winner" in posted[6]
-    assert posted[-1].startswith("🗓️ Daily Winners for")
-    assert "Demo & Playtest Winners → [Jump](https://discord.com/channels/guild-1/wchan/w-2)" in posted[-1]
-    assert "Free Winners → [Jump](https://discord.com/channels/guild-1/wchan/w-4)" in posted[-1]
-    assert "Paid Winners → [Jump](https://discord.com/channels/guild-1/wchan/w-6)" in posted[-1]
+    # Footer uses new format
+    assert posted[-1].startswith("🏆 Daily Winners - ")
+    assert "Top of Post ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-1)" in posted[-1]
+    assert "Demo & Playtest Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-2)" in posted[-1]
+    assert "Free Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-4)" in posted[-1]
+    assert "Paid Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-6)" in posted[-1]
+    # Header edited with jump links after sections posted
+    header_edits = [(mid, content) for _, mid, content, _ in fake.edits if mid == "w-1"]
+    assert header_edits, "Header message should be edited with jump links"
+    _, header_final = header_edits[-1]
+    assert "Demo & Playtest Winners ⟹ [Jump]" in header_final
+    assert "Free Winners ⟹ [Jump]" in header_final
+    assert "Paid Winners ⟹ [Jump]" in header_final
 
 
 def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
@@ -129,6 +140,93 @@ def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
     assert "Free Winners" in footer
     assert "Paid Winners" not in footer
     assert "Creator Winners" not in footer
+
+
+def test_winners_header_shows_date_and_subtitle(monkeypatch, tmp_path):
+    day_key = "2026-04-13"
+    path = tmp_path / "daily.json"
+    data = {day_key: {"items": [{"section": "free", "title": "G1", "url": "u1", "channel_id": "c", "message_id": "m-free"}]}}
+    path.write_text(json.dumps(data), encoding="utf-8")
+    fake = FakeDiscordClient(
+        {"m-free": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]}},
+        {"m-free": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}]},
+    )
+    _patch_common(monkeypatch, path, fake, day_key)
+    winners.main()
+
+    # First posted message is header placeholder
+    first_post = fake.posts[0][1]
+    assert "🏆 Daily Winners - Monday, April 13, 2026" in first_post
+    assert "bookmark to keep permanently" in first_post
+
+    # Header is subsequently edited with jump links
+    header_edits = [(mid, content) for _, mid, content, _ in fake.edits]
+    assert any("Free Winners ⟹ [Jump]" in content for _, content in header_edits)
+
+
+def test_winners_header_no_jump_links_when_guild_id_missing(monkeypatch, tmp_path):
+    day_key = "2026-04-13"
+    path = tmp_path / "daily.json"
+    data = {day_key: {"items": [{"section": "free", "title": "G1", "url": "u1", "channel_id": "c", "message_id": "m-free"}]}}
+    path.write_text(json.dumps(data), encoding="utf-8")
+    fake = FakeDiscordClient(
+        {"m-free": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]}},
+        {"m-free": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}]},
+    )
+    monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
+    monkeypatch.setattr(winners.requests, "Session", FakeSession)
+    monkeypatch.setattr(winners, "DiscordClient", lambda session: fake)
+    monkeypatch.setattr(winners, "DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setattr(winners, "DISCORD_WINNERS_CHANNEL_ID", "wchan")
+    monkeypatch.setattr(winners, "DISCORD_GUILD_ID", None)
+    monkeypatch.setenv(winners.WINNERS_DATE_OVERRIDE_ENV, day_key)
+
+    winners.main()
+
+    # No footer when guild ID missing
+    all_content = "\n".join(p[1] for p in fake.posts)
+    assert "Top of Post" not in all_content
+    # Header still posted with date
+    first_post = fake.posts[0][1]
+    assert "🏆 Daily Winners -" in first_post
+
+
+def test_winners_header_footer_reused_on_same_day_rerun(monkeypatch, tmp_path):
+    day_key = "2026-04-08"
+    path = tmp_path / "daily.json"
+    data = {
+        day_key: {
+            "items": [
+                {"section": "free", "title": "Free G", "url": "free-url", "channel_id": "c", "message_id": "m-free"}
+            ],
+            "winners_state": {
+                "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+                "section_headers": {"free": {"channel_id": "wchan", "message_id": "header-free-1"}},
+                "winner_messages": {"free-url": {"channel_id": "wchan", "message_id": "winner-1"}},
+                "footer": {"channel_id": "wchan", "message_id": "footer-1"},
+                "winner_keys": ["free-url"],
+                "winner_vote_counts": {"free-url": 1},
+                "winner_entries": [
+                    {"winner_key": "free-url", "section": "free", "title": "Free G", "url": "free-url", "human_votes": 1, "voter_names": ["u1"]}
+                ],
+            },
+        }
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    fake = FakeDiscordClient(
+        {
+            "m-free": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+            "intro-1": {},
+            "header-free-1": {},
+            "winner-1": {},
+            "footer-1": {},
+        },
+        {"m-free": [{"id": "bot-1"}, {"id": "u1", "username": "u1"}]},
+    )
+    _patch_common(monkeypatch, path, fake, day_key)
+    winners.main()
+    # No new posts — everything reused
+    assert fake.posts == []
 
 
 def test_bookmark_added_to_winners_game_messages_not_daily_messages(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Header posted as placeholder first (date + subtitle), then edited with jump links after all sections post
- Footer mirrors the header with a Top of Post jump link and per-category jump links
- Only categories with actual winners are shown
- Jump links omitted gracefully when `DISCORD_GUILD_ID` is missing
- Header and footer message IDs stored in `winners_state.intro` / `winners_state.footer` — reused on same-day reruns, no duplicates

## Test plan
- [x] `test_winners_header_shows_date_and_subtitle` — header includes date and subtitle; edited with jump links
- [x] `test_winners_header_no_jump_links_when_guild_id_missing` — graceful fallback
- [x] `test_winners_header_footer_reused_on_same_day_rerun` — no new posts on rerun
- [x] Updated `test_winners_channel_posts_intro_sections_games_and_footer_in_order` for new format
- [x] All 133 tests pass

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)