### PR TITLE
fix: health report — distinguish scheduled vs manual runs

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -150,7 +150,12 @@ def _format_ny_timestamp(value: Any) -> str | None:
     return f"{ny_time.strftime('%b')} {ny_time.day}, {hour_12}:{ny_time.minute:02d} {ny_time.strftime('%p')} ET"
 
 
-def evaluate_workflow_status(run: dict[str, Any] | None, stale_hours: int) -> tuple[str, str, bool, str]:
+def evaluate_workflow_status(
+    run: dict[str, Any] | None,
+    stale_hours: int,
+    *,
+    now_utc: datetime | None = None,
+) -> tuple[str, str, bool, str]:
     if not run:
         return "🟡", "no recent run found", False, "no_recent_run"
 
@@ -158,8 +163,9 @@ def evaluate_workflow_status(run: dict[str, Any] | None, stale_hours: int) -> tu
     if not isinstance(updated_at, str):
         return "🟡", "run timestamp missing", True, "timestamp_missing"
 
+    effective_now = now_utc or datetime.now(timezone.utc)
     run_time = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-    age_hours = (datetime.now(timezone.utc) - run_time).total_seconds() / 3600
+    age_hours = (effective_now - run_time).total_seconds() / 3600
     recency = _format_age(age_hours)
     conclusion = str(run.get("conclusion") or run.get("status") or "unknown")
 
