### PR TITLE
feat: improve bot error handling for missing Discord permissions (#198)

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -237,12 +237,21 @@ jobs:
                If this stash pattern is missing, add it and apply the same fix to all
                other workflows that use git pull --rebase.
             4. Fix only the root cause. Do not refactor unrelated code.
-            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-1
+            5. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-1
                branched from main.
-            5. Commit your changes with a message that explains what failed and
+            6. Commit your changes with a message that explains what failed and
                what you changed.
-            6. Open a pull request against main with a clear description of the
+            7. Open a pull request against main with a clear description of the
                failure and the fix.
+
+            IMPORTANT — 403 Forbidden errors are NOT code bugs: If the failure was
+            caused by a Discord 403 Forbidden response (e.g. the bot is missing
+            Send Messages, Add Reactions, Read Message History, or Manage Messages
+            permissions in a channel), this is a Discord server configuration issue,
+            not a code defect. Do NOT open a code PR. Instead, post a message to
+            the xiann-gpt-bot-health-monitor Discord channel (using the
+            DISCORD_HEALTH_MONITOR_WEBHOOK_URL secret) explaining which channel and
+            permission is missing, then exit without making any code changes.
 
             Important: use model claude-sonnet-4-6, not Opus.
 
@@ -299,12 +308,21 @@ jobs:
                If this stash pattern is missing, add it and apply the same fix to all
                other workflows that use git pull --rebase.
             4. Fix only the root cause. Do not refactor unrelated code.
-            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-2
+            5. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-2
                branched from main.
-            5. Commit your changes with a message that explains what failed and
+            6. Commit your changes with a message that explains what failed and
                what you changed.
-            6. Open a pull request against main with a clear description of the
+            7. Open a pull request against main with a clear description of the
                failure and the fix.
+
+            IMPORTANT — 403 Forbidden errors are NOT code bugs: If the failure was
+            caused by a Discord 403 Forbidden response (e.g. the bot is missing
+            Send Messages, Add Reactions, Read Message History, or Manage Messages
+            permissions in a channel), this is a Discord server configuration issue,
+            not a code defect. Do NOT open a code PR. Instead, post a message to
+            the xiann-gpt-bot-health-monitor Discord channel (using the
+            DISCORD_HEALTH_MONITOR_WEBHOOK_URL secret) explaining which channel and
+            permission is missing, then exit without making any code changes.
 
             Important: use model claude-sonnet-4-6, not Opus.
 
@@ -361,12 +379,21 @@ jobs:
                If this stash pattern is missing, add it and apply the same fix to all
                other workflows that use git pull --rebase.
             4. Fix only the root cause. Do not refactor unrelated code.
-            4. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-3
+            5. Create a new branch named fix/auto-fix-${{ github.event.workflow_run.id }}-3
                branched from main.
-            5. Commit your changes with a message that explains what failed and
+            6. Commit your changes with a message that explains what failed and
                what you changed.
-            6. Open a pull request against main with a clear description of the
+            7. Open a pull request against main with a clear description of the
                failure and the fix.
+
+            IMPORTANT — 403 Forbidden errors are NOT code bugs: If the failure was
+            caused by a Discord 403 Forbidden response (e.g. the bot is missing
+            Send Messages, Add Reactions, Read Message History, or Manage Messages
+            permissions in a channel), this is a Discord server configuration issue,
+            not a code defect. Do NOT open a code PR. Instead, post a message to
+            the xiann-gpt-bot-health-monitor Discord channel (using the
+            DISCORD_HEALTH_MONITOR_WEBHOOK_URL secret) explaining which channel and
+            permission is missing, then exit without making any code changes.
 
             Important: use model claude-sonnet-4-6, not Opus.
 

--- a/discord_api.py
+++ b/discord_api.py
@@ -11,6 +11,14 @@ DISCORD_MESSAGE_TARGET_LIMIT = 1900
 DEFAULT_TIMEOUT_SECONDS = 30
 RETRY_STATUSES = {429, 500, 502, 503, 504}
 
+# Discord permission bitflags
+PERM_ADMINISTRATOR = 1 << 3
+PERM_ADD_REACTIONS = 1 << 6
+PERM_VIEW_CHANNEL = 1 << 10
+PERM_SEND_MESSAGES = 1 << 11
+PERM_MANAGE_MESSAGES = 1 << 13
+PERM_READ_MESSAGE_HISTORY = 1 << 16
+
 
 def split_discord_content(
     content: str,
@@ -78,6 +86,20 @@ class DiscordMessageNotFoundError(DiscordApiError):
     pass
 
 
+class DiscordPermissionError(DiscordApiError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        channel_id: str = "",
+        permission: str = "",
+        response: requests.Response | None = None,
+    ):
+        super().__init__(message, response=response)
+        self.channel_id = channel_id
+        self.permission = permission
+
+
 class DiscordClient:
     def __init__(self, session: requests.Session, *, timeout: int = DEFAULT_TIMEOUT_SECONDS, max_retries: int = 5):
         self.session = session
@@ -106,6 +128,12 @@ class DiscordClient:
                 print(f"DISCORD RETRY: {context}; attempt={attempt}/{self.max_retries}; status={response.status_code}; sleeping {sleep_seconds:.1f}s")
                 time.sleep(sleep_seconds)
                 continue
+
+            if response.status_code == 403:
+                raise DiscordPermissionError(
+                    f"{context}: Discord returned 403 Forbidden — bot is missing permissions",
+                    response=response,
+                )
 
             if response.status_code == 404 and self._is_unknown_message(response):
                 raise DiscordMessageNotFoundError(f"{context}: Discord message not found", response=response)
@@ -174,6 +202,72 @@ class DiscordClient:
 
     def pin_message(self, channel_id: str, message_id: str, *, context: str) -> None:
         self.request("PUT", f"{DISCORD_API_BASE}/channels/{channel_id}/pins/{message_id}", context=context)
+
+    def check_bot_permissions(self, channel_id: str, guild_id: str, *, bot_user_id: str = "") -> int:
+        """Return the bot's effective permission bitfield for the given channel.
+
+        Fetches guild member roles, role permissions, and channel permission overwrites,
+        then computes the effective bitfield.  Returns 0 on any API error (best-effort
+        check — the caller should treat 0 as "permissions unknown").
+        """
+        try:
+            member_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/guilds/{guild_id}/members/@me",
+                context="check bot guild member",
+            )
+            member = self._parse_json_object(member_resp, "guild member JSON")
+            bot_role_ids: set[str] = {str(r) for r in member.get("roles", [])}
+
+            roles_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/guilds/{guild_id}/roles",
+                context="check guild roles",
+            )
+            roles = self._parse_json_array(roles_resp, "guild roles JSON")
+
+            base_permissions = 0
+            for role in roles:
+                role_id = str(role.get("id", ""))
+                perms = int(role.get("permissions", 0))
+                if role_id == str(guild_id) or role_id in bot_role_ids:
+                    base_permissions |= perms
+
+            if base_permissions & PERM_ADMINISTRATOR:
+                return (1 << 53) - 1  # all permissions
+
+            channel_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/channels/{channel_id}",
+                context="check channel overwrites",
+            )
+            channel = self._parse_json_object(channel_resp, "channel JSON")
+            overwrites: list[dict[str, Any]] = [
+                ow for ow in channel.get("permission_overwrites", []) if isinstance(ow, dict)
+            ]
+
+            if not bot_user_id:
+                bot_user = self.get_current_user(context="check bot user for permissions")
+                bot_user_id = str(bot_user.get("id", ""))
+
+            role_allow = role_deny = member_allow = member_deny = 0
+            for ow in overwrites:
+                ow_id = str(ow.get("id", ""))
+                ow_type = int(ow.get("type", -1))
+                ow_allow = int(ow.get("allow", 0))
+                ow_deny = int(ow.get("deny", 0))
+                if ow_type == 0 and (ow_id == str(guild_id) or ow_id in bot_role_ids):
+                    role_allow |= ow_allow
+                    role_deny |= ow_deny
+                elif ow_type == 1 and ow_id == bot_user_id:
+                    member_allow |= ow_allow
+                    member_deny |= ow_deny
+
+            permissions = (base_permissions & ~role_deny) | role_allow
+            permissions = (permissions & ~member_deny) | member_allow
+            return permissions
+        except (DiscordApiError, ValueError, TypeError, KeyError):
+            return 0
 
     @staticmethod
     def _parse_json_object(response: requests.Response, context: str) -> dict[str, Any]:

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -6,7 +6,15 @@ from urllib.parse import quote
 
 import requests
 
