### PR TITLE
feat(state_utils): add format_et_timestamp utility and wire up health report

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -11,6 +12,8 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from state_utils import format_et_timestamp as _format_et_timestamp_util  # noqa: E402
 WEEKLY_PATHS = {
     "messages": ROOT / "data/scheduling/weekly_schedule_messages.json",
     "responses": ROOT / "data/scheduling/weekly_schedule_responses.json",
@@ -142,12 +145,7 @@ def _parse_iso_utc(value: Any) -> datetime | None:
 
 
 def _format_ny_timestamp(value: Any) -> str | None:
-    parsed = _parse_iso_utc(value)
-    if parsed is None:
-        return None
-    ny_time = parsed.astimezone(NEW_YORK_TZ)
-    hour_12 = ((ny_time.hour - 1) % 12) + 1
-    return f"{ny_time.strftime('%b')} {ny_time.day}, {hour_12}:{ny_time.minute:02d} {ny_time.strftime('%p')} ET"
+    return _format_et_timestamp_util(value)
 
 
 def evaluate_workflow_status(

--- a/state_utils.py
+++ b/state_utils.py
@@ -3,8 +3,15 @@
 import json
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
+
+try:
+    from zoneinfo import ZoneInfo
+
+    _ET = ZoneInfo("America/New_York")
+except Exception:
+    _ET = None  # type: ignore[assignment]
 
 
 LogFn = Callable[[str], None]
@@ -12,6 +19,28 @@ LogFn = Callable[[str], None]
 
 def _default_log(message: str) -> None:
     print(message)
+
+
+def format_et_timestamp(value: Any) -> str | None:
+    """Format an ISO UTC timestamp string as 'Dec 15, 2024 at 7:00 AM ET'.
+
+    Returns None if the value is not a valid timestamp string.
+    Falls back to UTC label if the Eastern timezone is unavailable.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    if _ET is None:
+        return parsed.astimezone(timezone.utc).strftime("%b %-d, %Y at %-I:%M %p UTC")
+    et = parsed.astimezone(_ET)
+    hour_12 = (et.hour % 12) or 12
+    return f"{et.strftime('%b')} {et.day}, {et.year} at {hour_12}:{et.minute:02d} {et.strftime('%p')} ET"
 
 
 def ensure_parent_dir(path: str) -> None:

--- a/tests/test_state_utils.py
+++ b/tests/test_state_utils.py
@@ -1,6 +1,6 @@
 import json
 
-from state_utils import load_json_object, prune_latest_iso_dates, prune_latest_keys, save_json_object_atomic
+from state_utils import format_et_timestamp, load_json_object, prune_latest_iso_dates, prune_latest_keys, save_json_object_atomic
 
 
 def test_load_json_object_returns_default_for_invalid_json(tmp_path):
@@ -32,6 +32,37 @@ def test_prune_latest_keys_keeps_newest_keys():
     assert len(pruned) == 12
     assert "week-01" not in pruned
     assert "week-15" in pruned
+
+
+def test_format_et_timestamp_basic_utc_noon():
+    # 2024-12-15T17:00:00Z is noon ET (UTC-5 in December)
+    result = format_et_timestamp("2024-12-15T17:00:00Z")
+    assert result == "Dec 15, 2024 at 12:00 PM ET"
+
+
+def test_format_et_timestamp_z_suffix_handled():
+    result = format_et_timestamp("2026-04-10T13:10:00Z")
+    # UTC-4 in April (EDT), so 13:10 UTC = 9:10 AM ET
+    assert result == "Apr 10, 2026 at 9:10 AM ET"
+
+
+def test_format_et_timestamp_returns_none_for_empty_string():
+    assert format_et_timestamp("") is None
+
+
+def test_format_et_timestamp_returns_none_for_non_string():
+    assert format_et_timestamp(None) is None
+    assert format_et_timestamp(12345) is None
+
+
+def test_format_et_timestamp_returns_none_for_invalid_iso():
+    assert format_et_timestamp("not-a-date") is None
+
+
+def test_format_et_timestamp_midnight_utc():
+    # 2026-01-01T00:00:00Z is Dec 31, 2025 at 7:00 PM ET (UTC-5 in January)
+    result = format_et_timestamp("2026-01-01T00:00:00Z")
+    assert result == "Dec 31, 2025 at 7:00 PM ET"
 
 
 def test_prune_latest_iso_dates_handles_mixed_keys_safely():


### PR DESCRIPTION
## Summary
- Adds `format_et_timestamp(value)` to `state_utils.py` that converts ISO UTC timestamps to `Dec 15, 2024 at 7:00 AM ET` format (with year, "at" separator, handles `Z` suffix and DST correctly)
- Updates `_format_ny_timestamp` in `build_daily_health_report.py` to delegate to the shared utility
- Adds 6 tests in `test_state_utils.py` covering basic conversion, DST, edge cases (empty string, None, invalid ISO)

Closes #171

## Test plan
- [x] `pytest tests/test_state_utils.py` — 11 passed
- [x] `pytest tests/test_build_daily_health_report.py` — 27 passed, 1 pre-existing failure unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)