### PR TITLE
feat: manual workflow_dispatch runs always post fresh content (#200)

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -20,6 +20,7 @@ DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 WINNERS_DATE_OVERRIDE_ENV = "WINNERS_DATE_UTC"
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
 WINNERS_LOOKBACK_DAYS = 10
 MAX_VOTERS_SHOWN_PER_GAME = 6
 DISCORD_MESSAGE_CHAR_LIMIT = 2000
@@ -45,6 +46,16 @@ def get_target_day_key() -> str:
         return datetime.now(timezone.utc).date().isoformat()
     datetime.fromisoformat(manual_day)
     return manual_day
+
+
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT block subsequent scheduled runs —
+    they always re-post fresh content even when winners are unchanged.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
 
 
 def get_thumbsup_count(message_payload: dict) -> int:
@@ -855,6 +866,9 @@ def main() -> None:
     if not DISCORD_BOT_TOKEN:
         raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
     day_key = get_target_day_key()
+    manual_run = is_manual_run()
+    if manual_run:
+        print("Evening winners run is a manual (workflow_dispatch) run — idempotency skips bypassed")
     print(f"Starting evening winners for day={day_key}")
 
     daily_posts = load_discord_daily_posts()
@@ -1014,7 +1028,7 @@ def main() -> None:
             for key in current_winner_keys
         ]
 
-        if keys_unchanged and not had_previous_vote_snapshot:
+        if keys_unchanged and not had_previous_vote_snapshot and not manual_run:
             winners_state["winner_vote_counts"] = current_winner_vote_counts
             winners_state["winner_entries"] = current_winner_entries
             winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
@@ -1029,7 +1043,7 @@ def main() -> None:
             print(f"SKIP: no newly eligible winners for {day_key} (backfilled vote snapshot)")
             return
 
