### PR TITLE
feat: exclude demos/playtests not yet available to play (#203)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1029,6 +1029,47 @@ def has_demo_playtest_free_to_try_signal(title: str, description: str, text: str
     return any(phrase in combined for phrase in DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES)
 
 
+# Phrases in Steam page text that indicate a demo/playtest is not yet playable.
+DEMO_NOT_YET_AVAILABLE_PHRASES = [
+    "coming soon",
+    "not yet available",
+    "available soon",
+    "wishlist now",
+    "notify me when available",
+]
+
+
+def is_demo_not_yet_available(page_text: str, soup: "BeautifulSoup") -> tuple[bool, str]:
+    """Return (True, reason) if a demo/playtest page indicates it is not yet playable.
+
+    Checks (in order):
+    1. Future release date
+    2. Steam's dedicated coming-soon HTML elements (#game_area_comingsoon, .coming_soon)
+    3. 'Coming Soon' or similar phrases in the purchase/action block only
+    """
+    # 1. Future release date
+    release_date = extract_release_date(page_text)
+    if release_date is not None and release_date > datetime.now(timezone.utc):
+        days_until = (release_date - datetime.now(timezone.utc)).days
+        return True, f"release_date={release_date.date().isoformat()} is in the future ({days_until}d)"
+
+    # 2. Steam's dedicated coming-soon elements (unambiguous structural signals)
+    for selector in ("#game_area_comingsoon", ".coming_soon", "#coming_soon_text"):
+        if soup.select_one(selector):
+            return True, f"Steam coming-soon element '{selector}' present"
+
+    # 3. Purchase/action block text (targeted — not a broad page-text scan)
+    for selector in (".game_purchase_action", ".game_area_purchase_game"):
+        block = soup.select_one(selector)
+        if block:
+            block_text = block.get_text(" ", strip=True).lower()
+            for phrase in DEMO_NOT_YET_AVAILABLE_PHRASES:
+                if phrase in block_text:
+                    return True, f"purchase_block contains '{phrase}'"
+
+    return False, ""
+
+
 def extract_diversity_tags(title: str, description: str, text: str) -> List[str]:
     combined = f"{title} {description} {text}".lower()
     tag_terms = (
@@ -1510,6 +1551,13 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
 
     if item_type == "ignore":
         return None
+
+    # Exclude demos/playtests that are not yet available to play.
+    if item_type in {"demo", "playtest"}:
+        not_available, reason = is_demo_not_yet_available(page_text, soup)
+        if not_available:
+            print(f"DEMO NOT YET AVAILABLE: {title} | excluded: demo not yet available to play | reason={reason}")
+            return None
 
     multiplayer_score, multiplayer_hits = score_multiplayer(page_text)
     player_score, player_hits, rejected = score_player_count(page_text)

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -808,3 +808,110 @@ def test_hard_multiplayer_minimum_allows_coop(monkeypatch):
 
 def test_free_game_threshold_is_eleven(monkeypatch):
     assert main.MIN_SCORE_TO_POST_FREE == 11
+
+
+# --- Demo not-yet-available exclusion tests ---
+
+def _build_html_with_extras(title, description, feature_text, review_sentiment="Positive", extra_body=""):
+    """build_html variant that allows injecting extra HTML elements into the body."""
+    return f"""
+    <html>
+      <head><meta property="og:title" content="{title}" /></head>
+      <body>
+        <div id="appHubAppName">{title}</div>
+        <div class="game_description_snippet">{description}</div>
+        <div>{review_sentiment}</div>
+        <div>{feature_text}</div>
+        {extra_body}
+      </body>
+    </html>
+    """
+
+
+def test_demo_excluded_when_release_date_in_future(monkeypatch):
+    """Demo with a future release date is excluded as not yet available."""
+    from datetime import date, timedelta
+    future_date = (date.today() + timedelta(days=30)).strftime("%b %d, %Y")
+    html = _build_html_with_extras(
+        "Future Demo",
+        "multiplayer co-op friends",
+        f"Multiplayer Online Co-Op up to 6 players demo available Release Date: {future_date}",
+        "Positive",
+    )
+    stub_app_pages(monkeypatch, {"9001": html})
+    item = main.inspect_game("steam_demo", "9001")
+    assert item is None
+
+
+def test_demo_excluded_when_coming_soon_element_present(monkeypatch):
+    """Demo with Steam's #game_area_comingsoon element is excluded."""
+    html = _build_html_with_extras(
+        "Coming Soon Demo",
+        "multiplayer friends co-op",
+        "Multiplayer Online Co-Op up to 6 players",
+        "Positive",
+        extra_body='<div id="game_area_comingsoon">Coming Soon</div>',
+    )
+    stub_app_pages(monkeypatch, {"9002": html})
+    item = main.inspect_game("steam_demo", "9002")
+    assert item is None
+
+
+def test_demo_excluded_when_purchase_block_says_coming_soon(monkeypatch):
+    """Demo with 'coming soon' in the purchase action block is excluded."""
+    html = _build_html_with_extras(
+        "Blocked Demo",
+        "multiplayer friends co-op",
+        "Multiplayer Online Co-Op up to 6 players",
+        "Positive",
+        extra_body='<div class="game_purchase_action">Coming Soon</div>',
+    )
+    stub_app_pages(monkeypatch, {"9003": html})
+    item = main.inspect_game("steam_demo", "9003")
+    assert item is None
+
+
+def test_demo_not_excluded_when_release_date_in_past(monkeypatch):
+    """Demo with a past release date is NOT excluded (available to play)."""
+    from datetime import date, timedelta
+    past_date = (date.today() - timedelta(days=30)).strftime("%b %d, %Y")
+    html = _build_html_with_extras(
+        "Past Demo",
+        "multiplayer friends co-op",
+        f"Multiplayer Online Co-Op up to 6 players demo available Release Date: {past_date}",
+        "Positive",
+    )
+    stub_app_pages(monkeypatch, {"9004": html})
+    item = main.inspect_game("steam_demo", "9004")
+    assert item is not None
+    assert item["type"] == "demo"
+
+
+def test_demo_not_excluded_when_no_coming_soon_signals(monkeypatch):
+    """Normal playable demo with no coming-soon signals passes through."""
+    html = build_html(
+        "Normal Demo",
+        "multiplayer friends co-op",
+        "Multiplayer Online Co-Op up to 6 players demo available free to try",
+        "Positive",
+    )
+    stub_app_pages(monkeypatch, {"9005": html})
+    item = main.inspect_game("steam_demo", "9005")
+    assert item is not None
+    assert item["type"] == "demo"
+
+
+def test_non_demo_not_affected_by_coming_soon_check(monkeypatch):
+    """'Coming soon' element does NOT affect free_game type items."""
+    html = _build_html_with_extras(
+        "Free Game",
+        "multiplayer friends co-op",
+        "Multiplayer Online Co-Op up to 6 players",
+        "Positive",
+        extra_body='<div id="game_area_comingsoon">Coming Soon</div>',
+    )
+    stub_app_pages(monkeypatch, {"9006": html})
+    item = main.inspect_game("steam_free", "9006")
+    # free_game items should NOT be filtered by the demo availability check
+    assert item is not None
+    assert item["type"] == "free_game"


### PR DESCRIPTION
## Summary

Added `is_demo_not_yet_available(page_text, soup)` which checks three signals and is wired into `inspect_game()` right after `item_type` is confirmed as `demo` or `playtest`:

1. **Future release date** — `extract_release_date()` returns a date after today
2. **Steam coming-soon HTML elements** — presence of `#game_area_comingsoon`, `.coming_soon`, or `#coming_soon_text` in the page structure
3. **Purchase action block phrases** — `coming soon`, `not yet available`, `available soon`, `wishlist now`, `notify me when available` found inside `.game_purchase_action` or `.game_area_purchase_game` only (not a broad page-text scan, which would have false positives)

Excluded items log: `DEMO NOT YET AVAILABLE: {title} | excluded: demo not yet available to play | reason={reason}`

Free/paid game types are unaffected — the check only applies to `demo`/`playtest`.

## Test plan

- [x] 258 tests pass (6 new)
- [x] `test_demo_excluded_when_release_date_in_future`
- [x] `test_demo_excluded_when_coming_soon_element_present`
- [x] `test_demo_excluded_when_purchase_block_says_coming_soon`
- [x] `test_demo_not_excluded_when_release_date_in_past`
- [x] `test_demo_not_excluded_when_no_coming_soon_signals`
- [x] `test_non_demo_not_affected_by_coming_soon_check`

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)