@@ -372,6 +378,11 @@ def _workflow_guidance(
     if icon == "🟢":
         return None
     run_url = run.get("html_url") if isinstance(run, dict) and isinstance(run.get("html_url"), str) else None
+    if status_reason == "schedule_missed":
+        return (
+            "Action recommended",
+            f"Verify the scheduled trigger for {workflow_name} is still active; manually trigger if needed.",
+        )
     if status_reason == "stale":
         return (
             "Action required",
@@ -800,13 +811,38 @@ def build_workflow_status_lines(
         run = workflow.get("run")
         if not isinstance(run, dict):
             run = recent_runs[0] if isinstance(recent_runs, list) and recent_runs and isinstance(recent_runs[0], dict) else None
-        icon, status_text, include_details, status_reason = evaluate_workflow_status(run, stale_hours)
+        icon, status_text, include_details, status_reason = evaluate_workflow_status(run, stale_hours, now_utc=now_utc)
         schedule_diagnostics = build_schedule_diagnostics(
             workflow["name"],
             latest_run=run if isinstance(run, dict) else None,
             recent_runs=recent_runs if isinstance(recent_runs, list) else ([run] if isinstance(run, dict) else []),
             now_utc=now_utc,
         )
+        # Override icon to yellow for schedule-missed cases even when the run itself succeeded.
+        # Only override when we positively know the latest run was manual/non-scheduled
+        # (latest_run_event is set and not "schedule"). Unknown-event runs are not overridden.
+        if schedule_diagnostics and icon == "🟢":
+            known_manual = (
+                schedule_diagnostics.latest_run_event is not None
+                and schedule_diagnostics.latest_run_event != "schedule"
+            )
+            if (
+                known_manual
+                and schedule_diagnostics.code == "workflow.expected_scheduled_run_missing"
+            ):
+                icon = "🟡"
+                status_text = f"{status_text} — scheduled run missed, recovered manually"
+                status_reason = "schedule_missed"
+                include_details = True
+            elif (
+                known_manual
+                and schedule_diagnostics.code == "workflow.latest_manual_run"
+                and not schedule_diagnostics.found_scheduled_run_in_window
+            ):
+                icon = "🟡"
+                status_text = f"{status_text} — scheduled run missed, recovered manually"
+                status_reason = "schedule_missed"
+                include_details = True
         serialized = _serialize_schedule_diagnostics(workflow["name"], stale_hours, schedule_diagnostics)
         if serialized:
             diagnostics_payload.append(serialized)

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -595,3 +595,114 @@ def test_overall_summary_is_green_when_fully_healthy():
 
     assert "🟢 Overall: Healthy" in rendered
     assert "No action needed." in rendered
+
+
+# ---- Issue #169: schedule-missed cases always render as yellow ----
+
+def _make_workflow(name: str, run: dict, recent_runs: list) -> dict:
+    return {"name": name, "staleHours": 36, "run": run, "recentRuns": recent_runs}
+
+
+def test_expected_scheduled_run_missing_renders_yellow():
+    """workflow.expected_scheduled_run_missing must always show 🟡, not 🟢."""
+    now_utc = datetime(2026, 4, 10, 14, 30, tzinfo=timezone.utc)
+    manual_run = {
+        "id": 1,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T14:00:00+00:00",
+        "updated_at": "2026-04-10T14:05:00+00:00",
+        "conclusion": "success",
+    }
+    lines, _ = report.build_workflow_status_lines(
+        [_make_workflow("Daily Steam Picks", manual_run, [manual_run])],
+        now_utc=now_utc,
+    )
+    workflow_line = lines[0]
+    status_line = lines[1]
+    assert workflow_line.startswith("🟡"), f"Expected yellow, got: {workflow_line!r}"
+    assert "scheduled run missed" in status_line
+
+
+def test_latest_manual_run_without_scheduled_run_renders_yellow():
+    """workflow.latest_manual_run with no scheduled run in window must show 🟡."""
+    now_utc = datetime(2026, 4, 10, 23, 30, tzinfo=timezone.utc)
+    manual_run = {
+        "id": 2,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T23:10:00+00:00",
+        "updated_at": "2026-04-10T23:12:00+00:00",
+        "conclusion": "success",
+    }
+    # No scheduled run in recent_runs
+    lines, _ = report.build_workflow_status_lines(
+        [_make_workflow("Evening Winners", manual_run, [manual_run])],
+        now_utc=now_utc,
+    )
+    workflow_line = lines[0]
+    assert workflow_line.startswith("🟡"), f"Expected yellow, got: {workflow_line!r}"
+    assert "scheduled run missed" in lines[1]
+
+
+def test_latest_manual_run_with_scheduled_run_present_renders_green():
+    """workflow.latest_manual_run WITH a scheduled run in window keeps green."""
+    now_utc = datetime(2026, 4, 10, 23, 30, tzinfo=timezone.utc)
+    manual_run = {
+        "id": 3,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T23:20:00+00:00",
+        "updated_at": "2026-04-10T23:22:00+00:00",
+        "conclusion": "success",
+    }
+    scheduled_run = {
+        "id": 2,
+        "event": "schedule",
+        "created_at": "2026-04-10T23:01:00+00:00",
+        "updated_at": "2026-04-10T23:05:00+00:00",
+        "conclusion": "success",
+    }
+    lines, _ = report.build_workflow_status_lines(
+        [_make_workflow("Evening Winners", manual_run, [manual_run, scheduled_run])],
+        now_utc=now_utc,
+    )
+    workflow_line = lines[0]
+    assert workflow_line.startswith("🟢"), f"Expected green (scheduled run present), got: {workflow_line!r}"
+
+
+def test_schedule_missed_counts_as_follow_up_not_action_required_in_overall():
+    """Yellow schedule-missed workflows produce 'Follow-up recommended', not 'Action needed'."""
+    now_utc = datetime(2026, 4, 10, 14, 30, tzinfo=timezone.utc)
+    manual_run = {
+        "id": 4,
+        "event": "workflow_dispatch",
+        "created_at": "2026-04-10T14:00:00+00:00",
+        "updated_at": "2026-04-10T14:05:00+00:00",
+        "conclusion": "success",
+    }
+    lines, _ = report.build_workflow_status_lines(
+        [_make_workflow("Daily Steam Picks", manual_run, [manual_run])],
+        now_utc=now_utc,
+    )
+    rendered = report.render_report(
+        workflow_status_lines=lines,
+        state_issues=[],
+        report_date="Apr 10, 2026",
+    )
+    assert "🔴 Overall: Action needed" not in rendered
+    assert "🟡 Overall: Follow-up recommended" in rendered
+
+
+def test_scheduled_run_succeeded_renders_green():
+    """Normally scheduled and successful run must stay green."""
+    now_utc = datetime(2026, 4, 10, 13, 30, tzinfo=timezone.utc)
+    scheduled_run = {
+        "id": 5,
+        "event": "schedule",
+        "created_at": "2026-04-10T13:00:00+00:00",
+        "updated_at": "2026-04-10T13:10:00+00:00",
+        "conclusion": "success",
+    }
+    lines, _ = report.build_workflow_status_lines(
+        [_make_workflow("Daily Steam Picks", scheduled_run, [scheduled_run])],
+        now_utc=now_utc,
+    )
+    assert lines[0].startswith("🟢"), f"Expected green for successful scheduled run: {lines[0]!r}"


### PR DESCRIPTION
## Summary
- `workflow.expected_scheduled_run_missing` now renders as 🟡 instead of 🟢 — a scheduled run was missed even though a manual recovery succeeded
- `workflow.latest_manual_run` without a scheduled run in window also renders as 🟡 for the same reason
- `workflow.latest_manual_run` WITH a scheduled run in window stays 🟢
- Overall health summary correctly counts yellow schedule-missed workflows as "Follow-up recommended" not "Action needed"
- Also threads `now_utc` through `evaluate_workflow_status` to make stale-age calculations testable

## Test plan
- [x] `test_expected_scheduled_run_missing_renders_yellow` — 🟡 icon for missed schedule
- [x] `test_latest_manual_run_without_scheduled_run_renders_yellow` — 🟡 when no scheduled run in window
- [x] `test_latest_manual_run_with_scheduled_run_present_renders_green` — 🟢 when scheduled run found
- [x] `test_schedule_missed_counts_as_follow_up_not_action_required_in_overall` — overall health correct
- [x] `test_scheduled_run_succeeded_renders_green` — normal scheduled success still green
- [x] 160 tests pass (1 pre-existing failure unrelated to this change)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)