-from discord_api import DiscordClient, DiscordMessageNotFoundError
+from discord_api import (
+    DiscordClient,
+    DiscordMessageNotFoundError,
+    DiscordPermissionError,
+    PERM_ADD_REACTIONS,
+    PERM_MANAGE_MESSAGES,
+    PERM_READ_MESSAGE_HISTORY,
+    PERM_SEND_MESSAGES,
+)
 from state_utils import load_json_object, save_json_object_atomic
 
 GAMING_LIBRARY_FILE = "gaming_library.json"
@@ -14,6 +22,7 @@ DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_GAMING_LIBRARY_CHANNEL_ID = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID")
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
 LIBRARY_DATE_OVERRIDE_ENV = "LIBRARY_DATE_UTC"
 
 STATUS_ACTIVE = "active"
@@ -940,6 +949,66 @@ def _find_game_by_name(games: Dict[str, Any], name: str) -> Optional[Dict[str, A
     return None
 
 
+def _notify_health_monitor(message: str) -> None:
+    """Post a warning to the Discord health monitor webhook (best-effort, never raises)."""
+    url = DISCORD_HEALTH_MONITOR_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json={"content": message}, timeout=10)
+    except Exception:
+        pass
+
+
+def _check_channel_permissions(
+    client: DiscordClient,
+    channel_id: str,
+    guild_id: str,
+    context: str,
+    *,
+    bot_user_id: str = "",
+) -> None:
+    """Preflight check: warn if the bot is missing required permissions in a channel.
+
+    Logs a warning and notifies the health monitor if any required permission is
+    missing.  Always returns — the caller continues regardless.
+    """
+    required = {
+        "Send Messages": PERM_SEND_MESSAGES,
+        "Add Reactions": PERM_ADD_REACTIONS,
+        "Read Message History": PERM_READ_MESSAGE_HISTORY,
+        "Manage Messages": PERM_MANAGE_MESSAGES,
+    }
+    try:
+        effective = client.check_bot_permissions(channel_id, guild_id, bot_user_id=bot_user_id)
+    except Exception as exc:
+        print(f"WARN: {context} — could not check bot permissions: {exc}")
+        return
+
+    if effective == 0:
+        print(f"WARN: {context} — could not determine bot permissions for channel {channel_id}")
+        return
+
+    missing = [name for name, flag in required.items() if not (effective & flag)]
+    if not missing:
+        return
+
+    warning = (
+        f"⚠️ {context} — Bot is missing Discord permissions in <#{channel_id}>: "
+        + ", ".join(missing)
+        + ". The bot will attempt to continue but errors may occur."
+    )
+    print(f"WARN: {warning}")
+    _notify_health_monitor(
+        f"⚠️ Gaming Library — Missing Discord Permissions\n\n"
+        f"Context: {context}\n"
+        f"Channel: <#{channel_id}>\n"
+        f"Missing: {', '.join(missing)}\n\n"
+        f"The bot will attempt to continue but errors may occur. "
+        f"Please grant the required permissions to the bot in that channel."
+    )
+
+
 def ensure_command_reference_pinned(
     state: Dict[str, Any],
     client: DiscordClient,
@@ -960,6 +1029,23 @@ def ensure_command_reference_pinned(
         if msg_id:
             try:
                 client.pin_message(channel_id, msg_id, context="pin command reference")
+            except DiscordPermissionError as exc:
+                warning = (
+                    f"⚠️ Bot is missing permission to pin messages in <#{channel_id}>. "
+                    f"The command reference was posted (message ID {msg_id}) but could not be pinned. "
+                    f"Please grant the bot 'Manage Messages' permission in this channel."
+                )
+                print(f"WARN: pin command reference — {exc}")
+                try:
+                    client.post_message(channel_id, warning, context="post pin permission warning")
+                except Exception:
+                    pass
+                _notify_health_monitor(
+                    f"⚠️ Gaming Library — Missing Pin Permission\n\n"
+                    f"Channel: <#{channel_id}>\n"
+                    f"The bot posted the command reference (message ID {msg_id}) but cannot pin it. "
+                    f"Please grant 'Manage Messages' permission to the bot in that channel."
+                )
             except Exception:
                 pass
             state["command_reference_message"] = {"message_id": msg_id, "channel_id": channel_id}
@@ -981,6 +1067,12 @@ def run_discord_sync(state_path: str = GAMING_LIBRARY_FILE, daily_posts_path: st
         client = DiscordClient(session)
         bot_user = client.get_current_user(context="fetch bot user for gaming library")
         bot_user_id = str(bot_user.get("id") or "").strip() or None
+
+        if channel_id and DISCORD_GUILD_ID:
+            _check_channel_permissions(
+                client, channel_id, DISCORD_GUILD_ID, "gaming library sync",
+                bot_user_id=bot_user_id or "",
+            )
 
         promotions = sync_promotions_from_winners(state, daily_posts, client, bot_user_id)
         status_updates = sync_statuses_from_library_posts(state, client, bot_user_id)
@@ -1012,6 +1104,10 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
             "Content-Type": "application/json",
         })
         client = DiscordClient(session)
+        if DISCORD_GUILD_ID:
+            _check_channel_permissions(
+                client, channel_id, DISCORD_GUILD_ID, "gaming library daily post",
+            )
         posted = post_daily_library_reminder(state, day_key=day_key, channel_id=channel_id, client=client)
 
     save_gaming_library(state, state_path)


### PR DESCRIPTION
## Summary

- **Fix 4 — discord_api.py**: Added `DiscordPermissionError(DiscordApiError)` raised on all 403 Forbidden responses. Added Discord permission bitflag constants (`PERM_SEND_MESSAGES`, `PERM_ADD_REACTIONS`, `PERM_READ_MESSAGE_HISTORY`, `PERM_MANAGE_MESSAGES`, `PERM_VIEW_CHANNEL`, `PERM_ADMINISTRATOR`). Added `check_bot_permissions(channel_id, guild_id)` helper that computes the bot's effective permissions by combining guild role permissions with channel overwrites.
- **Fix 1 — gaming_library.py**: Replaced the bare `except Exception: pass` in `ensure_command_reference_pinned()` with a specific `DiscordPermissionError` catch that posts a human-readable fallback warning message to the channel and notifies the health monitor webhook.
- **Fix 2 — gaming_library.py**: Added `_notify_health_monitor()` and `_check_channel_permissions()` helpers. Wired preflight permission checks into `run_discord_sync()` and `run_daily_post()` — if Send Messages, Add Reactions, Read Message History, or Manage Messages is missing, a warning is logged and posted to the health monitor, but the bot continues running.
- **Fix 3 — auto-fix.yml**: Added 403 Forbidden guidance to all 3 fix attempt prompts. The fixer is now instructed that permission errors are Discord server configuration issues, not code bugs — it should post to the health monitor instead of opening a code PR.

## Test plan

- [x] All 239 existing tests pass (`python -m pytest tests/ -x -q`)
- [x] `DiscordPermissionError` is a proper subclass of `DiscordApiError` with `channel_id` and `permission` fields
- [x] `_notify_health_monitor()` handles missing `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` gracefully without raising
- [x] Both Python files import cleanly

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)