### PR TITLE
fix: prevent merge conflicts with concurrency groups and git stash pattern

### DIFF
--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gaming-library-state
+  cancel-in-progress: false
+
 jobs:
   run-gaming-library-daily:
     runs-on: ubuntu-latest

--- a/.github/workflows/gaming-library-manage.yml
+++ b/.github/workflows/gaming-library-manage.yml
@@ -60,6 +60,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gaming-library-state
+  cancel-in-progress: false
+
 jobs:
   run-gaming-library-manage:
     runs-on: ubuntu-latest

--- a/.github/workflows/gaming-library-sync.yml
+++ b/.github/workflows/gaming-library-sync.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gaming-library-state
+  cancel-in-progress: false
+
 jobs:
   run-gaming-library-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: weekly-schedule-state
+  cancel-in-progress: false
+
 jobs:
   post-weekly-availability:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -25,7 +25,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: weekly-scheduling-responses-sync
+  group: weekly-schedule-state
   cancel-in-progress: false
 
 jobs:
@@ -85,6 +85,9 @@ jobs:
           fi
 
           git commit -m "chore: update weekly schedule responses state"
+          git stash --include-untracked || true
+          git pull --rebase origin main
+          git stash pop || true
           git push
 
       - name: Notify Discord health monitor on failure


### PR DESCRIPTION
## Summary

- Add `concurrency: group: gaming-library-state` to `gaming-library-sync.yml`, `gaming-library-daily.yml`, and `gaming-library-manage.yml` — concurrent runs now queue instead of racing and producing JSON conflict markers
- Add `concurrency: group: weekly-schedule-state` to `weekly-scheduling-bot.yml`
- Fix `weekly-scheduling-responses-sync.yml`: unify to `weekly-schedule-state` concurrency group and add `git stash --include-untracked / pull --rebase / stash pop` pattern before push, matching the standard save-state pattern used across all other workflows

Closes #210

## Test plan

- [x] 264 tests pass (`pytest`)
- [x] All 5 workflow files have correct concurrency groups
- [x] `weekly-scheduling-responses-sync.yml` commit step matches the standard stash/rebase/pop pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)