### PR TITLE
feat: add per-player game counts and pending reactions to daily summary

### DIFF
--- a/gaming_library.py
+++ b/gaming_library.py
@@ -159,43 +159,61 @@ def compute_daily_delta(state: Dict[str, Any]) -> str:
 
     new_games = []
     status_changes = []
-    pending = 0
+    pending_items: List[str] = []
+
+    # Per-player game count: count assignments across all active (non-archived) games.
+    player_game_counts: Dict[str, int] = {}
 
     for key, game in current_games.items():
         if not isinstance(game, dict):
             continue
+        if game.get("archived"):
+            continue
+        curr_assignments = game.get("assignments", {})
+        game_name = game.get("canonical_name", "Untitled")
+
+        # Count this game toward each assigned player.
+        for user_id in curr_assignments:
+            player_game_counts[user_id] = player_game_counts.get(user_id, 0) + 1
+
         if key not in previous_games:
-            new_games.append(game.get("canonical_name", "Untitled"))
+            new_games.append(game_name)
         else:
             prev_assignments = previous_games[key].get("assignments", {})
-            curr_assignments = game.get("assignments", {})
             for user_id, curr_ass in curr_assignments.items():
                 if not isinstance(curr_ass, dict):
                     continue
                 prev_ass = prev_assignments.get(user_id)
                 if isinstance(prev_ass, dict) and curr_ass.get("status") != prev_ass.get("status"):
                     user_mention = f"<@{user_id}>"
-                    game_name = game.get("canonical_name", "Untitled")
                     old_status = prev_ass.get("status", "unknown")
                     new_status = curr_ass.get("status", "unknown")
                     status_changes.append(f"{user_mention} changed {game_name}: {old_status} → {new_status}")
-                # Check pending: assigned but status active and not updated after created
+                # Pending: assigned with active status but never updated (no reaction recorded yet).
                 if curr_ass.get("status") == STATUS_ACTIVE:
                     updated = curr_ass.get("updated_at_utc")
                     created = game.get("created_at_utc")
                     if updated == created:
-                        pending += 1
+                        pending_items.append(f"⏳ <@{user_id}> has not reacted on {game_name}")
 
     lines = []
+
+    # Per-player summary at the top.
+    if player_game_counts:
+        lines.append("👥 Players:")
+        for user_id, count in sorted(player_game_counts.items()):
+            lines.append(f"  • <@{user_id}> — {count} game{'s' if count != 1 else ''} assigned")
+
     if new_games:
         lines.append(f"🎉 {len(new_games)} Games added to library today (bookmarked from Step 2)")
     if status_changes:
         lines.append(f"🔄 {len(status_changes)} Status changes since yesterday:")
         for change in status_changes[:5]:  # limit to 5
             lines.append(f"  • {change}")
-    if pending:
-        lines.append(f"⏳ {pending} Players who have not reacted on a game they are assigned to (pending status)")
-    if not new_games and not status_changes and not pending:
+    if pending_items:
+        for item in pending_items[:10]:  # limit to 10 to avoid message bloat
+            lines.append(item)
+    if not new_games and not status_changes and not pending_items:
         lines.append("No changes since yesterday")
 
     return "\n".join(lines)

--- a/tests/test_gaming_library.py
+++ b/tests/test_gaming_library.py
@@ -544,3 +544,87 @@ def test_header_edited_with_jump_links_after_sections_posted(monkeypatch):
 
     monkeypatch.delenv("DISCORD_GUILD_ID", raising=False)
     importlib.reload(_lib_mod)
