### PR TITLE
fix: Mostly Positive games no longer qualify for free or paid sections (#204)

### DIFF
--- a/main.py
+++ b/main.py
@@ -360,7 +360,7 @@ REVIEW_SENTIMENT_SCORES = {
     "Overwhelmingly Positive": 6,
     "Very Positive": 5,
     "Positive": 4,
-    "Mostly Positive": 2,
+    "Mostly Positive": -1,
     "Mixed": -3,
     "Mostly Negative": -8,
     "Negative": -8,
@@ -389,6 +389,7 @@ REVIEW_SENTIMENT_PATTERNS = [
 ]
 
 FREE_REVIEW_BLOCKLIST = {
+    "Mostly Positive",
     "Mostly Negative",
     "Negative",
     "Very Negative",
@@ -396,7 +397,6 @@ FREE_REVIEW_BLOCKLIST = {
 }
 
 PAID_MINIMUM_REVIEW_SENTIMENTS = {
-    "Mostly Positive",
     "Positive",
     "Very Positive",
     "Overwhelmingly Positive",

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -618,12 +618,12 @@ def test_review_score_caps_positive(monkeypatch):
     assert item["review_score"] == 4
 
 
-def test_review_score_caps_mostly_positive(monkeypatch):
+def test_review_score_mostly_positive_is_minus_one(monkeypatch):
     html = build_html("Okay Game", "friends", "Multiplayer Online Co-Op up to 6 players", "Mostly Positive")
     stub_app_pages(monkeypatch, {"2004": html})
     item = main.inspect_game("steam_free", "2004")
     assert item is not None
-    assert item["review_score"] == 2
+    assert item["review_score"] == -1
 
 
 def test_review_score_mixed_is_minus_three(monkeypatch):
@@ -808,6 +808,65 @@ def test_hard_multiplayer_minimum_allows_coop(monkeypatch):
 
 def test_free_game_threshold_is_eleven(monkeypatch):
     assert main.MIN_SCORE_TO_POST_FREE == 11
+
+
+# --- Mostly Positive scoring rebalance tests ---
+
+def test_mostly_positive_score_is_minus_one():
+    assert main.REVIEW_SENTIMENT_SCORES["Mostly Positive"] == -1
+
+
+def test_mostly_positive_in_free_review_blocklist():
+    assert "Mostly Positive" in main.FREE_REVIEW_BLOCKLIST
+
+
+def test_mostly_positive_not_in_paid_minimum_review_sentiments():
+    assert "Mostly Positive" not in main.PAID_MINIMUM_REVIEW_SENTIMENTS
+
+
+def test_mostly_positive_free_game_does_not_qualify(monkeypatch):
+    """Armored Warfare scenario — Mostly Positive free game must not qualify even with high score."""
+    html = build_html(
+        "Armored Warfare",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players party game",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"9901": html})
+    item = main.inspect_game("steam_free", "9901")
+    assert item is not None
+    assert item["review_gate_failed"] is True
+    assert item["keep"] is False
+
+
+def test_mostly_positive_paid_game_does_not_qualify(monkeypatch):
+    """Mostly Positive paid game must not qualify."""
+    html = build_html(
+        "Mostly Positive Paid",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players party game",
+        "Mostly Positive",
+    )
+    stub_app_pages(monkeypatch, {"9902": html})
+    monkeypatch.setattr(main, "get_price_info", lambda app_id: (9.99, False, 50, "game"))
+    item = main.inspect_game("paid_candidate", "9902")
+    assert item is not None
+    assert item["review_gate_failed"] is True
+    assert item["keep"] is False
+
+
+def test_positive_free_game_still_qualifies(monkeypatch):
+    """Positive (not just Mostly Positive) free game should still qualify."""
+    html = build_html(
+        "Positive Free Game",
+        "team up with friends",
+        "Multiplayer Online Co-Op up to 6 players party game",
+        "Positive",
+    )
+    stub_app_pages(monkeypatch, {"9903": html})
+    item = main.inspect_game("steam_free", "9903")
+    assert item is not None
+    assert item["review_gate_failed"] is False
 
 
 # --- Demo not-yet-available exclusion tests ---


### PR DESCRIPTION
## Summary

- `REVIEW_SENTIMENT_SCORES["Mostly Positive"]`: `+2` → `-1` — weak signal that should not help games qualify
- Added `"Mostly Positive"` to `FREE_REVIEW_BLOCKLIST` — sets `review_gate_failed=True` for `free_game` and `temporarily_free` items, blocking them from the free section regardless of total score
- Removed `"Mostly Positive"` from `PAID_MINIMUM_REVIEW_SENTIMENTS` — paid games now require `Positive` or better

**Armored Warfare scenario**: score=41, sentiment=Mostly Positive → `review_gate_failed=True` → `keep=False` ✓

Demo/playtest items are unaffected — they use a separate review gate.

## Test plan

- [x] 264 tests pass (6 new, 1 renamed/updated)
- [x] `test_mostly_positive_score_is_minus_one` — score constant
- [x] `test_mostly_positive_in_free_review_blocklist` — blocklist membership
- [x] `test_mostly_positive_not_in_paid_minimum_review_sentiments`
- [x] `test_mostly_positive_free_game_does_not_qualify` — Armored Warfare scenario, keep=False
- [x] `test_mostly_positive_paid_game_does_not_qualify`
- [x] `test_positive_free_game_still_qualifies` — Positive still passes

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)