-        if keys_unchanged and vote_counts_unchanged and has_previous_winner_entries:
+        if keys_unchanged and vote_counts_unchanged and has_previous_winner_entries and not manual_run:
             for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
                 upsert_winners_messages_for_day(
                     client,
@@ -1042,7 +1056,7 @@ def main() -> None:
             print(f"SKIP: no newly eligible winners for {day_key}")
             return
 
-        if keys_unchanged and vote_counts_unchanged:
+        if keys_unchanged and vote_counts_unchanged and not manual_run:
             winners_state["winner_entries"] = current_winner_entries
             winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
             for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -23,6 +23,7 @@ DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_GAMING_LIBRARY_CHANNEL_ID = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID")
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
 LIBRARY_DATE_OVERRIDE_ENV = "LIBRARY_DATE_UTC"
 
 STATUS_ACTIVE = "active"
@@ -77,6 +78,16 @@ COMMAND_REFERENCE_MESSAGE = """\
 React on any game message to update your status:
 ✅ Playing · ⏸️ Paused · ❌ Dropped\
 """
+
+
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT mark the day as completed so that
+    the subsequent scheduled run always executes cleanly.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
 
 
 def utc_now_iso() -> str:
@@ -506,6 +517,7 @@ def post_daily_library_reminder(
     day_key: str,
     channel_id: str,
     client: DiscordClient,
+    manual_run: bool = False,
 ) -> bool:
     daily_posts = state.setdefault("daily_posts", {})
     day_entry = daily_posts.setdefault(day_key, {})
@@ -579,8 +591,11 @@ def post_daily_library_reminder(
     }
 
     day_entry["messages"] = reconciled_messages
-    day_entry["completed"] = True
-    day_entry["completed_at_utc"] = utc_now_iso()
+    if manual_run:
+        print(f"MANUAL RUN: gaming library daily post done for {day_key}; skipping completed=True to preserve scheduled run eligibility")
+    else:
+        day_entry["completed"] = True
+        day_entry["completed_at_utc"] = utc_now_iso()
     return changed
 
 
@@ -1095,6 +1110,10 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
     if not channel_id:
         raise RuntimeError("DISCORD_GAMING_LIBRARY_CHANNEL_ID is not set")
 
+    manual_run = is_manual_run()
+    if manual_run:
+        print("Gaming library daily post is a manual (workflow_dispatch) run — completed flag will not be set")
+
     # Save previous day's games for delta comparison
     state["previous_day_games"] = dict(state.get("games", {}))
 
@@ -1108,7 +1127,7 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
             _check_channel_permissions(
                 client, channel_id, DISCORD_GUILD_ID, "gaming library daily post",
             )
-        posted = post_daily_library_reminder(state, day_key=day_key, channel_id=channel_id, client=client)
+        posted = post_daily_library_reminder(state, day_key=day_key, channel_id=channel_id, client=client, manual_run=manual_run)
 
     save_gaming_library(state, state_path)
     return posted

--- a/main.py
+++ b/main.py
@@ -2048,12 +2048,13 @@ def post_daily_pick_messages(
     run_state.setdefault("section_headers", {})
     run_state["last_attempt_at_utc"] = utc_now_iso()
 
-    if bool(run_state.get("completed")) and not force_refresh_same_day:
+    if bool(run_state.get("completed")) and not force_refresh_same_day and not manual_run:
         print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")
         save_discord_daily_posts(daily_posts)
         return run_counts, True, {}
-    if bool(run_state.get("completed")) and force_refresh_same_day:
-        print(f"REFRESH: daily picks already completed for {day_key}; force_refresh_same_day=true so reconciling posts")
+    if bool(run_state.get("completed")) and (force_refresh_same_day or manual_run):
+        label = "force_refresh_same_day=true" if force_refresh_same_day else "manual_run=true"
+        print(f"REFRESH: daily picks already completed for {day_key}; {label} so reconciling posts")
 
     discord_client: Optional[DiscordClient] = None
     if token_available:
@@ -2069,7 +2070,7 @@ def post_daily_pick_messages(
     def post_or_reconcile_simple(message: str, state_key: str, state_obj: dict) -> None:
         existing_message_id = state_obj.get("message_id")
         existing_channel_id = state_obj.get("channel_id")
-        should_attempt_edit = bool(force_refresh_same_day)
+        should_attempt_edit = bool(force_refresh_same_day) or bool(manual_run)
         if (
             token_available
             and discord_client
@@ -2179,7 +2180,7 @@ def post_daily_pick_messages(
             ):
                 existing_channel_id = str(existing_record["channel_id"])
                 existing_message_id = str(existing_record["message_id"])
-                if force_refresh_same_day:
+                if force_refresh_same_day or manual_run:
                     try:
                         payload = discord_client.edit_message(
                             existing_channel_id,

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -350,6 +350,90 @@ def test_cross_day_duplicate_suppression_and_section_order(monkeypatch, tmp_path
     assert body.index("🧪 Demo & Playtest Winners") < body.index("💸 Paid Winners")
 
 
+def test_manual_run_bypasses_skip_when_winners_unchanged(monkeypatch, tmp_path):
+    """workflow_dispatch run must re-post even when winners keys and vote counts are unchanged."""
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    # Pre-populate winners_state so it looks like a same-day rerun with no changes
+    data[day_key]["winners_state"] = {
+        "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+        "section_headers": {"free": {"channel_id": "wchan", "message_id": "hdr-free-1"}},
+        "winner_messages": {"shared-dupe": {"channel_id": "wchan", "message_id": "wm-1"}},
+        "footer": {"channel_id": "wchan", "message_id": "footer-1"},
+        "winner_keys": ["shared-dupe"],
+        "winner_vote_counts": {"shared-dupe": 1},
+        "winner_entries": [
+            {"winner_key": "shared-dupe", "section": "free", "title": "Late Voted Earlier Day",
+             "url": "shared-dupe", "human_votes": 1, "voter_names": ["jan"]}
+        ],
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    fake = FakeDiscordClient(
+        {
+            "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+            "intro-1": {}, "hdr-free-1": {}, "wm-1": {}, "footer-1": {},
+        },
+        {"m-late": [{"id": "bot-1"}, {"id": "u1", "username": "jan"}]},
+    )
+    _patch_common(monkeypatch, path, fake, day_key)
+    monkeypatch.setenv(winners.GITHUB_EVENT_NAME_ENV, "workflow_dispatch")
+
+    winners.main()
+
+    # Manual run must produce Discord activity (edits to existing messages at minimum)
+    assert fake.posts or fake.edits, "manual run produced no Discord activity"
+
+
+def test_scheduled_run_skips_when_winners_unchanged(monkeypatch, tmp_path):
+    """Scheduled runs must still skip when winners keys and vote counts are unchanged."""
+    day_key, path = _setup_daily(tmp_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[day_key]["winners_state"] = {
+        "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+        "section_headers": {"free": {"channel_id": "wchan", "message_id": "hdr-free-1"}},
+        "winner_messages": {"shared-dupe": {"channel_id": "wchan", "message_id": "wm-1"}},
+        "footer": {"channel_id": "wchan", "message_id": "footer-1"},
+        "winner_keys": ["shared-dupe"],
+        "winner_vote_counts": {"shared-dupe": 1},
+        "winner_entries": [
+            {"winner_key": "shared-dupe", "section": "free", "title": "Late Voted Earlier Day",
+             "url": "shared-dupe", "human_votes": 1, "voter_names": ["jan"]}
+        ],
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    fake = FakeDiscordClient(
+        {
+            "m-late": {"reactions": [{"emoji": {"name": "👍"}, "count": 2}]},
+            "intro-1": {}, "hdr-free-1": {}, "wm-1": {}, "footer-1": {},
+        },
+        {"m-late": [{"id": "bot-1"}, {"id": "u1", "username": "jan"}]},
+    )
+    _patch_common(monkeypatch, path, fake, day_key)
+    monkeypatch.setenv(winners.GITHUB_EVENT_NAME_ENV, "schedule")
+
+    winners.main()
+
+    assert fake.posts == []
+    assert fake.edits == []
+
+
+def test_is_manual_run_detects_workflow_dispatch(monkeypatch):
+    monkeypatch.setenv(winners.GITHUB_EVENT_NAME_ENV, "workflow_dispatch")
+    assert winners.is_manual_run() is True
+
+
+def test_is_manual_run_returns_false_for_schedule(monkeypatch):
+    monkeypatch.setenv(winners.GITHUB_EVENT_NAME_ENV, "schedule")
+    assert winners.is_manual_run() is False
+
+
+def test_is_manual_run_returns_false_when_env_unset(monkeypatch):
+    monkeypatch.delenv(winners.GITHUB_EVENT_NAME_ENV, raising=False)
+    assert winners.is_manual_run() is False
+
+
 def test_instagram_fallback_description_is_preserved():
     msg = winners.build_winner_game_message(
         {

--- a/tests/test_gaming_library.py
+++ b/tests/test_gaming_library.py
@@ -690,3 +690,55 @@ def test_player_with_no_status_appears_in_library_post_after_sync():
 
     game_posts = [p[1] for p in client2.posts if "Appear Game" in p[1] and "Players:" in p[1]]
     assert any("<@u4>" in msg for msg in game_posts), "User u4 should appear in library post after status default"
+
+
+# --- Manual run vs scheduled run completed flag ---
+
+def test_gaming_library_scheduled_run_sets_completed_flag():
+    """Scheduled runs mark the day_entry as completed."""
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    client = FakeDiscordClient()
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client)
+    assert state["daily_posts"]["2026-04-10"]["completed"] is True
+
+
+def test_gaming_library_manual_run_does_not_set_completed_flag():
+    """workflow_dispatch runs post content but do not mark the day as completed."""
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+    client = FakeDiscordClient()
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client, manual_run=True)
+    assert state["daily_posts"]["2026-04-10"].get("completed") is not True
+    assert len(client.posts) > 0  # content was still posted
+
+
+def test_gaming_library_manual_run_followed_by_scheduled_run_posts_normally():
+    """After a manual run, the scheduled run still produces output (not blocked by completed flag)."""
+    state = lib.load_gaming_library(path="/tmp/does-not-exist.json")
+
+    # Manual run — completed flag NOT set
+    client1 = FakeDiscordClient()
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client1, manual_run=True)
+    assert state["daily_posts"]["2026-04-10"].get("completed") is not True
+    assert len(client1.posts) > 0
+
+    # Scheduled run — completed flag IS set, and it still posts (edits existing messages)
+    client2 = FakeDiscordClient()
+    lib.post_daily_library_reminder(state, day_key="2026-04-10", channel_id="lib-chan", client=client2, manual_run=False)
+    assert state["daily_posts"]["2026-04-10"]["completed"] is True
+    assert len(client2.posts) + len(client2.edits) > 0  # produced Discord activity
+
+
+def test_is_manual_run_detects_workflow_dispatch(monkeypatch):
+    monkeypatch.setenv(lib.GITHUB_EVENT_NAME_ENV, "workflow_dispatch")
+    assert lib.is_manual_run() is True
+
+
+def test_is_manual_run_returns_false_for_schedule(monkeypatch):
+    monkeypatch.setenv(lib.GITHUB_EVENT_NAME_ENV, "schedule")
+    assert lib.is_manual_run() is False
+
+
+def test_is_manual_run_returns_false_when_env_unset(monkeypatch):
+    monkeypatch.delenv(lib.GITHUB_EVENT_NAME_ENV, raising=False)
+    assert lib.is_manual_run() is False
+

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -655,6 +655,50 @@ def test_manual_run_followed_by_scheduled_run_executes_normally(monkeypatch, tmp
     assert saved[day_key]["run_state"]["completed"] is True
 
 
+def test_manual_run_bypasses_completed_skip(monkeypatch, tmp_path):
+    """A manual run must post even when completed=True (bypass scheduled-run idempotency skip)."""
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-08"
+    daily_path.write_text(json.dumps({day_key: {"run_state": {"completed": True}}}), encoding="utf-8")
+    posted = []
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda message, capture_metadata=False: posted.append(message))
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    _, rerun_protection_active, _ = main.post_daily_pick_messages(
+        [], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [],
+        manual_run=True,
+    )
+
+    assert not rerun_protection_active  # was NOT skipped
+    assert len(posted) > 0  # posts actually happened
+
+
+def test_scheduled_run_still_skips_when_completed(monkeypatch, tmp_path):
+    """Scheduled runs must still skip when completed=True (unchanged behavior)."""
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-08"
+    daily_path.write_text(json.dumps({day_key: {"run_state": {"completed": True}}}), encoding="utf-8")
+    posted = []
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda message, capture_metadata=False: posted.append(message))
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    _, rerun_protection_active, _ = main.post_daily_pick_messages(
+        [], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [],
+        manual_run=False,
+    )
+
+    assert rerun_protection_active  # was skipped
+    assert posted == []  # nothing posted
+
+
 def test_is_manual_run_detects_workflow_dispatch(monkeypatch):
     monkeypatch.setenv(main.GITHUB_EVENT_NAME_ENV, "workflow_dispatch")
     assert main.is_manual_run() is True


### PR DESCRIPTION
## Summary

- **main.py**: Bypass the `completed=True` early-exit when `manual_run=True`. Manual runs now treat themselves as implicit `force_refresh_same_day` — they edit existing messages rather than creating duplicates. They still do not set the `completed` flag, so subsequent scheduled runs execute cleanly.
- **evening_winners.py**: Added `GITHUB_EVENT_NAME_ENV` constant and `is_manual_run()` function. All three "winners keys/vote counts unchanged → skip" paths now gate on `not manual_run`, so manual runs always re-post winners regardless of prior state.
- **gaming_library.py**: Added `GITHUB_EVENT_NAME_ENV` constant and `is_manual_run()` function. Added `manual_run` parameter to `post_daily_library_reminder()`. Manual runs skip setting `day_entry["completed"] = True`. Wired `is_manual_run()` into `run_daily_post()`.

## Test plan

- [x] All 252 tests pass (`python -m pytest tests/ -x -q`)
- [x] `test_manual_run_bypasses_completed_skip` — manual run posts even when `completed=True`
- [x] `test_scheduled_run_still_skips_when_completed` — scheduled run still skips (unchanged behavior)
- [x] `test_manual_run_bypasses_skip_when_winners_unchanged` — manual winners run re-posts despite no change
- [x] `test_scheduled_run_skips_when_winners_unchanged` — scheduled winners run still skips (unchanged behavior)
- [x] `test_gaming_library_manual_run_does_not_set_completed_flag` — manual library run posts but skips completed flag
- [x] `test_gaming_library_manual_run_followed_by_scheduled_run_posts_normally` — manual run does not block subsequent scheduled run
- [x] `is_manual_run()` detection tests in all three modules (workflow_dispatch / schedule / unset)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)