### PR TITLE
fix(workflows): align all schedules to complete within same ET day

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -2,7 +2,7 @@ name: Auto Fix Loop
 
 on:
   workflow_run:
-    workflows: ["Steam Free Games", "Daily Game Picks Winners"]
+    workflows: ["Steam Free Games", "Daily Game Picks Winners", "Gaming Library Daily Reminder"]
     types: [completed]
 
 # Only one auto-fix may run at a time. Queue rather than cancel so no fix

--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # GitHub Actions cron uses UTC only (no timezone/DST support).
-    # 03:10 UTC is ~11:10 PM New York during EDT, ~10:10 PM during EST.
-    - cron: "10 3 * * *"
+    # 03:00 UTC is ~11:00 PM New York during EDT, ~10:00 PM during EST.
+    - cron: "0 3 * * *"
 
 permissions:
   actions: read
@@ -66,7 +66,7 @@ jobs:
               { file: "daily.yml", name: "Daily Steam Picks", staleHours: 20 },
               { file: "evening-winners.yml", name: "Evening Winners", staleHours: 12 },
               { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 20 },
-              { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 2 },
+              { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 4 },
             ];
 
             const output = [];
@@ -207,3 +207,50 @@ jobs:
                   print(result.stderr, file=sys.stderr)
               sys.exit(1)
           PY
+
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: post-health-report
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+
+          print(json.dumps({
+              "content": (
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -3,8 +3,8 @@ name: Daily System Briefing
 on:
   workflow_dispatch:
   schedule:
-    # 04:00 UTC — after all daily workflows have completed.
-    - cron: "0 4 * * *"
+    # 03:30 UTC — after bot-health-report (03:00 UTC) has completed.
+    - cron: "30 3 * * *"
 
 permissions:
   actions: read
@@ -231,3 +231,50 @@ jobs:
         run: |
           printf '%s' "${RUN_DATA_JSON}" > run_data.json
           python scripts/build_daily_briefing.py --run-data-json run_data.json
+
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: briefing
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+
+          print(json.dumps({
+              "content": (
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"

--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "0 14 * * *"
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/gaming-library-sync.yml
+++ b/.github/workflows/gaming-library-sync.yml
@@ -3,7 +3,7 @@ name: Gaming Library Sync
 on:
   workflow_dispatch:
   schedule:
-    - cron: "15 * * * *"
+    - cron: "0 */3 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -38,6 +38,11 @@ jobs:
             const WATCHED = [
               // --- Same-day mode (1.5× interval > 24 h) ---
               {
+                file: "daily.yml",
+                name: "Steam Free Games",
+                mode: "same-day",
+              },
+              {
                 file: "evening-winners.yml",
                 name: "Daily Game Picks Winners",
                 mode: "same-day",
@@ -48,6 +53,16 @@ jobs:
                 mode: "same-day",
               },
               {
+                file: "bot-health-report.yml",
+                name: "Bot Health Report",
+                mode: "same-day",
+              },
+              {
+                file: "daily-briefing.yml",
+                name: "Daily System Briefing",
+                mode: "same-day",
+              },
+              {
                 file: "weekly-scheduling-bot.yml",
                 name: "Weekly Scheduling Bot",
                 mode: "saturday-only",
@@ -55,16 +70,10 @@ jobs:
 
               // --- Elapsed-time mode (1.5× interval ≤ 24 h) ---
               {
-                file: "daily.yml",
-                name: "Steam Free Games",
-                mode: "elapsed",
-                intervalMs: 12 * 60 * 60 * 1000,   // 12 h → threshold 18 h
-              },
-              {
                 file: "gaming-library-sync.yml",
                 name: "Gaming Library Sync",
                 mode: "elapsed",
-                intervalMs: 1 * 60 * 60 * 1000,    // 1 h → threshold 90 min
+                intervalMs: 3 * 60 * 60 * 1000,    // 3 h → threshold 4.5 h
               },
               {
                 file: "weekly-scheduling-responses-sync.yml",


### PR DESCRIPTION
## Summary
- **4 cron changes** so all daily workflows complete within the same ET calendar day
- **Watchdog expanded** — added Bot Health Report + Daily System Briefing as same-day entries; daily.yml moved from elapsed-12h to same-day; gaming-library-sync threshold updated 1h→3h
- **Failure notifications added** to `bot-health-report.yml` and `daily-briefing.yml` (both were missing `failure()` guards)
- **Auto-fix trigger** expanded to include `Gaming Library Daily Reminder` (limited to workflows that produce verification artifacts)

### Schedule table (all ET)
| Workflow | Before | After |
|---|---|---|
| Gaming Library Sync | :15 every hour | every 3h on the hour |
| Gaming Library Daily | 10:00 AM ET | 8:00 PM ET |
| Bot Health Report | 11:10 PM ET | 11:00 PM ET |
| Daily Briefing | 12:00 AM ET (next day) | 11:30 PM ET |

Closes #175

## Test plan
- [x] `pytest` — 199 passed, 1 pre-existing failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)