### PR TITLE
fix: use real OS time for summary_last_synced_at_utc in healthy state fixture

### DIFF
--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -31,6 +31,9 @@ def _seed_healthy_state(root: Path, *, now_utc: datetime):
     _write_json(root / "data/scheduling/weekly_schedule_messages.json", {week: {"intro_message_id": "123"}})
     _write_json(root / "data/scheduling/weekly_schedule_responses.json", {week: {"users": {"1": {"days": {}}}}})
     _write_json(root / "data/scheduling/weekly_schedule_summary.json", {week: {"summary": {"day_counts": {}}}})
+    # summary_last_synced_at_utc must use the actual OS time (not the test's fixed now_utc)
+    # because the staleness check compares this value against file mtime on disk.
+    # Using now_utc (a past fixed date) would always cause a >20-minute gap with the real mtime.
     _write_json(
         root / "data/scheduling/weekly_schedule_bot_outputs.json",
         {
@@ -38,7 +41,7 @@ def _seed_healthy_state(root: Path, *, now_utc: datetime):
                 "summary_message_id": "123",
                 "summary_message_content": "hello",
                 "summary_data_signature": "sig",
-                "summary_last_synced_at_utc": now_utc.isoformat(),
+                "summary_last_synced_at_utc": datetime.now(timezone.utc).isoformat(),
             }
         },
     )


### PR DESCRIPTION
## Summary
- `_seed_healthy_state` was setting `summary_last_synced_at_utc` to the test's fixed `now_utc` (2026-04-10)
- The staleness check compares this value against the actual file mtime on disk
- Files are written at real OS time, creating a multi-day gap that always triggers the >20-minute stale warning
- Fix: use `datetime.now(timezone.utc)` for that field so it tracks actual file write time

Closes #185

## Test plan
- [x] `test_healthy_state_has_all_clear_message` — now passes
- [x] Full suite: 235 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)