### PR TITLE
fix: manual workflow_dispatch runs no longer block scheduled runs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -64,6 +64,7 @@ jobs:
           INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python main.py
 
       - name: Verify Discord output

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -37,6 +37,7 @@ jobs:
           DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python evening_winners.py
 
       - name: Save updated winners state

--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -36,6 +36,7 @@ jobs:
           DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/post_daily_gaming_library.py
 
       - name: Verify gaming library output

--- a/.github/workflows/gaming-library-sync.yml
+++ b/.github/workflows/gaming-library-sync.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           PYTHONPATH: .
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/sync_gaming_library.py
 
       - name: Save synced gaming library state

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -41,6 +41,7 @@ jobs:
           DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
           DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
           SCHEDULE_WEEK_START: ${{ inputs.schedule_week_start }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/post_weekly_availability.py
 
       - name: Verify weekly schedule output

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -64,6 +64,7 @@ jobs:
           TARGET_WEEK_KEY: ${{ github.event.inputs.target_week_key || '' }}
           REBUILD_SUMMARY_ONLY: ${{ github.event.inputs.rebuild_summary_only || 'false' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/sync_weekly_schedule_responses.py
 
       - name: Log sync completion

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
 FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 DAILY_VERIFICATION_FILE = "daily_verification.json"
 STOP_GO_RESULT_FILE = "daily_stop_go_result.json"
@@ -1781,6 +1782,16 @@ def get_force_refresh_same_day() -> bool:
     )
 
 
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT mark the day as completed so that
+    the subsequent scheduled run always executes cleanly.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
+
+
 def format_daily_picks_footer_date(target_day_key: str) -> str:
     target_day = datetime.fromisoformat(target_day_key).date()
     return f"{target_day:%A, %B} {target_day.day}, {target_day:%Y}"
@@ -1963,8 +1974,14 @@ def post_daily_pick_messages(
     instagram_posts: List[dict],
     *,
     force_refresh_same_day: bool = False,
+    manual_run: bool = False,
 ) -> Tuple[Dict[str, int], bool]:
-    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active, verification_state)."""
+    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active, verification_state).
+
+    When manual_run is True (workflow_dispatch trigger), the run completes normally
+    but does NOT mark the day as completed in state. This ensures the next scheduled
+    run always executes cleanly regardless of prior manual runs.
+    """
     run_counts: Dict[str, int] = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
     if not (demo_playtest_items or free_items or paid_items or instagram_posts):
         return run_counts, False, {}
@@ -2207,10 +2224,13 @@ def post_daily_pick_messages(
         post_or_reconcile_simple(footer_content, "footer", footer_state)
         sleep_briefly()
 
-    run_state["completed"] = True
-    run_state["completed_at_utc"] = utc_now_iso()
+    if manual_run:
+        print(f"MANUAL RUN: daily picks done for {day_key}; skipping completed=True to preserve scheduled run eligibility")
+    else:
+        run_state["completed"] = True
+        run_state["completed_at_utc"] = utc_now_iso()
+        print(f"COMPLETE: daily picks state marked completed for {day_key}")
     save_discord_daily_posts(daily_posts)
-    print(f"COMPLETE: daily picks state marked completed for {day_key}")
     return run_counts, False, {
         "run_state": run_state,
         "items": day_entry.get("items") or [],
@@ -2497,7 +2517,7 @@ def export_stop_go_result(
     )
 
 
-def run_daily_workflow(*, force_refresh_same_day: bool = False) -> None:
+def run_daily_workflow(*, force_refresh_same_day: bool = False, manual_run: bool = False) -> None:
     state = load_state()
     print(f"Daily run target date (UTC): {get_target_day_key()}")
 
@@ -2668,12 +2688,16 @@ def run_daily_workflow(*, force_refresh_same_day: bool = False) -> None:
     force_refresh_same_day = force_refresh_same_day or get_force_refresh_same_day()
     if force_refresh_same_day:
         print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
+    manual_run = manual_run or is_manual_run()
+    if manual_run:
+        print("Daily picks run is a manual (workflow_dispatch) run — completed flag will not be set")
     run_counts, rerun_protection_active, verification_state = post_daily_pick_messages(
         demo_playtest_items,
         free_items,
         paid_items,
         instagram_posts,
         force_refresh_same_day=force_refresh_same_day,
+        manual_run=manual_run,
     )
 
     if not demo_playtest_items and not free_items and not paid_items:

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -578,6 +578,98 @@ def test_daily_picks_footer_skips_safely_when_guild_id_missing(monkeypatch, tmp_
     assert saved[day_key]["run_state"]["completed"] is True
 
 
+def test_manual_run_does_not_set_completed_flag(monkeypatch, tmp_path):
+    """workflow_dispatch runs post normally but do not mark the day as completed."""
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-09"
+    posted = []
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda message, capture_metadata=False: posted.append(message))
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages(
+        [], [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}], [], [],
+        manual_run=True,
+    )
+
+    # Posts happened (manual run still posts to Discord)
+    assert len(posted) > 0
+    # But completed flag is NOT set
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"].get("completed") is not True
+
+
+def test_scheduled_run_sets_completed_flag(monkeypatch, tmp_path):
+    """schedule-triggered runs mark the day as completed normally."""
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-09"
+    posted = []
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda message, capture_metadata=False: posted.append(message))
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages(
+        [], [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}], [], [],
+        manual_run=False,
+    )
+
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"]["completed"] is True
+
+
+def test_manual_run_followed_by_scheduled_run_executes_normally(monkeypatch, tmp_path):
+    """After a manual run, the scheduled run still runs (not blocked by completed flag)."""
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-09"
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}]
+
+    # Manual run first
+    manual_posts = []
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda msg, capture_metadata=False: manual_posts.append(msg))
+    main.post_daily_pick_messages([], free_items, [], [], manual_run=True)
+    assert manual_posts  # posts happened
+
+    # Scheduled run after — must NOT be blocked
+    scheduled_posts = []
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda msg, capture_metadata=False: scheduled_posts.append(msg))
+    _, rerun_protection_active, _ = main.post_daily_pick_messages([], free_items, [], [], manual_run=False)
+    assert not rerun_protection_active  # was not skipped
+    assert scheduled_posts  # posts happened
+    # Now completed is set
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"]["completed"] is True
+
+
+def test_is_manual_run_detects_workflow_dispatch(monkeypatch):
+    monkeypatch.setenv(main.GITHUB_EVENT_NAME_ENV, "workflow_dispatch")
+    assert main.is_manual_run() is True
+
+
+def test_is_manual_run_returns_false_for_schedule(monkeypatch):
+    monkeypatch.setenv(main.GITHUB_EVENT_NAME_ENV, "schedule")
+    assert main.is_manual_run() is False
+
+
+def test_is_manual_run_returns_false_when_env_unset(monkeypatch):
+    monkeypatch.delenv(main.GITHUB_EVENT_NAME_ENV, raising=False)
+    assert main.is_manual_run() is False
+
+
 def test_daily_section_order_is_product_invariant():
     assert main.DAILY_SECTION_ORDER == ["demo_playtest", "free", "paid", "instagram"]
     assert [entry["header"] for entry in main.DAILY_SECTION_CONFIG] == [


### PR DESCRIPTION
## Summary
- Adds `is_manual_run()` to detect `workflow_dispatch` triggers in `main.py`
- Manual runs skip setting `completed=True`, so the scheduled run remains eligible to execute
- Wires `GITHUB_EVENT_NAME: ${{ github.event_name }}` into all 6 affected workflows (daily, evening-winners, gaming-library-daily, gaming-library-sync, weekly-scheduling-bot, weekly-scheduling-responses-sync)
- Adds 6 new tests covering manual/scheduled flag behaviour

Closes #180

## Test plan
- [x] `python -m pytest tests/test_main_daily_picks.py -v` — 66 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)