### PR TITLE
feat: expand auto-fix trigger to cover Gaming Library Sync and Weekly Scheduling Responses Sync (#208)

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -2,7 +2,7 @@ name: Auto Fix Loop
 
 on:
   workflow_run:
-    workflows: ["Steam Free Games", "Daily Game Picks Winners", "Gaming Library Daily Reminder"]
+    workflows: ["Steam Free Games", "Daily Game Picks Winners", "Gaming Library Daily Reminder", "Gaming Library Sync", "Weekly Scheduling Responses Sync"]
     types: [completed]
 
 # Only one auto-fix may run at a time. Queue rather than cancel so no fix


### PR DESCRIPTION
## Summary

Added `"Gaming Library Sync"` and `"Weekly Scheduling Responses Sync"` to the `workflow_run` trigger list in `auto-fix.yml`. Both workflow names were verified against the actual `name:` fields in [gaming-library-sync.yml](.github/workflows/gaming-library-sync.yml) and [weekly-scheduling-responses-sync.yml](.github/workflows/weekly-scheduling-responses-sync.yml).

## Test plan

- [x] 264 tests pass (`python -m pytest tests/ -x -q`)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)