+
+
+# --- Issue #184: Per-player counts and pending reactions in daily summary ---
+
+def _make_state_with_games(game_specs):
+    """Build a minimal library state from a list of (name, url, assignments) tuples.
+    assignments is a dict of {user_id: {status, updated_at_utc}} or None for no assignments.
+    Sets previous_day_games to an empty dict so all games are treated as new.
+    """
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    for name, url, assignments in game_specs:
+        game = lib.ensure_game_entry(state, canonical_name=name, url=url)
+        if assignments:
+            for user_id, ass_data in assignments.items():
+                game.setdefault("assignments", {})[user_id] = ass_data
+    state["previous_day_games"] = {}
+    return state
+
+
+def test_per_player_summary_included_when_players_assigned():
+    state = _make_state_with_games([
+        ("Alpha", "https://store.steampowered.com/app/1/alpha/", {"u1": {"status": "active", "updated_at_utc": "t1"}, "u2": {"status": "active", "updated_at_utc": "t1"}}),
+        ("Beta", "https://store.steampowered.com/app/2/beta/", {"u1": {"status": "active", "updated_at_utc": "t1"}}),
+    ])
+    result = lib.compute_daily_delta(state)
+    assert "👥 Players:" in result
+    assert "<@u1> — 2 games assigned" in result
+    assert "<@u2> — 1 game assigned" in result
+
+
+def test_per_player_summary_absent_when_no_assignments():
+    state = _make_state_with_games([
+        ("No Players Game", "https://store.steampowered.com/app/3/noplayers/", None),
+    ])
+    result = lib.compute_daily_delta(state)
+    assert "👥 Players:" not in result
+
+
+def test_per_player_summary_skips_archived_games():
+    state = _make_state_with_games([
+        ("Active Game", "https://store.steampowered.com/app/4/active/", {"u1": {"status": "active", "updated_at_utc": "t1"}}),
+        ("Archived Game", "https://store.steampowered.com/app/5/archived/", {"u1": {"status": "active", "updated_at_utc": "t1"}}),
+    ])
+    state["games"]["steam:5"]["archived"] = True
+    result = lib.compute_daily_delta(state)
+    assert "<@u1> — 1 game assigned" in result
+
+
+def test_pending_reaction_flags_specific_user_and_game():
+    """A player with status=active and updated_at_utc == game's created_at_utc is flagged as pending."""
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    game = lib.ensure_game_entry(state, canonical_name="Pending Game", url="https://store.steampowered.com/app/6/pending/")
+    created_ts = game["created_at_utc"]
+    # Simulate assignment with updated_at == game.created_at (no reaction yet)
+    game["assignments"]["u99"] = {"status": lib.STATUS_ACTIVE, "updated_at_utc": created_ts}
+    state["previous_day_games"] = {list(state["games"].keys())[0]: game.copy()}
+    result = lib.compute_daily_delta(state)
+    assert "⏳ <@u99> has not reacted on Pending Game" in result
+
+
+def test_pending_not_flagged_when_status_updated():
+    """A player whose assignment was updated after game creation is NOT flagged as pending."""
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    game = lib.ensure_game_entry(state, canonical_name="Updated Game", url="https://store.steampowered.com/app/7/updated/")
+    game["assignments"]["u88"] = {"status": lib.STATUS_ACTIVE, "updated_at_utc": "2099-01-01T00:00:00+00:00"}
+    state["previous_day_games"] = {list(state["games"].keys())[0]: game.copy()}
+    result = lib.compute_daily_delta(state)
+    assert "⏳" not in result
+
+
+def test_new_games_still_reported_alongside_per_player_summary():
+    state = _make_state_with_games([
+        ("New Addition", "https://store.steampowered.com/app/8/new/", {"u1": {"status": "active", "updated_at_utc": "t1"}}),
+    ])
+    result = lib.compute_daily_delta(state)
+    assert "🎉 1 Games added to library today" in result
+    assert "👥 Players:" in result
+
+
+def test_no_changes_message_shown_when_empty_library():
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    state["previous_day_games"] = {}
+    result = lib.compute_daily_delta(state)
+    assert "No changes since yesterday" in result


### PR DESCRIPTION
## Summary
- `compute_daily_delta` now shows a **👥 Players:** section at the top listing each assigned player and their total game count
- Pending reaction detection changed from an aggregate count to per-game/per-player `⏳ @user has not reacted on GameName` lines
- Archived games are excluded from player counts

Closes #184

## Test plan
- [x] `python -m pytest tests/test_gaming_library.py -v` — 32 passed (7 new tests)
- [x] `python -m pytest` — 207 passed (excluding pre-existing health report failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)