### PR TITLE
Add repo_dump.txt containing raw bot file contents

### DIFF
--- a/repo_dump.txt
+++ b/repo_dump.txt
@@ -1,0 +1,7440 @@
+===== channel_specs.json =====
+{
+  "step-1-vote-on-games-to-test": {
+    "description": "Morning candidate games and voting",
+    "required": {
+      "intro": true,
+      "min_items": 1,
+      "footer": true,
+      "reactions": ["👍"],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Free Picks", "Paid Under $20", "Instagram Creator Picks", "Demos / Playtests"]
+    },
+    "broken_if": [
+      "no games posted",
+      "duplicate game messages",
+      "missing intro",
+      "bot reaction counted in votes"
+    ]
+  },
+  "step-2-test-then-vote-to-keep": {
+    "description": "Evening winners and bookmarkable final picks",
+    "required": {
+      "intro": true,
+      "min_items": 1,
+      "footer": true,
+      "reactions": ["🔖"],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Free Picks", "Paid Under $20", "Instagram Creator Picks", "Demos / Playtests"]
+    },
+    "broken_if": [
+      "no winners posted",
+      "duplicate winners",
+      "missing footer",
+      "missing intro",
+      "bot vote counted as human vote"
+    ]
+  },
+  "step-3-review-existing-games": {
+    "description": "Persistent playable backlog with live player status",
+    "required": {
+      "intro": true,
+      "min_items": 0,
+      "footer": true,
+      "reactions": ["✅", "⏸️", "❌"],
+      "no_duplicates": true
+    },
+    "optional": {},
+    "broken_if": [
+      "game entry missing name",
+      "IG Picks entry without actual game name",
+      "missing footer",
+      "duplicate library entries"
+    ]
+  },
+  "update-weekly-schedule-here": {
+    "description": "Availability overlap and session coordination",
+    "required": {
+      "intro": false,
+      "min_items": 0,
+      "footer": false,
+      "reactions": [],
+      "no_duplicates": true
+    },
+    "optional": {
+      "sections": ["Morning", "Afternoon", "Evening", "Late Night"]
+    },
+    "broken_if": [
+      "scheduling post for game not in active library",
+      "ping sent with zero player overlap",
+      "missing availability time bucket"
+    ]
+  },
+  "xiann-gpt-bot-health-monitor": {
+    "description": "Workflow health, debugging, verification, and escalation",
+    "required": {
+      "intro": false,
+      "min_items": 1,
+      "footer": false,
+      "reactions": [],
+      "no_duplicates": false
+    },
+    "optional": {},
+    "broken_if": [
+      "no health report posted after workflow run",
+      "missing workflow status",
+      "missing verification result"
+    ]
+  }
+}
+
+===== CLAUDE.md =====
+# Repo Rules
+
+- Always review recent merged PRs before making changes.
+- Prefer patterns already used in the repo over inventing new ones.
+- Never create duplicate Discord messages if an existing message can be reused or edited.
+- Preserve idempotency and same-day rerun safety.
+- Run targeted tests before suggesting a change.
+- Prefer editing existing messages over recreating them.
+- For Discord workflow changes, always preserve:
+  - intro message
+  - section headers
+  - one message per item
+  - footer
+- Never remove reactions from existing messages unless explicitly required.
+- Only add reactions when a message is newly created.
+- Before making changes, summarize:
+  - files to edit
+  - likely risks
+  - tests to run
+- After making changes, summarize:
+  - exactly what changed
+  - what tests passed
+  - any remaining risks
+- Never merge directly to main.
+- Always create a new branch and PR.
+- All save state steps in workflow files must use `git stash --include-untracked || true` before `git pull --rebase` and `git stash pop || true` after, to prevent unstaged changes from causing rebase failures.
+- Future work should support:
+  - debug summaries
+  - verification JSON artifacts
+  - autonomous rerun-safe behavior
+
+## Content Rules
+
+- **VR exclusion** — games flagged as VR (via `is_vr_content()` in `main.py`) are excluded from daily picks. Check both tag matches (`VR_TAG_EXACT`) and phrase matches (`VR_INDICATOR_PHRASES`) in title/description.
+- **DLC hard exclusion** — items detected as DLC are always excluded, no exceptions.
+- **Instagram 7-day filter** — posts older than 7 days (`INSTAGRAM_MAX_POST_AGE_DAYS = 7`) are skipped during Instagram fetch. Posts are newest-first; stop iterating when a post exceeds the cutoff.
+- **Steam URL embed suppression** — all Steam store URLs in Discord messages must be wrapped in `<>` (e.g. `<https://store.steampowered.com/app/123/>`). Use `_suppress_steam_url()` from `gaming_library.py`.
+- **ET timestamps** — all human-readable timestamps in Discord messages must use `format_et_timestamp()` from `state_utils.py`. Format: `Dec 15, 2024 at 7:00 AM ET`.
+- **Demo/playtest source gating** — paid games that mention "demo" or "playtest" in title/text are excluded (`detect_item_type()` in `main.py`). Free items pass through.
+
+## System Architecture
+
+This repo runs a 5-channel Discord pipeline for multiplayer game discovery. Each channel represents a stage in the pipeline:
+
+- `step-1-vote-on-games-to-test` — morning candidate games posted for 👍 voting
+- `step-2-test-then-vote-to-keep` — evening winners posted for 🔖 bookmarking
+- `step-3-review-existing-games` — persistent playable backlog with ✅/⏸️/❌ reactions and bot commands
+- `update-weekly-schedule-here` — session scheduling and availability coordination
+- `xiann-gpt-bot-health-monitor` — workflow health, verification results, and escalation alerts
+
+`channel_specs.json` at the repo root defines the correct output spec for each channel (required fields, reactions, failure conditions). Always read it before diagnosing or fixing any Discord-related issue.
+
+## Step 3 Discord Commands
+
+Players can type commands in `step-3-review-existing-games`. Commands are processed on the next sync run (`gaming-library-sync.yml`). The bot reacts with ✅ on each processed command.
+
+| Command | Effect |
+|---------|--------|
+| `!add @user GameName` | Assign player to a game |
+| `!remove @user GameName` | Unassign player from a game |
+| `!rename GameName NewName` | Rename a game |
+| `!unassign @user` | Remove player from all games |
+| `!archive GameName` | Archive a game |
+| `!addgame GameName SteamURL @user1 @user2` | Add game directly to library |
+
+Processed command message IDs are tracked in `gaming_library.json` under `processed_command_ids` to prevent reprocessing. The pinned command reference message is tracked under `command_reference_message`.
+
+## Automation Loop
+
+`auto-fix.yml` triggers automatically when any of these workflows complete: **Steam Free Games**, **Daily Game Picks Winners**, **Gaming Library Daily Reminder**. It fires a fix attempt when either `daily_verification.json` or `discord_verification.json` reports `pass: false`.
+
+- Claude Code is the fixer — it reads both verification artifacts and `channel_specs.json` to diagnose the root cause before making any change
+- Fix branches are named `fix/auto-fix-{workflow-run-id}-{attempt}` (e.g. `fix/auto-fix-12345678-1`)
+- PRs are auto-merged when checks pass
+- Maximum 3 attempts; if all fail, an escalation alert is posted to `xiann-gpt-bot-health-monitor`
+
+## Workflow Schedule (all times ET)
+
+| Workflow file | Name | Schedule |
+|---|---|---|
+| `daily.yml` | Steam Free Games (Step 1) | 9:00 AM daily |
+| `evening-winners.yml` | Daily Game Picks Winners (Step 2) | 7:00 PM daily |
+| `gaming-library-sync.yml` | Gaming Library Sync | Every 3 hours |
+| `gaming-library-daily.yml` | Gaming Library Daily Reminder (Step 3) | 8:00 PM daily |
+| `weekly-scheduling-bot.yml` | Weekly Scheduling Bot | 9:00 AM Saturday |
+| `weekly-scheduling-responses-sync.yml` | Weekly Scheduling Responses Sync | Every 3 hours |
+| `bot-health-report.yml` | Bot Health Report | 11:00 PM daily |
+| `daily-briefing.yml` | Daily System Briefing | 11:30 PM daily |
+| `watchdog.yml` | Missed-Run Watchdog | Every hour |
+| `auto-fix.yml` | Auto-Fix | Triggered by workflow_run |
+
+Every workflow has a `Notify Discord health monitor on failure` step that posts to `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` on failure.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `main.py` | Step 1 — Steam scraping, scoring model, demo/playtest/VR detection, Instagram fetch |
+| `evening_winners.py` | Step 2 — winners channel management with header/footer jump links |
+| `gaming_library.py` | Step 3 — library state, daily post, Discord command processing, sync |
+| `state_utils.py` | Shared helpers: atomic JSON writes, `format_et_timestamp()`, prune utilities |
+| `discord_api.py` | Discord REST client — post, edit, react, pin, get channel messages |
+| `daily_section_config.py` | Section definitions for Step 1 daily post categories |
+| `channel_specs.json` | Per-channel correctness spec — required fields, reactions, and failure conditions |
+| `daily_verification.json` | Runtime artifact from `main.py` — structural checks on what was posted |
+| `discord_verification.json` | Runtime artifact from `scripts/verify_discord_output.py` — live Discord read-back checks |
+| `discord_daily_posts.json` | Message ID state store — maps each day's posts to their Discord message and channel IDs |
+| `gaming_library.json` | Library state — persistent backlog of games tracked in `step-3-review-existing-games` |
+| `seen_ids.json` | Deduplication store for Step 1 Steam items |
+| `instagram_seen.json` | Deduplication store for Instagram posts |
+| `page_state.json` | Pagination state for Steam free games scraper |
+| `state_sanity.json` | Output of `scripts/check_state_sanity.py` — cross-file consistency checks |
+
+## Key Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/sync_gaming_library.py` | Syncs Step 2 bookmarks → Step 3 library, reads reactions, processes !commands |
+| `scripts/post_daily_gaming_library.py` | Posts daily Step 3 library reminder with category grouping and jump links |
+| `scripts/build_daily_health_report.py` | Builds the bot health report with workflow schedule diagnostics |
+| `scripts/build_daily_briefing.py` | Builds the daily system briefing with 24h run summary |
+| `scripts/verify_discord_output.py` | Live Discord read-back verification against `channel_specs.json` |
+| `scripts/verify_gaming_library.py` | Structural verification of `gaming_library.json` |
+| `scripts/check_state_sanity.py` | Cross-file state consistency checks |
+| `scripts/manage_gaming_library.py` | CLI tool for manual library operations |
+
+===== main.py =====
+import json
+import os
+import re
+import time
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple, TypedDict
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+try:
+    import instaloader
+except ImportError:
+    instaloader = None
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from daily_section_config import DAILY_SECTION_CONFIG, DAILY_SECTION_ORDER
+from state_utils import (
+    load_json_object,
+    prune_latest_iso_dates,
+    save_json_object_atomic,
+)
+
+WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
+DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+DISCORD_DEBUG_CHANNEL_ID = os.getenv("DISCORD_DEBUG_CHANNEL_ID")
+DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
+STATE_FILE = "seen_ids.json"
+PAGE_STATE_FILE = "page_state.json"
+INSTAGRAM_STATE_FILE = "instagram_seen.json"
+DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
+DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
+DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
+FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
+DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
+DAILY_VERIFICATION_FILE = "daily_verification.json"
+STOP_GO_RESULT_FILE = "daily_stop_go_result.json"
+MAX_RETRY_ATTEMPTS = 3
+
+INSTAGRAM_CREATORS = [
+    "gemgamingnetwork",
+    "cloudual",
+    "mildsoss_official",
+    "sharedxp_official",
+    "wilfratgaming",
+    "indiegamespotlights",
+    "biffmatictv",
+    "itzjaysasa",
+]
+
+MAX_INSTAGRAM_POSTS_PER_ACCOUNT = 2
+INSTAGRAM_MAX_POST_AGE_DAYS = 7
+INSTAGRAM_SEEN_RETENTION_PER_CREATOR = 50
+INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS = [
+    r"\bdemo\b",
+    r"\bplaytest\b",
+    r"\bfree\b",
+    r"\bsteam\b",
+    r"\bwishlist\b",
+    r"\bout\s+now\b",
+    r"\blink\s+in\s+bio\b",
+]
+INSTAGRAM_GAME_KEY_FALLBACK_BOUNDARY_PATTERNS = [
+    r"\bdemo\b",
+    r"\bplaytest\b",
+    r"\bfree\b",
+    r"\bsteam\b",
+    r"\bwishlist\b",
+    r"\bout\s+now\b",
+    r"\blink\s+in\s+bio\b",
+]
+INSTAGRAM_GAME_KEY_GENERIC_PREFIX_TOKENS = {
+    "check",
+    "this",
+    "that",
+    "out",
+    "pick",
+    "picks",
+    "today",
+    "game",
+    "games",
+    "new",
+    "my",
+    "our",
+    "you",
+}
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0"
+}
+
+# ---------- CONFIG ----------
+# Edit-safely note: tune thresholds only after observing real production runs;
+# avoid speculative changes that are not feedback-driven.
+# Daily routing intent (do not redesign without explicit product change):
+# - demo / playtest -> Demo & Playtest section (discovery lane for promising friend-group titles).
+# - free_game / temporarily_free -> Free Picks (higher-confidence full free or temporary-free full games).
+# - paid_under_20 -> Paid Under $20 (strictest paid recommendation lane).
+# - Instagram creator picks remain a separate unchanged section.
+# Threshold philosophy:
+# - Demo/Playtest tolerates thinner review history, but demands stronger friend-group fit.
+# - Free is stricter on review confidence.
+# - Paid is strictest overall.
+# Section caps are intentionally independent: Demo/Playtest picks are curated separately
+# from Free Picks so one noisy pool cannot crowd out the other.
+MAX_FREE_POSTS = 5
+MAX_DEMO_PLAYTEST_POSTS = 5
+MAX_PAID_POSTS = 5
+
+PAGE_WINDOW_SIZE = 10
+MAX_PAGE_LIMIT = 50
+
+REQUEST_DELAY_SECONDS = 1.2
+REPOST_COOLDOWN_DAYS = 30
+# Threshold philosophy guardrails (quality-over-cap is intentional, especially for demos/playtests):
+# - Demo/Playtest has lower review strictness but stronger friend-group gating.
+# - Free raises review-confidence expectations.
+# - Paid is strictest overall.
+# These thresholds are intentionally conservative; do not tune further without
+# first observing real Discord output over multiple runs.
+MIN_SCORE_TO_POST_FREE = 11
+MIN_SCORE_TO_POST_DEMO_PLAYTEST = 6
+MIN_SCORE_TO_POST_PAID = 8
+
+MAX_FETCH_RETRIES = 5
+BACKOFF_SECONDS = 4
+
+STEAM_FREE_SEARCH_URL = "https://store.steampowered.com/search/?maxprice=free&page={}"
+STEAM_DEMO_SEARCH_URL = "https://store.steampowered.com/search/?category1=10&page={}"
+STEAM_TOPSELLERS_URL = "https://store.steampowered.com/search/?filter=topsellers&page={}"
+STEAMDB_FREE_PROMO_URL = "https://steamdb.info/upcoming/free/"
+
+DISCORD_CHAR_LIMIT = 1900
+
+FILTER_REASON_WEAK_REVIEW = "weak_review"
+FILTER_REASON_WEAK_GROUP_FIT = "weak_group_fit"
+FILTER_REASON_LOW_SIGNAL_JUNK = "low_signal_junk"
+FILTER_REASON_REPOST_COOLDOWN = "repost_cooldown"
+FILTER_REASON_BELOW_THRESHOLD = "below_threshold"
+FILTER_REASON_QUALIFIED = "qualified"
+
+MULTIPLAYER_TERMS = {
+    "Massively Multiplayer": 6,
+    "MMO": 4,
+    "Online Co-Op": 3,
+    "Online Co-op": 3,
+    "Co-op": 2,
+    "Co-Op": 2,
+    "Multiplayer": 2,
+    "Multi-player": 2,
+    "Online PvP": 2,
+    "PvP": 1,
+    "Squad": 1,
+    "Team-based": 1,
+}
+
+GOOD_GENRE_TERMS = {
+    "Survival": 2,
+    "Shooter": 2,
+    "Action RPG": 2,
+    "Party": 2,
+    "Roguelike": 2,
+    "Roguelite": 2,
+    "Extraction": 2,
+    "Dungeon": 1,
+    "Crafting": 1,
+    "Base-building": 1,
+    "Hack and slash": 1,
+    "Adventure": 1,
+}
+
+GOOD_DESCRIPTION_TERMS = {
+    "team up": 2,
+    "friends": 1,
+    "squad": 2,
+    "party": 2,
+    "raid": 1,
+    "cooperate": 2,
+    "cooperative": 2,
+    "online co-op": 3,
+    "multiplayer": 2,
+    "co-op": 2,
+    "pvp": 1,
+}
+
+BAD_TERMS = {
+    "Soundtrack": -10,
+    "soundtrack": -10,
+    "DLC": -8,
+    "benchmark": -6,
+    "test server": -5,
+    "dedicated server": -5,
+    "server tools": -6,
+    "wallpaper": -8,
+    "art book": -8,
+    "prologue": -3,
+    "character creator": -4,
+}
+
+FRIEND_GROUP_PHRASE_SCORES = {
+    "4-player co-op": 2,
+    "4 player co-op": 2,
+    "4-player online co-op": 2,
+    "drop-in co-op": 1,
+    "couch co-op": 2,
+    "party game": 2,
+    "cross-platform multiplayer": 1,
+    "up to 6 players": 2,
+    "up to 8 players": 2,
+}
+
+REPLAYABILITY_PHRASE_SCORES = {
+    "procedurally generated": 1,
+    "procedural": 1,
+    "roguelite co-op": 1,
+    "endless replayability": 1,
+    "replayable": 1,
+    "loot": 1,
+    "runs": 1,
+    "randomized": 1,
+    "randomly generated": 1,
+    "progression": 1,
+}
+
+DEMO_PLAYTEST_FRIEND_SIGNALS = {
+    "online co-op": 4,
+    "co-op": 3,
+    "coop": 3,
+    "multiplayer": 3,
+    "party game": 3,
+    "party": 2,
+    "squad": 2,
+    "team up": 2,
+    "drop-in co-op": 2,
+    "couch co-op": 2,
+    "4-player co-op": 3,
+    "4 player co-op": 3,
+    "up to 4 players": 3,
+    "up to 5 players": 3,
+    "up to 6 players": 4,
+    "up to 8 players": 4,
+    "replayability": 1,
+    "replayable": 1,
+    "procedural": 1,
+    "procedurally generated": 1,
+    "randomly generated": 1,
+    "loot": 1,
+    "runs": 1,
+    "progression": 1,
+    "randomized": 1,
+}
+
+DEMO_PLAYTEST_SOLO_SIGNALS = {
+    "single-player only": -6,
+    "single player only": -6,
+    "single-player": -3,
+    "single player": -3,
+    "solo": -2,
+    "story-rich": -2,
+    "narrative": -2,
+    "visual novel": -4,
+}
+
+DEMO_PLAYTEST_MIN_FRIEND_SIGNAL = 5
+# Quality-over-cap for Demo/Playtest: we prefer fewer stronger items over filling
+# the entire section with borderline picks.
+DEMO_PLAYTEST_QUALITY_FLOOR_SCORE = MIN_SCORE_TO_POST_DEMO_PLAYTEST + 1
+# Diversity rerank is intentionally weak (light penalty only after a couple repeats)
+# so quality remains primary and variety is just a soft tie-breaker.
+LIGHT_DIVERSITY_PER_EXTRA_DUPLICATE = 1
+LIGHT_DIVERSITY_DUPLICATE_FREE_SLOTS = 2
+
+RELEASE_DATE_FORMATS = [
+    "%b %d, %Y",
+    "%B %d, %Y",
+    "%d %b, %Y",
+    "%d %B, %Y",
+]
+
+# Heavier penalties here are intentional to suppress low-signal/junk entries from
+# leaking into daily picks despite keyword stuffing elsewhere on the page.
+LOW_SIGNAL_KEYWORD_SCORES = {
+    "clicker": -3,
+    "idle": -2,
+    "hentai": -4,
+    "nsfw": -4,
+    "prototype": -2,
+    "vertical slice": -2,
+    "proof of concept": -2,
+    "test": -2,
+    "placeholder": -2,
+    "ai-generated": -2,
+    "meme": -2,
+    "asset flip": -4,
+    "unity asset": -3,
+}
+
+DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES = {
+    "download demo": 1,
+    "demo available": 1,
+    "playtest available": 1,
+    "request access": 1,
+    "join playtest": 1,
+    "play now": 1,
+}
+
+VR_INDICATOR_PHRASES = [
+    "virtual reality",
+    "vr headset",
+    "requires vr",
+    "requires a vr",
+    "requires virtual reality",
+    "supports vr",
+    "play in vr",
+    "vr only",
+    "vr supported",
+    "oculus rift",
+    "oculus quest",
+    "htc vive",
+    "valve index",
+    "steam vr",
+    "steamvr",
+    "vr game",
+    "vr experience",
+    "mixed reality",
+    "windows mixed reality",
+]
+
+VR_TAG_EXACT = {"vr", "virtual reality", "steamvr", "room-scale vr", "vr only", "vr supported"}
+
+TITLE_LOW_SIGNAL_KEYWORD_SCORES = {
+    "simulator": -1,
+    "clicker": -2,
+    "idle": -2,
+    "prototype": -2,
+    "test": -1,
+}
+
+PLAYER_COUNT_PATTERNS = [
+    (r"\b1\s*-\s*4\b", 3),
+    (r"\b1\s*-\s*6\b", 4),
+    (r"\b1\s*-\s*8\b", 5),
+    (r"\b2\s*-\s*4\b", 3),
+    (r"\b2\s*-\s*6\b", 4),
+    (r"\b2\s*-\s*8\b", 5),
+    (r"\b3\s*\+\b", 4),
+    (r"\b3\s*-\s*4\b", 3),
+    (r"\b3\s*-\s*6\b", 4),
+    (r"\b3\s*-\s*8\b", 5),
+    (r"\b4\s*player\b", 3),
+    (r"\b4\s*players\b", 3),
+    (r"\bup to 4 players\b", 3),
+    (r"\bup to 6 players\b", 4),
+    (r"\bup to 8 players\b", 5),
+]
+
+REVIEW_SENTIMENT_SCORES = {
+    "Overwhelmingly Positive": 6,
+    "Very Positive": 5,
+    "Positive": 4,
+    "Mostly Positive": -1,
+    "Mixed": -3,
+    "Mostly Negative": -8,
+    "Negative": -8,
+    "Very Negative": -10,
+    "Overwhelmingly Negative": -12,
+}
+
+# Hard-excluded from all sections regardless of other scores.
+# Exception: demos/playtests with no reviews are handled separately (review_sentiment is None).
+HARD_EXCLUDE_REVIEW_SENTIMENTS = {
+    "Mostly Negative",
+    "Very Negative",
+    "Overwhelmingly Negative",
+}
+
+REVIEW_SENTIMENT_PATTERNS = [
+    "Overwhelmingly Positive",
+    "Very Positive",
+    "Mostly Positive",
+    "Positive",
+    "Mixed",
+    "Overwhelmingly Negative",
+    "Very Negative",
+    "Mostly Negative",
+    "Negative",
+]
+
+FREE_REVIEW_BLOCKLIST = {
+    "Mostly Positive",
+    "Mostly Negative",
+    "Negative",
+    "Very Negative",
+    "Overwhelmingly Negative",
+}
+
+PAID_MINIMUM_REVIEW_SENTIMENTS = {
+    "Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+
+TEMPORARILY_FREE_SCORE_BONUS = 1
+DEMO_SCORE_PENALTY = 2
+
+UNKNOWN_REVIEW_SCORE_BY_TYPE = {
+    "free_game": -2,
+    "demo": -1,
+    "playtest": 0,
+    "temporarily_free": -2,
+    "paid_under_20": -6,
+}
+
+STRONG_REVIEW_SENTIMENTS = {"Very Positive", "Overwhelmingly Positive"}
+POSITIVE_OR_BETTER_REVIEW_SENTIMENTS = {
+    "Positive",
+    "Mostly Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+REVIEW_CONFIDENCE_BASELINE_SENTIMENTS = {
+    "Positive",
+    "Mostly Positive",
+    "Very Positive",
+    "Overwhelmingly Positive",
+}
+REVIEW_CONFIDENCE_STRONG_SENTIMENTS = {"Very Positive", "Overwhelmingly Positive"}
+
+REJECT_PATTERNS = [
+    r"\b1\s*-\s*2\b",
+    r"\b2\s*player\b",
+    r"\b2\s*players\b",
+    r"\b2-player\b",
+    r"\btwo-player only\b",
+    r"\bfor 2 players\b",
+]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_iso(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+def load_state() -> Dict[str, dict]:
+    if not os.path.exists(STATE_FILE):
+        return {}
+
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        if isinstance(data, list):
+            converted = {}
+            now = utc_now_iso()
+            for app_id in data:
+                converted[str(app_id)] = {
+                    "last_posted": now,
+                    "last_type": "unknown"
+                }
+            return converted
+
+        if isinstance(data, dict):
+            return data
+
+        return {}
+    except Exception:
+        return {}
+
+
+def _notify_health_monitor(message: str) -> None:
+    """Post a warning to the Discord health monitor webhook (best-effort, never raises)."""
+    url = DISCORD_HEALTH_MONITOR_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json={"content": message}, timeout=10)
+    except Exception:
+        pass
+
+
+def save_state(state: Dict[str, dict]) -> None:
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+
+def load_page_state() -> int:
+    if not os.path.exists(PAGE_STATE_FILE):
+        return 1
+
+    try:
+        with open(PAGE_STATE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        start_page = int(data.get("start_page", 1))
+        valid_starts = set(range(1, MAX_PAGE_LIMIT + 1, PAGE_WINDOW_SIZE))
+
+        if start_page not in valid_starts:
+            return 1
+
+        return start_page
+    except Exception:
+        return 1
+
+
+def save_page_state(start_page: int) -> None:
+    payload = {
+        "start_page": start_page,
+        "updated_at": utc_now_iso(),
+    }
+    with open(PAGE_STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+
+
+def get_page_window() -> Tuple[int, int]:
+    start_page = load_page_state()
+    end_page = min(start_page + PAGE_WINDOW_SIZE - 1, MAX_PAGE_LIMIT)
+    return start_page, end_page
+
+
+def get_next_start_page(current_start: int) -> int:
+    next_start = current_start + PAGE_WINDOW_SIZE
+    if next_start > MAX_PAGE_LIMIT:
+        return 1
+    return next_start
+
+
+def can_repost(app_id: str, item_type: str, state: Dict[str, dict]) -> bool:
+    if app_id not in state:
+        return True
+
+    entry = state[app_id]
+    last_posted = entry.get("last_posted")
+    last_type = entry.get("last_type", "unknown")
+
+    if last_type != item_type:
+        return True
+
+    if not last_posted:
+        return True
+
+    try:
+        dt = parse_iso(last_posted)
+    except Exception:
+        return True
+
+    cooldown_cutoff = datetime.now(timezone.utc) - timedelta(days=REPOST_COOLDOWN_DAYS)
+    return dt < cooldown_cutoff
+
+
+def update_state_for_post(app_id: str, item_type: str, state: Dict[str, dict]) -> None:
+    state[app_id] = {
+        "last_posted": utc_now_iso(),
+        "last_type": item_type
+    }
+
+
+def fetch_html(url: str) -> str:
+    response = requests.get(url, headers=HEADERS, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def safe_fetch_html(url: str) -> Optional[str]:
+    for attempt in range(1, MAX_FETCH_RETRIES + 1):
+        try:
+            return fetch_html(url)
+        except requests.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code == 429 and attempt < MAX_FETCH_RETRIES:
+                wait_time = BACKOFF_SECONDS * attempt
+                print(f"FETCH RETRY {attempt}/{MAX_FETCH_RETRIES}: {url} | 429 received, waiting {wait_time}s")
+                time.sleep(wait_time)
+                continue
+
+            print(f"FETCH FAILED: {url} | error={e}")
+            return None
+        except Exception as e:
+            print(f"FETCH FAILED: {url} | error={e}")
+            return None
+
+
+def sleep_briefly():
+    time.sleep(REQUEST_DELAY_SECONDS)
+
+
+def extract_appids_from_html(html: str, from_search_results: bool = False) -> List[str]:
+    ids: List[str] = []
+    if from_search_results:
+        soup = BeautifulSoup(html, "html.parser")
+        for anchor in soup.select("a.search_result_row[href*='/app/']"):
+            href = anchor.get("href", "")
+            match = re.search(r"/app/(\d+)", href)
+            if match:
+                ids.append(match.group(1))
+    else:
+        ids = re.findall(r"/app/(\d+)", html)
+
+    seen = set()
+    result = []
+    for app_id in ids:
+        if app_id not in seen:
+            seen.add(app_id)
+            result.append(app_id)
+    return result
+
+
+def collect_steam_free_candidates(start_page: int, end_page: int) -> List[Tuple[str, str]]:
+    results = []
+    seen = set()
+
+    for page in range(start_page, end_page + 1):
+        url = STEAM_FREE_SEARCH_URL.format(page)
+        html = safe_fetch_html(url)
+        if not html:
+            continue
+
+        page_ids = extract_appids_from_html(html, from_search_results=True)
+        print(f"FREE PAGE {page}: extracted {len(page_ids)} app ids")
+
+        for app_id in page_ids:
+            key = ("steam_free", app_id)
+            if key not in seen:
+                seen.add(key)
+                results.append(("steam_free", app_id))
+
+        sleep_briefly()
+
+    return results
+
+
+def collect_steam_demo_candidates(start_page: int, end_page: int) -> List[Tuple[str, str]]:
+    results = []
+    seen = set()
+
+    for page in range(start_page, end_page + 1):
+        url = STEAM_DEMO_SEARCH_URL.format(page)
+        html = safe_fetch_html(url)
+        if not html:
+            continue
+
+        page_ids = extract_appids_from_html(html, from_search_results=True)
+        print(f"DEMO PAGE {page}: extracted {len(page_ids)} app ids")
+
+        for app_id in page_ids:
+            key = ("steam_demo", app_id)
+            if key not in seen:
+                seen.add(key)
+                results.append(("steam_demo", app_id))
+
+        sleep_briefly()
+
+    return results
+
+
+def collect_paid_candidates(start_page: int, end_page: int) -> List[Tuple[str, str]]:
+    results = []
+    seen = set()
+
+    for page in range(start_page, end_page + 1):
+        url = STEAM_TOPSELLERS_URL.format(page)
+        html = safe_fetch_html(url)
+        if not html:
+            continue
+
+        page_ids = extract_appids_from_html(html, from_search_results=True)
+        print(f"PAID PAGE {page}: extracted {len(page_ids)} app ids")
+
+        for app_id in page_ids:
+            key = ("paid_candidate", app_id)
+            if key not in seen:
+                seen.add(key)
+                results.append(("paid_candidate", app_id))
+
+        sleep_briefly()
+
+    return results
+
+
+def collect_steamdb_promo_candidates() -> List[Tuple[str, str]]:
+    html = safe_fetch_html(STEAMDB_FREE_PROMO_URL)
+    if not html:
+        return []
+
+    ids = extract_appids_from_html(html)
+    print(f"STEAMDB PROMO: extracted {len(ids)} app ids")
+    return [("steamdb_promo", app_id) for app_id in ids]
+
+
+def clean_text(s: str) -> str:
+    return " ".join(s.split())
+
+
+def parse_title(soup: BeautifulSoup) -> Optional[str]:
+    title_el = soup.select_one("#appHubAppName")
+    if title_el:
+        return clean_text(title_el.get_text(" ", strip=True))
+
+    meta_title = soup.find("meta", property="og:title")
+    if meta_title and meta_title.get("content"):
+        return clean_text(meta_title["content"])
+
+    return None
+
+
+def parse_description(soup: BeautifulSoup) -> str:
+    desc_el = soup.select_one(".game_description_snippet")
+    if desc_el:
+        return clean_text(desc_el.get_text(" ", strip=True))
+
+    meta_desc = soup.find("meta", attrs={"name": "Description"})
+    if meta_desc and meta_desc.get("content"):
+        return clean_text(meta_desc["content"])
+
+    return ""
+
+
+def extract_steam_tags(soup: BeautifulSoup) -> List[str]:
+    tags = []
+    for tag_el in soup.select(".glance_tags.popular_tags a.app_tag"):
+        text = clean_text(tag_el.get_text(" ", strip=True))
+        if text:
+            tags.append(text.lower())
+    return tags
+
+
+def is_vr_content(title: str, description: str, text: str, tags: List[str]) -> bool:
+    lower_combined = normalize_text_lower(title, description, text)
+    if any(phrase in lower_combined for phrase in VR_INDICATOR_PHRASES):
+        return True
+
+    for tag in tags:
+        if tag in VR_TAG_EXACT:
+            return True
+        if any(phrase in tag for phrase in VR_INDICATOR_PHRASES):
+            return True
+        if tag == "vr" or tag.startswith("vr ") or tag.endswith(" vr"):
+            return True
+    return False
+
+
+def get_price_info(app_id: str) -> Tuple[Optional[float], bool, Optional[int], Optional[str]]:
+    try:
+        url = (
+            f"https://store.steampowered.com/api/appdetails"
+            f"?appids={app_id}&cc=us"
+        )
+        response = requests.get(url, headers=HEADERS, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        app_data = data.get(str(app_id), {})
+        if not app_data.get("success"):
+            return None, False, None, None
+
+        info = app_data.get("data", {})
+
+        if info.get("is_free") is True:
+            return 0.0, True, None, info.get("type")
+
+        price_info = info.get("price_overview")
+        if not price_info:
+            return None, False, None, info.get("type")
+
+        final_price_cents = price_info.get("final")
+        if final_price_cents is None:
+            return None, False, None, info.get("type")
+
+        discount_percent = price_info.get("discount_percent", 0)
+        return round(final_price_cents / 100.0, 2), False, discount_percent, info.get("type")
+    except Exception as e:
+        print(f"PRICE API FAILED: app_id={app_id} | error={e}")
+        return None, False, None, None
+
+
+def detect_item_type(source: str, app_id: str, title: str, text: str) -> str:
+    lower_title = title.lower()
+    lower_text = text.lower()
+
+    if source == "steamdb_promo" or "free to keep" in lower_text or "100% off" in lower_text:
+        return "temporarily_free"
+
+    # Paid candidates are only ever evaluated as paid_under_20 — skip demo/playtest paths.
+    if source != "paid_candidate":
+        if "playtest" in lower_title or "playtest" in lower_text:
+            # Verify the app is actually free — paid games sometimes mention
+            # "playtest" in their page text without offering a free trial.
+            price, is_free, _, _ = get_price_info(app_id)
+            if price is not None and price > 0 and not is_free:
+                print(f"DEMO/PLAYTEST PAID SKIP: app_id={app_id} | price={price} | classified as playtest but is paid")
+                return "ignore"
+            return "playtest"
+
+        if source == "steam_demo" or "demo" in lower_title or "demo" in lower_text:
+            # For non-steam_demo sources, verify the app is actually free before
+            # classifying as demo — paid games can mention "demo" anywhere in page text.
+            if source != "steam_demo":
+                price, is_free, _, _ = get_price_info(app_id)
+                if price is not None and price > 0 and not is_free:
+                    print(f"DEMO/PLAYTEST PAID SKIP: app_id={app_id} | price={price} | classified as demo but is paid")
+                    return "ignore"
+            return "demo"
+
+    if source == "paid_candidate":
+        price, is_free, _, item_type = get_price_info(app_id)
+
+        if item_type == "dlc":
+            return "ignore"
+
+        if is_free:
+            return "ignore"
+
+        if price is not None and 0 < price <= 20:
+            return "paid_under_20"
+
+        return "ignore"
+
+    return "free_game"
+
+
+def normalize_text_lower(*parts: str) -> str:
+    return " ".join(part.strip().lower() for part in parts if isinstance(part, str) and part.strip())
+
+
+def score_multiplayer(text: str) -> Tuple[int, List[str]]:
+    score = 0
+    hits = []
+
+    lower_text = text.lower()
+    for term, points in MULTIPLAYER_TERMS.items():
+        if term.lower() in lower_text:
+            score += points
+            hits.append(term)
+
+    return score, hits
+
+
+def score_player_count(text: str) -> Tuple[int, List[str], bool]:
+    score = 0
+    hits = []
+    rejected = False
+
+    lower_text = text.lower()
+
+    if "massively multiplayer" in lower_text or re.search(r"\bmmo\b", lower_text):
+        score += 4
+        hits.append("MMO/Massively Multiplayer")
+        return score, hits, False
+
+    for pattern, points in PLAYER_COUNT_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            score += points
+            hits.append(pattern)
+
+    for pattern in REJECT_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            rejected = True
+
+    return score, hits, rejected
+
+
+def score_genres_and_description(title: str, description: str, text: str) -> Tuple[int, List[str]]:
+    score = 0
+    hits = []
+
+    lower_combined = normalize_text_lower(title, description, text)
+
+    for term, points in GOOD_GENRE_TERMS.items():
+        if term.lower() in lower_combined:
+            score += points
+            hits.append(term)
+
+    for term, points in GOOD_DESCRIPTION_TERMS.items():
+        if term.lower() in lower_combined:
+            score += points
+            hits.append(term)
+
+    for term, points in BAD_TERMS.items():
+        if term.lower() in lower_combined:
+            score += points
+            hits.append(term)
+
+    return score, hits
+
+
+def has_4plus_player_signal(text: str) -> bool:
+    patterns = [
+        r"\b4\s*player\b",
+        r"\b4\s*players\b",
+        r"\b5\s*player\b",
+        r"\b5\s*players\b",
+        r"\b6\s*player\b",
+        r"\b6\s*players\b",
+        r"\bup to 4 players\b",
+        r"\bup to 5 players\b",
+        r"\bup to 6 players\b",
+        r"\bup to 8 players\b",
+        r"\b1\s*-\s*4\b",
+        r"\b1\s*-\s*6\b",
+        r"\b2\s*-\s*4\b",
+        r"\b2\s*-\s*6\b",
+        r"\b3\s*-\s*4\b",
+        r"\b3\s*-\s*6\b",
+        r"\b4\s*\+\b",
+    ]
+    return any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns)
+
+
+def extract_review_count(page_text: str) -> int:
+    match = re.search(r"([\d,]+)\s+(?:user\s+)?reviews?\b", page_text, re.IGNORECASE)
+    if not match:
+        return 0
+    try:
+        return int(match.group(1).replace(",", ""))
+    except ValueError:
+        return 0
+
+
+def extract_release_date(page_text: str) -> Optional[datetime]:
+    match = re.search(
+        r"Release Date:\s*([A-Za-z]{3,9}\s+\d{1,2},\s+\d{4})",
+        page_text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    raw = clean_text(match.group(1))
+    for fmt in RELEASE_DATE_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+# Recency bonus tiers for free and paid games (not applied to demos/playtests).
+RECENCY_BONUS_TIERS = [
+    (7, 6),
+    (30, 4),
+    (90, 2),
+    (180, 1),
+]
+
+
+def score_recency_bonus(page_text: str) -> Tuple[int, List[str]]:
+    """Return a recency bonus for free/paid games based on release date age."""
+    release_date = extract_release_date(page_text)
+    if release_date is None:
+        return 0, []
+    age_days = (datetime.now(timezone.utc) - release_date).days
+    for threshold, bonus in RECENCY_BONUS_TIERS:
+        if age_days <= threshold:
+            return bonus, [f"recency:{bonus}(age={age_days}d)"]
+    return 0, []
+
+
+def score_demo_playtest_friend_group_fit(
+    title: str,
+    description: str,
+    text: str,
+    review_sentiment: Optional[str],
+    review_count: int,
+) -> Tuple[int, int, int, List[str]]:
+    score = 0
+    friend_signal_score = 0
+    freshness_bonus = 0
+    hits: List[str] = []
+
+    combined = f"{title} {description} {text}".lower()
+    for phrase, points in DEMO_PLAYTEST_FRIEND_SIGNALS.items():
+        if phrase in combined:
+            score += points
+            friend_signal_score += points
+            hits.append(f"friend:{phrase}")
+
+    for phrase, points in DEMO_PLAYTEST_SOLO_SIGNALS.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"solo:{phrase}")
+
+    for phrase, points in DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"playable-cue:{phrase}")
+
+    has_coop_or_mp = (
+        "co-op" in combined
+        or "coop" in combined
+        or "multiplayer" in combined
+        or "massively multiplayer" in combined
+    )
+    if has_coop_or_mp:
+        friend_signal_score += 1
+        score += 1
+        hits.append("friend:coop-or-mp")
+
+    if has_4plus_player_signal(text):
+        friend_signal_score += 2
+        score += 2
+        hits.append("friend:4plus")
+
+    if review_sentiment in FREE_REVIEW_BLOCKLIST:
+        score -= 4
+        hits.append("review:negative")
+    elif review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS and review_count >= 100:
+        score += 1
+        hits.append("review:positive")
+
+    release_date = extract_release_date(text)
+    if release_date:
+        age_days = (datetime.now(timezone.utc) - release_date).days
+        if age_days <= 14:
+            freshness_bonus = 2
+        elif age_days <= 45:
+            freshness_bonus = 1
+        if freshness_bonus > 0:
+            score += freshness_bonus
+            hits.append(f"freshness:{freshness_bonus}")
+
+    return score, friend_signal_score, freshness_bonus, hits
+
+
+def has_demo_playtest_free_to_try_signal(title: str, description: str, text: str) -> bool:
+    combined = f"{title} {description} {text}".lower()
+    return any(phrase in combined for phrase in DEMO_PLAYTEST_LEGIT_PLAYABLE_CUE_SCORES)
+
+
+# Phrases in Steam page text that indicate a demo/playtest is not yet playable.
+DEMO_NOT_YET_AVAILABLE_PHRASES = [
+    "coming soon",
+    "not yet available",
+    "available soon",
+    "wishlist now",
+    "notify me when available",
+]
+
+
+def is_demo_not_yet_available(page_text: str, soup: "BeautifulSoup") -> tuple[bool, str]:
+    """Return (True, reason) if a demo/playtest page indicates it is not yet playable.
+
+    Checks (in order):
+    1. Future release date
+    2. Steam's dedicated coming-soon HTML elements (#game_area_comingsoon, .coming_soon)
+    3. 'Coming Soon' or similar phrases in the purchase/action block only
+    """
+    # 1. Future release date
+    release_date = extract_release_date(page_text)
+    if release_date is not None and release_date > datetime.now(timezone.utc):
+        days_until = (release_date - datetime.now(timezone.utc)).days
+        return True, f"release_date={release_date.date().isoformat()} is in the future ({days_until}d)"
+
+    # 2. Steam's dedicated coming-soon elements (unambiguous structural signals)
+    for selector in ("#game_area_comingsoon", ".coming_soon", "#coming_soon_text"):
+        if soup.select_one(selector):
+            return True, f"Steam coming-soon element '{selector}' present"
+
+    # 3. Purchase/action block text (targeted — not a broad page-text scan)
+    for selector in (".game_purchase_action", ".game_area_purchase_game"):
+        block = soup.select_one(selector)
+        if block:
+            block_text = block.get_text(" ", strip=True).lower()
+            for phrase in DEMO_NOT_YET_AVAILABLE_PHRASES:
+                if phrase in block_text:
+                    return True, f"purchase_block contains '{phrase}'"
+
+    return False, ""
+
+
+def extract_diversity_tags(title: str, description: str, text: str) -> List[str]:
+    combined = f"{title} {description} {text}".lower()
+    tag_terms = (
+        "survival",
+        "crafting",
+        "shooter",
+        "roguelike",
+        "roguelite",
+        "party",
+        "extraction",
+    )
+    return [term for term in tag_terms if term in combined]
+
+
+def apply_light_diversity_rerank(items: List[dict]) -> List[dict]:
+    # Diversity rerank is intentionally weaker than base quality scoring:
+    # it only nudges away from near-identical same-day picks and should never
+    # overpower stronger underlying scores.
+    if len(items) <= 2:
+        return items
+
+    remaining = list(items)
+    selected: List[dict] = []
+    tag_counts: Dict[str, int] = {}
+
+    while remaining:
+        best_item = None
+        best_adjusted_score = None
+        for item in remaining:
+            penalty = 0
+            for tag in item.get("diversity_tags", []):
+                extra = max(0, tag_counts.get(tag, 0) - LIGHT_DIVERSITY_DUPLICATE_FREE_SLOTS + 1)
+                penalty += extra * LIGHT_DIVERSITY_PER_EXTRA_DUPLICATE
+            adjusted_score = item["score"] - penalty
+            if best_adjusted_score is None or adjusted_score > best_adjusted_score:
+                best_item = item
+                best_adjusted_score = adjusted_score
+
+        assert best_item is not None
+        picked = dict(best_item)
+        picked["diversity_penalty"] = picked["score"] - int(best_adjusted_score)
+        selected.append(picked)
+        for tag in best_item.get("diversity_tags", []):
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        remaining.remove(best_item)
+
+    return selected
+
+
+def select_demo_playtest_items(qualified_demo_playtest: List[dict], cap: int) -> List[dict]:
+    # Explicit quality-over-cap behavior:
+    # for demo/playtest we intentionally prefer posting fewer strong picks over
+    # filling the cap with weak borderline items.
+    strong_items = [item for item in qualified_demo_playtest if item["score"] >= DEMO_PLAYTEST_QUALITY_FLOOR_SCORE]
+    if strong_items:
+        return strong_items[:cap]
+    return qualified_demo_playtest[:cap]
+
+
+def build_keep_debug_context(item: dict) -> str:
+    keep_parts = [
+        f"keep={item['keep']}",
+        f"rejected={item.get('rejected', False)}",
+        f"review_gate_failed={item.get('review_gate_failed', False)}",
+    ]
+    if item["type"] in {"demo", "playtest"}:
+        keep_parts.append(f"friend_signal={item.get('demo_friend_signal_score', 0)}")
+    return ", ".join(keep_parts)
+
+
+def log_candidate_decision(item: dict, phase: str) -> None:
+    if item["type"] in {"demo", "playtest"}:
+        print(
+            f"DEMO_CANDIDATE[{phase}]: {item['title']} | type={item['type']} "
+            f"| score={item['score']} | sentiment={item.get('review_sentiment')} "
+            f"| reviews={item.get('review_count', 0)} | friend_signal={item.get('demo_friend_signal_score', 0)} "
+            f"| freshness={item.get('demo_freshness_bonus', 0)} | refinement_hits={item.get('refinement_hits', [])[:4]} "
+            f"| demo_hits={item.get('demo_hits', [])[:4]} | {build_keep_debug_context(item)}"
+        )
+        return
+
+    print(
+        f"CANDIDATE[{phase}]: {item['title']} | type={item['type']} | score={item['score']} "
+        f"| sentiment={item.get('review_sentiment')} | reviews={item.get('review_count', 0)} "
+        f"| {build_keep_debug_context(item)}"
+    )
+
+
+def _is_filtered_for_weak_group_fit(item: dict) -> bool:
+    item_type = item.get("type")
+    if item.get("rejected"):
+        return True
+    if item_type in {"free_game", "temporarily_free"}:
+        return not item.get("multiplayer_hits") or not item.get("player_hits")
+    if item_type in {"demo", "playtest"}:
+        return item.get("demo_friend_signal_score", 0) < DEMO_PLAYTEST_MIN_FRIEND_SIGNAL
+    if item_type == "paid_under_20":
+        return not item.get("multiplayer_hits")
+    return False
+
+
+def _is_filtered_as_low_signal_junk(item: dict) -> bool:
+    for hit in item.get("refinement_hits", []):
+        if hit.startswith("low-signal:") or hit.startswith("title-low-signal:"):
+            return True
+    return False
+
+
+class DebugRecord(TypedDict):
+    title: str
+    type: str
+    final_score: int
+    review_sentiment: Optional[str]
+    friend_group_signal: int
+    keep: bool
+    reason_list: List[str]
+
+
+def build_filter_reason_list(item: dict) -> List[str]:
+    reasons: List[str] = []
+    if item.get("review_gate_failed"):
+        reasons.append(FILTER_REASON_WEAK_REVIEW)
+    if _is_filtered_for_weak_group_fit(item):
+        reasons.append(FILTER_REASON_WEAK_GROUP_FIT)
+    if _is_filtered_as_low_signal_junk(item):
+        reasons.append(FILTER_REASON_LOW_SIGNAL_JUNK)
+    return reasons
+
+
+ITEM_TYPE_TO_DAILY_SECTION = {
+    "demo": "demo_playtest",
+    "playtest": "demo_playtest",
+    "free_game": "free",
+    "temporarily_free": "free",
+    "paid_under_20": "paid",
+}
+
+
+def route_item_to_daily_section(item_type: str) -> Optional[str]:
+    return ITEM_TYPE_TO_DAILY_SECTION.get(item_type)
+
+
+def build_run_summary(
+    *,
+    steam_candidates_scanned: int,
+    demo_playtest_candidates_qualified: int,
+    free_candidates_qualified: int,
+    paid_candidates_qualified: int,
+    demo_playtest_posted: int,
+    free_posted: int,
+    paid_posted: int,
+    filtered_weak_reviews: int,
+    filtered_weak_group_fit: int,
+    filtered_low_signal_junk: int,
+    filtered_repost_cooldown: int,
+    top_filter_reasons: Optional[List[Tuple[str, int]]] = None,
+    selected_title_samples: Optional[Dict[str, List[str]]] = None,
+) -> List[str]:
+    lines = [
+        "RUN SUMMARY",
+        f"- Steam candidates scanned: {steam_candidates_scanned}",
+        f"- Demo/playtest candidates qualified: {demo_playtest_candidates_qualified}",
+        f"- Free candidates qualified: {free_candidates_qualified}",
+        f"- Paid candidates qualified: {paid_candidates_qualified}",
+        f"- Demo/playtest posted: {demo_playtest_posted}",
+        f"- Free posted: {free_posted}",
+        f"- Paid posted: {paid_posted}",
+        f"- Filtered for weak reviews: {filtered_weak_reviews}",
+        f"- Filtered for weak multiplayer/friend-group fit: {filtered_weak_group_fit}",
+        f"- Filtered as junk/prototype/low-signal: {filtered_low_signal_junk}",
+        f"- Filtered by repost cooldown: {filtered_repost_cooldown}",
+    ]
+    for index, (reason, count) in enumerate(top_filter_reasons or []):
+        rank = ["Top", "Second", "Third"][index] if index < 3 else f"#{index + 1}"
+        lines.append(f"- {rank} filter reason: {reason} ({count})")
+    if selected_title_samples:
+        lines.append("- Selected by section (sample):")
+        for section in ("demo_playtest", "free", "paid"):
+            titles = selected_title_samples.get(section, [])
+            label = next((cfg["message_label"] for cfg in DAILY_SECTION_CONFIG if cfg["key"] == section), section)
+            display = ", ".join(titles) if titles else "none"
+            lines.append(f"  - {label}: {display}")
+    return lines
+
+
+def export_daily_debug_summary(
+    records: List[dict],
+    run_summary_lines: List[str],
+    path: str = DAILY_DEBUG_SUMMARY_FILE,
+    target_day_key: Optional[str] = None,
+    instagram_debug: Optional[Dict[str, object]] = None,
+) -> None:
+    # Intentionally ephemeral troubleshooting artifact: overwritten each run.
+    payload = {
+        "generated_at_utc": utc_now_iso(),
+        "target_day_key": target_day_key or get_target_day_key(),
+        "section_order": DAILY_SECTION_ORDER,
+        "run_summary": run_summary_lines,
+        "instagram_debug": instagram_debug or {},
+        "records": records,
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+        print(f"DEBUG EXPORT: wrote {path} ({len(records)} records)")
+    except Exception as e:
+        print(f"WARN: failed to write debug summary ({path}): {e}")
+
+
+def export_verification_artifact(
+    day_key: str,
+    run_counts: Dict[str, int],
+    rerun_protection_active: bool,
+    verification_state: Optional[dict] = None,
+    path: str = DAILY_VERIFICATION_FILE,
+) -> None:
+    """Write a JSON verification artifact summarizing the daily workflow run outcome."""
+    vs = verification_state or {}
+    run_state = vs.get("run_state") if isinstance(vs.get("run_state"), dict) else {}
+    items = vs.get("items") if isinstance(vs.get("items"), list) else []
+    posted_section_keys = vs.get("posted_section_keys") if isinstance(vs.get("posted_section_keys"), list) else []
+
+    intro_state = run_state.get("intro") if isinstance(run_state.get("intro"), dict) else {}
+    intro_present = bool(intro_state.get("message_id"))
+    intro_count = 1 if intro_present else 0
+
+    section_headers_state = run_state.get("section_headers") if isinstance(run_state.get("section_headers"), dict) else {}
+    section_header_counts = {
+        sk: (1 if isinstance(v, dict) and v.get("message_id") else 0)
+        for sk, v in section_headers_state.items()
+    }
+
+    item_count = len(items)
+    key_seq = [item.get("item_key") for item in items if isinstance(item, dict) and item.get("item_key")]
+    seen_keys: set = set()
+    dup_keys: List[str] = []
+    for k in key_seq:
+        if k in seen_keys and k not in dup_keys:
+            dup_keys.append(k)
+        seen_keys.add(k)
+    duplicate_item_keys = dup_keys
+
+    footer_state = run_state.get("footer") if isinstance(run_state.get("footer"), dict) else {}
+    footer_present = bool(footer_state.get("message_id"))
+
+    skipped = run_counts.get("skipped", 0)
+
+    if rerun_protection_active:
+        # Run was intentionally skipped; structural checks belong to the completing run.
+        passes = skipped == 0
+    else:
+        footer_expected = bool(posted_section_keys) and bool(DISCORD_GUILD_ID)
+        footer_ok = footer_present if footer_expected else True
+        headers_ok = all(
+            sk in posted_section_keys
+            for sk, count in section_header_counts.items()
+            if count > 0
+        )
+        passes = (
+            intro_count == 1
+            and not duplicate_item_keys
+            and footer_ok
+            and headers_ok
+            and skipped == 0
+        )
+
+    artifact = {
+        "day_key": day_key,
+        "created": run_counts.get("created", 0),
+        "updated": run_counts.get("updated", 0),
+        "reused": run_counts.get("reused", 0),
+        "skipped": skipped,
+        "rerun_protection_active": rerun_protection_active,
+        "intro_present": intro_present,
+        "intro_count": intro_count,
+        "section_header_counts": section_header_counts,
+        "item_count": item_count,
+        "duplicate_item_keys": duplicate_item_keys,
+        "footer_present": footer_present,
+        "posted_section_keys": posted_section_keys,
+        "pass": passes,
+        "generated_at_utc": utc_now_iso(),
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(artifact, f, indent=2, ensure_ascii=False)
+        print(f"VERIFICATION: wrote {path}")
+    except Exception as e:
+        print(f"WARN: failed to write verification artifact ({path}): {e}")
+
+
+def post_discord_debug_summary(
+    day_key: str,
+    run_counts: Dict[str, int],
+    rerun_protection_active: bool,
+    force_refresh_same_day: bool,
+) -> None:
+    """Post a compact debug summary message to DISCORD_DEBUG_CHANNEL_ID after a daily workflow run."""
+    if not DISCORD_DEBUG_CHANNEL_ID or not DISCORD_BOT_TOKEN:
+        return
+    try:
+        day_label = datetime.strptime(day_key, "%Y-%m-%d").strftime("%Y-%m-%d (%a)")
+    except ValueError:
+        day_label = day_key
+    created = run_counts.get("created", 0)
+    updated = run_counts.get("updated", 0)
+    reused = run_counts.get("reused", 0)
+    skipped = run_counts.get("skipped", 0)
+    lines = [
+        f"🛠 Debug | Daily Picks | {day_label}",
+        f"Created: {created} | Updated: {updated} | Reused: {reused} | Skipped: {skipped}",
+        f"Rerun protection: {'active' if rerun_protection_active else 'inactive'}"
+        + (" | Force refresh: on" if force_refresh_same_day else ""),
+    ]
+    content = "\n".join(lines)
+    try:
+        session = requests.Session()
+        session.headers.update({
+            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+            "Content-Type": "application/json",
+        })
+        client = DiscordClient(session)
+        client.post_message(DISCORD_DEBUG_CHANNEL_ID, content, context="daily picks debug summary")
+        print(f"DEBUG SUMMARY: posted to channel {DISCORD_DEBUG_CHANNEL_ID}")
+    except Exception as e:
+        print(f"WARN: failed to post debug summary to Discord: {e}")
+
+
+def score_quality_refinements(
+    title: str,
+    description: str,
+    text: str,
+    review_sentiment: Optional[str],
+    review_count: int,
+    multiplayer_score: int,
+    player_score: int,
+) -> Tuple[int, List[str]]:
+    score = 0
+    hits = []
+    lower_title = title.lower()
+    lower_text = text.lower()
+    combined = normalize_text_lower(title, description, text)
+
+    strong_review = review_sentiment in STRONG_REVIEW_SENTIMENTS
+    positive_or_better = review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS
+    has_4plus = has_4plus_player_signal(text)
+    has_coop = "co-op" in lower_text or "co op" in lower_text or "online co-op" in lower_text
+    has_pvp = "pvp" in lower_text or "online pvp" in lower_text
+    strong_multiplayer = multiplayer_score >= 4 or player_score >= 3
+
+    if strong_review and has_4plus:
+        score += 2
+        hits.append("strong-review-4plus-combo")
+
+    if review_count >= 10000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
+        score += 2
+        hits.append("review-count-10k")
+    elif review_count >= 1000 and review_sentiment in REVIEW_CONFIDENCE_BASELINE_SENTIMENTS:
+        score += 1
+        hits.append("review-count-1k")
+
+    for phrase, points in FRIEND_GROUP_PHRASE_SCORES.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"group:{phrase}")
+
+    for phrase, points in REPLAYABILITY_PHRASE_SCORES.items():
+        if phrase in combined:
+            score += points
+            hits.append(f"replay:{phrase}")
+
+    if "single-player" in combined and multiplayer_score <= 2:
+        score -= 2
+        hits.append("single-player-with-weak-mp")
+
+    for keyword, points in LOW_SIGNAL_KEYWORD_SCORES.items():
+        if keyword in combined:
+            score += points
+            hits.append(f"low-signal:{keyword}")
+
+    for keyword, points in TITLE_LOW_SIGNAL_KEYWORD_SCORES.items():
+        if keyword in lower_title:
+            score += points
+            hits.append(f"title-low-signal:{keyword}")
+
+    story_terms = ["visual novel", "dating sim", "interactive fiction", "story-rich", "narrative"]
+    if not strong_multiplayer:
+        for term in story_terms:
+            if term in combined:
+                score -= 2
+                hits.append(f"story:{term}")
+
+    if "early access" in combined and not strong_review:
+        score -= 2
+        hits.append("early-access")
+
+    if has_coop:
+        score += 1
+        hits.append("coop-preference")
+    if has_pvp and not has_coop:
+        score -= 1
+        hits.append("pvp-only-penalty")
+
+    if has_4plus and any(token in combined for token in ["4 players", "4-player", "up to 4 players", "up to 5 players", "up to 6 players", "5 players", "6 players"]):
+        score += 1
+        hits.append("4to6-player-preference")
+
+    if multiplayer_score >= 6 and review_sentiment == "Mixed":
+        score -= 2
+        hits.append("keyword-stuffing-weak-review")
+
+    trusted_genres = ["survival", "shooter", "roguelike", "roguelite", "party", "extraction"]
+    if strong_review and has_4plus and has_coop and any(term in combined for term in trusted_genres):
+        score += 2
+        hits.append("trusted-profile")
+
+    return score, hits
+
+
+def extract_review_sentiment(soup: BeautifulSoup) -> Optional[str]:
+    page_text = soup.get_text(" ", strip=True)
+
+    for sentiment in REVIEW_SENTIMENT_PATTERNS:
+        if sentiment in page_text:
+            return sentiment
+
+    return None
+
+
+def extract_review_score(soup: BeautifulSoup) -> int:
+    sentiment = extract_review_sentiment(soup)
+    if sentiment is None:
+        return 0
+
+    return REVIEW_SENTIMENT_SCORES[sentiment]
+
+
+def inspect_game(source: str, app_id: str) -> Optional[dict]:
+    url = f"https://store.steampowered.com/app/{app_id}/"
+    try:
+        response = requests.get(url, headers=HEADERS, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        print(f"FETCH FAILED: {url} | error={e}")
+        return None
+
+    final_url = response.url or url
+    final_path = urlparse(final_url).path or ""
+    if not re.search(r"/app/\d+", final_path):
+        print(f"INVALID APP PAGE: app_id={app_id} | final_url={final_url}")
+        return None
+
+    html = response.text
+    soup = BeautifulSoup(html, "html.parser")
+    if not soup.select_one("#appHubAppName"):
+        print(f"INVALID APP PAGE: app_id={app_id} | missing #appHubAppName")
+        return None
+
+    title = parse_title(soup)
+    if not title:
+        return None
+    if title == "Steam Store":
+        print(f"INVALID APP PAGE: app_id={app_id} | title={title}")
+        return None
+
+    description = parse_description(soup)
+    page_text = clean_text(soup.get_text(" ", strip=True))
+    steam_tags = extract_steam_tags(soup)
+
+    if is_vr_content(title, description, page_text, steam_tags):
+        print(f"VR GAME DETECTED: {title}")
+        return None
+
+    item_type = detect_item_type(source, app_id, title, page_text)
+
+    if source == "paid_candidate":
+        price, is_free, discount_percent, api_type = get_price_info(app_id)
+        print(f"PAID CHECK: {title} | price={price} | is_free={is_free} | discount={discount_percent}% | api_type={api_type} | item_type={item_type}")
+
+    if item_type == "ignore":
+        return None
+
+    # Exclude demos/playtests that are not yet available to play.
+    if item_type in {"demo", "playtest"}:
+        not_available, reason = is_demo_not_yet_available(page_text, soup)
+        if not_available:
+            print(f"DEMO NOT YET AVAILABLE: {title} | excluded: demo not yet available to play | reason={reason}")
+            return None
+
+    multiplayer_score, multiplayer_hits = score_multiplayer(page_text)
+    player_score, player_hits, rejected = score_player_count(page_text)
+    flavor_score, flavor_hits = score_genres_and_description(title, description, page_text)
+    review_sentiment = extract_review_sentiment(soup)
+    review_count = extract_review_count(page_text)
+    review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, UNKNOWN_REVIEW_SCORE_BY_TYPE.get(item_type, 0))
+
+    # Hard exclude: Mostly Negative / Very Negative / Overwhelmingly Negative → skip entirely.
+    # Demos/playtests with no reviews (review_sentiment is None) are exempt.
+    if review_sentiment in HARD_EXCLUDE_REVIEW_SENTIMENTS:
+        print(f"HARD EXCLUDED (negative reviews): {title} | sentiment={review_sentiment}")
+        return None
+
+    review_gate_failed = False
+    if item_type in ["free_game", "temporarily_free"]:
+        review_gate_failed = review_sentiment is None or review_sentiment in FREE_REVIEW_BLOCKLIST
+    elif item_type in ["demo", "playtest"]:
+        review_gate_failed = review_sentiment in {"Very Negative", "Overwhelmingly Negative"}
+    elif item_type == "paid_under_20":
+        review_gate_failed = review_sentiment not in PAID_MINIMUM_REVIEW_SENTIMENTS
+
+    refinement_score, refinement_hits = score_quality_refinements(
+        title=title,
+        description=description,
+        text=page_text,
+        review_sentiment=review_sentiment,
+        review_count=review_count,
+        multiplayer_score=multiplayer_score,
+        player_score=player_score,
+    )
+
+    type_adjustment = 0
+    if item_type == "temporarily_free" and review_sentiment in POSITIVE_OR_BETTER_REVIEW_SENTIMENTS:
+        type_adjustment += TEMPORARILY_FREE_SCORE_BONUS
+    if item_type in {"demo", "playtest"}:
+        type_adjustment -= DEMO_SCORE_PENALTY
+
+    demo_section_score = 0
+    demo_friend_signal_score = 0
+    demo_freshness_bonus = 0
+    demo_hits: List[str] = []
+    demo_has_free_to_try_signal = True
+    if item_type in {"demo", "playtest"}:
+        demo_section_score, demo_friend_signal_score, demo_freshness_bonus, demo_hits = score_demo_playtest_friend_group_fit(
+            title=title,
+            description=description,
+            text=page_text,
+            review_sentiment=review_sentiment,
+            review_count=review_count,
+        )
+        demo_has_free_to_try_signal = has_demo_playtest_free_to_try_signal(title, description, page_text)
+
+    discount_score = 0
+    if item_type == "paid_under_20" and discount_percent is not None:
+        if discount_percent >= 50:
+            discount_score = 3
+        elif discount_percent >= 25:
+            discount_score = 2
+        elif discount_percent >= 10:
+            discount_score = 1
+
+    # Recency bonus applies to free/paid games only — demos/playtests use their own freshness scoring.
+    recency_score = 0
+    recency_hits: List[str] = []
+    if item_type not in {"demo", "playtest"}:
+        recency_score, recency_hits = score_recency_bonus(page_text)
+
+    total_score = (
+        multiplayer_score
+        + player_score
+        + flavor_score
+        + review_score
+        + refinement_score
+        + type_adjustment
+        + demo_section_score
+        + discount_score
+        + recency_score
+    )
+
+    has_strong_multiplayer = multiplayer_score >= 2
+    has_3plus_signal = player_score > 0
+
+    if item_type == "paid_under_20":
+        keep = (
+            has_strong_multiplayer and
+            not rejected and
+            not review_gate_failed and
+            total_score >= MIN_SCORE_TO_POST_PAID
+        )
+    elif item_type in ["free_game", "temporarily_free"]:
+        keep = (
+            has_strong_multiplayer and
+            has_3plus_signal and
+            not rejected and
+            not review_gate_failed and
+            total_score >= MIN_SCORE_TO_POST_FREE
+        )
+    elif item_type in {"demo", "playtest"}:
+        # Demo/Playtest has a stricter friend-group gate than full free games:
+        # we only post tests that already show multiplayer viability for group nights.
+        keep = (
+            demo_has_free_to_try_signal and
+            has_strong_multiplayer and
+            not rejected and
+            not review_gate_failed and
+            demo_friend_signal_score >= DEMO_PLAYTEST_MIN_FRIEND_SIGNAL and
+            total_score >= MIN_SCORE_TO_POST_DEMO_PLAYTEST
+        )
+    else:
+        keep = False
+
+    return {
+        "id": app_id,
+        "title": title,
+        "url": url,
+        "description": description,
+        "type": item_type,
+        "source": source,
+        "score": total_score,
+        "keep": keep,
+        "rejected": rejected,
+        "multiplayer_hits": multiplayer_hits,
+        "player_hits": player_hits,
+        "flavor_hits": flavor_hits,
+        "refinement_hits": refinement_hits,
+        "review_sentiment": review_sentiment,
+        "review_score": review_score,
+        "review_count": review_count,
+        "review_gate_failed": review_gate_failed,
+        "recency_score": recency_score,
+        "recency_hits": recency_hits,
+        "demo_friend_signal_score": demo_friend_signal_score,
+        "demo_freshness_bonus": demo_freshness_bonus,
+        "demo_has_free_to_try_signal": demo_has_free_to_try_signal,
+        "demo_hits": demo_hits,
+        "diversity_tags": extract_diversity_tags(title, description, page_text),
+    }
+
+
+def type_label(item_type: str) -> str:
+    if item_type == "demo":
+        return "Demo"
+    if item_type == "playtest":
+        return "Playtest"
+    if item_type == "temporarily_free":
+        return "Temporarily Free"
+    if item_type == "paid_under_20":
+        return "Paid Under $20"
+    return "Free Game"
+
+
+def format_item_block(item: dict, idx: int, paid: bool = False) -> str:
+    lines = []
+    lines.append(f"**{idx}. {item['title']}**")
+    lines.append(f"Type: {'Paid Under $20' if paid else type_label(item['type'])}")
+    lines.append(f"Score: {item['score']}")
+    if item["description"]:
+        lines.append(item["description"][:180])
+    lines.append(item["url"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_steam_item_message(item: dict, idx: int, paid: bool = False, demo_playtest: bool = False) -> str:
+    emoji = "💸" if paid else ("🧪" if demo_playtest else "🎮")
+    if paid:
+        label = "Paid Pick"
+    elif demo_playtest:
+        label = f"{type_label(item.get('type', 'demo'))} Pick"
+    else:
+        label = "Free Pick"
+    lines = [
+        f"{emoji} {label} #{idx}",
+        item["title"],
+        f"Score: {item['score']}",
+    ]
+
+    if item.get("description"):
+        lines.append(item["description"][:180])
+
+    lines.append(item["url"])
+    return "\n".join(lines)
+
+
+def format_instagram_item_message(post: dict, idx: int) -> str:
+    return (
+        f"📸 Creator Pick #{idx}\n"
+        f"@{post['username']} — {post['caption']}\n"
+        f"{post['url']}"
+    )
+
+
+def build_message_chunks(title_line: str, items: List[dict], paid: bool = False) -> List[str]:
+    if not items:
+        return []
+
+    chunks = []
+    current = f"{title_line}\n\n"
+
+    for idx, item in enumerate(items, start=1):
+        block = format_item_block(item, idx, paid=paid)
+
+        if len(current) + len(block) > DISCORD_CHAR_LIMIT:
+            chunks.append(current.rstrip())
+            current = block
+        else:
+            current += block
+
+    if current.strip():
+        chunks.append(current.rstrip())
+
+    return chunks
+    
+def build_instagram_chunks(posts: List[dict]) -> List[str]:
+    title = "📸 **New Instagram Creator Picks**"
+    chunks = []
+    current = title + "\n\n"
+
+    for idx, post in enumerate(posts, start=1):
+        block = (
+            f"{idx}. @{post['username']} — {post['caption']}\n"
+            f"{post['url']}\n\n"
+        )
+
+        if len(current) + len(block) > DISCORD_CHAR_LIMIT:
+            chunks.append(current.rstrip())
+            current = title + "\n\n" + block
+        else:
+            current += block
+
+    if current.strip():
+        chunks.append(current.rstrip())
+
+    return chunks
+
+def post_to_discord(message: str) -> None:
+    if not WEBHOOK_URL:
+        raise RuntimeError("DISCORD_WEBHOOK_URL is not set.")
+
+    response = requests.post(
+        WEBHOOK_URL,
+        json={"content": message},
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+
+
+def post_to_discord_with_metadata(message: str, capture_metadata: bool = False) -> Optional[dict]:
+    if not WEBHOOK_URL:
+        raise RuntimeError("DISCORD_WEBHOOK_URL is not set.")
+
+    webhook_url = WEBHOOK_URL
+    if capture_metadata:
+        separator = "&" if "?" in WEBHOOK_URL else "?"
+        webhook_url = f"{WEBHOOK_URL}{separator}wait=true"
+
+    response = requests.post(
+        webhook_url,
+        json={"content": message},
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    if not capture_metadata:
+        return None
+
+    try:
+        payload = response.json()
+    except Exception as e:
+        print(f"DISCORD METADATA PARSE FAILED: error={e}")
+        return None
+
+    message_id = payload.get("id")
+    channel_id = payload.get("channel_id")
+    if not message_id:
+        return None
+
+    return {
+        "message_id": str(message_id),
+        "channel_id": str(channel_id) if channel_id else None,
+    }
+
+
+def load_discord_daily_posts() -> Dict[str, dict]:
+    return load_json_object(DISCORD_DAILY_POSTS_FILE, log=print)
+
+
+def save_discord_daily_posts(data: Dict[str, dict]) -> None:
+    data = prune_discord_daily_posts(data)
+    save_json_object_atomic(DISCORD_DAILY_POSTS_FILE, data)
+
+
+def prune_discord_daily_posts(data: Dict[str, dict]) -> Dict[str, dict]:
+    pruned = prune_latest_iso_dates(data, DISCORD_DAILY_POSTS_RETENTION_DAYS, log=print)
+    if len(pruned) < len(data):
+        print(f"RETENTION: pruned daily posts state from {len(data)} to {len(pruned)} day keys")
+    return pruned
+
+
+def get_target_day_key() -> str:
+    manual_day = (os.getenv(DAILY_DATE_OVERRIDE_ENV, "") or "").strip()
+    if not manual_day:
+        return datetime.now(timezone.utc).date().isoformat()
+    try:
+        datetime.fromisoformat(manual_day)
+    except ValueError:
+        raise RuntimeError(f"{DAILY_DATE_OVERRIDE_ENV} must be YYYY-MM-DD")
+    return manual_day
+
+
+def get_force_refresh_same_day() -> bool:
+    raw = (os.getenv(FORCE_REFRESH_SAME_DAY_ENV, "") or "").strip().lower()
+    if not raw:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(
+        f"{FORCE_REFRESH_SAME_DAY_ENV} must be one of: true/false, 1/0, yes/no, on/off"
+    )
+
+
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT mark the day as completed so that
+    the subsequent scheduled run always executes cleanly.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
+
+
+def format_daily_picks_footer_date(target_day_key: str) -> str:
+    target_day = datetime.fromisoformat(target_day_key).date()
+    return f"{target_day:%A, %B} {target_day.day}, {target_day:%Y}"
+
+
+def add_thumbs_up_reaction(client: DiscordClient, channel_id: str, message_id: str) -> None:
+    if not DISCORD_BOT_TOKEN:
+        raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
+    client.put_reaction(
+        channel_id,
+        message_id,
+        "%F0%9F%91%8D",
+        context=f"add thumbs-up reaction channel={channel_id} message={message_id}",
+    )
+
+
+def message_exists(client: DiscordClient, channel_id: str, message_id: str, context: str) -> bool:
+    try:
+        client.get_message(channel_id, message_id, context=context)
+        return True
+    except DiscordMessageNotFoundError:
+        return False
+    except Exception as error:
+        print(f"WARN: failed to verify existing message ({context}): {error}")
+        return False
+
+
+def record_posted_item(
+    daily_posts: Dict[str, dict],
+    day_key: str,
+    section: str,
+    title: str,
+    url: str,
+    source_type: str,
+    item_key: str,
+    message_id: str,
+    channel_id: Optional[str],
+    description: Optional[str] = None,
+) -> None:
+    try:
+        day_entry = daily_posts.setdefault(day_key, {"items": []})
+        items = day_entry.get("items")
+        if not isinstance(items, list):
+            day_entry["items"] = []
+            items = day_entry["items"]
+
+        item_record = {
+            "item_key": item_key,
+            "section": section,
+            "title": title,
+            "url": url,
+            "message_id": message_id,
+            "channel_id": channel_id,
+            "source_type": source_type,
+            "posted_at": utc_now_iso(),
+        }
+        if isinstance(description, str):
+            item_record["description"] = description
+        existing_index = next(
+            (index for index, existing in enumerate(items) if isinstance(existing, dict) and existing.get("item_key") == item_key),
+            None,
+        )
+        if existing_index is None:
+            items.append(item_record)
+        else:
+            items[existing_index] = item_record
+        save_discord_daily_posts(daily_posts)
+    except Exception as e:
+        print(f"RECORD DAILY DISCORD ITEM FAILED: title={title} | error={e}")
+
+
+def post_message_chunks(chunks: List[str]) -> None:
+    for chunk in chunks:
+        post_to_discord(chunk)
+        sleep_briefly()
+
+
+def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def build_daily_navigation_footer(
+    run_state: dict,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> Optional[str]:
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        print("WARN: DISCORD_GUILD_ID missing; skipping daily navigation footer.")
+        return None
+
+    intro_state = run_state.get("intro")
+    if not isinstance(intro_state, dict):
+        print("WARN: intro state missing; skipping daily navigation footer.")
+        return None
+
+    intro_channel_id = intro_state.get("channel_id")
+    intro_message_id = intro_state.get("message_id")
+    if not (isinstance(intro_channel_id, str) and isinstance(intro_message_id, str)):
+        print("WARN: intro message metadata missing; skipping daily navigation footer.")
+        return None
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Picks",
+        "free": "🎮 Free Picks",
+        "paid": "💸 Paid Picks",
+        "instagram": "📸 Creator Picks",
+    }
+    section_headers = run_state.get("section_headers", {})
+    lines = [
+        f"🗓️ Daily Picks for {format_daily_picks_footer_date(target_day_key)}",
+        "",
+        f"🎯 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
+    ]
+
+    for section_key in DAILY_SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            print(f"WARN: {section_key} header state missing; skipping daily navigation footer.")
+            return None
+        channel_id = section_state.get("channel_id")
+        message_id = section_state.get("message_id")
+        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
+            print(f"WARN: {section_key} header metadata missing; skipping daily navigation footer.")
+            return None
+        section_label = section_labels.get(section_key)
+        if not section_label:
+            continue
+        lines.append(f"{section_label} → [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
+
+    return "\n".join(lines)
+
+
+def build_daily_picks_navigation_content(
+    run_state: dict,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> Optional[str]:
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        return None
+
+    lines = [
+        f"📅 Daily Picks - {format_daily_picks_footer_date(target_day_key)}",
+        "Vote 👍 on any game you want to try. Every vote advances to Step 2.",
+    ]
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Picks",
+        "free": "🎮 Free Picks",
+        "paid": "💸 Paid Picks",
+        "instagram": "📸 Creator Picks",
+    }
+    section_headers = run_state.get("section_headers", {})
+
+    for section_key in DAILY_SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            continue
+        channel_id = section_state.get("channel_id")
+        message_id = section_state.get("message_id")
+        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
+            continue
+        section_label = section_labels.get(section_key)
+        if not section_label:
+            continue
+        lines.append(f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
+
+    return "\n".join(lines)
+
+
+def post_daily_pick_messages(
+    demo_playtest_items: List[dict],
+    free_items: List[dict],
+    paid_items: List[dict],
+    instagram_posts: List[dict],
+    *,
+    force_refresh_same_day: bool = False,
+    manual_run: bool = False,
+) -> Tuple[Dict[str, int], bool]:
+    """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active, verification_state).
+
+    When manual_run is True (workflow_dispatch trigger), the run completes normally
+    but does NOT mark the day as completed in state. This ensures the next scheduled
+    run always executes cleanly regardless of prior manual runs.
+    """
+    run_counts: Dict[str, int] = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
+    if not (demo_playtest_items or free_items or paid_items or instagram_posts):
+        return run_counts, False, {}
+
+    token_available = bool(DISCORD_BOT_TOKEN)
+    daily_posts = load_discord_daily_posts() if token_available else {}
+    day_key = get_target_day_key()
+    day_entry = daily_posts.setdefault(day_key, {})
+    if not isinstance(day_entry, dict):
+        day_entry = {}
+        daily_posts[day_key] = day_entry
+
+    if not token_available:
+        print("DISCORD_BOT_TOKEN missing; skipping auto-reactions and message-ID tracking.")
+    else:
+        print(f"Daily picks target day={day_key}")
+
+    run_state = day_entry.get("run_state")
+    if not isinstance(run_state, dict):
+        run_state = {}
+        day_entry["run_state"] = run_state
+    run_state.setdefault("section_headers", {})
+    run_state["last_attempt_at_utc"] = utc_now_iso()
+
+    if bool(run_state.get("completed")) and not force_refresh_same_day and not manual_run:
+        print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")
+        save_discord_daily_posts(daily_posts)
+        return run_counts, True, {}
+    if bool(run_state.get("completed")) and (force_refresh_same_day or manual_run):
+        label = "force_refresh_same_day=true" if force_refresh_same_day else "manual_run=true"
+        print(f"REFRESH: daily picks already completed for {day_key}; {label} so reconciling posts")
+
+    discord_client: Optional[DiscordClient] = None
+    if token_available:
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+                "Content-Type": "application/json",
+            }
+        )
+        discord_client = DiscordClient(session)
+
+    def post_or_reconcile_simple(message: str, state_key: str, state_obj: dict) -> None:
+        existing_message_id = state_obj.get("message_id")
+        existing_channel_id = state_obj.get("channel_id")
+        should_attempt_edit = bool(force_refresh_same_day) or bool(manual_run)
+        if (
+            token_available
+            and discord_client
+            and isinstance(existing_message_id, str)
+            and isinstance(existing_channel_id, str)
+        ):
+            if should_attempt_edit:
+                try:
+                    payload = discord_client.edit_message(
+                        existing_channel_id,
+                        existing_message_id,
+                        message,
+                        context=f"edit {state_key} for {day_key}",
+                    )
+                    state_obj["message_id"] = str(payload.get("id") or existing_message_id)
+                    state_obj["channel_id"] = str(payload.get("channel_id") or existing_channel_id)
+                    state_obj["posted_at_utc"] = utc_now_iso()
+                    print(f"REFRESH: updated {state_key} for {day_key} (message_id={state_obj['message_id']})")
+                    run_counts["updated"] += 1
+                    save_discord_daily_posts(daily_posts)
+                    return
+                except DiscordMessageNotFoundError:
+                    print(f"RECOVER: stale/deleted {state_key} for {day_key}; posting replacement")
+                except Exception as error:
+                    print(f"WARN: failed to edit {state_key} for {day_key}: {error}; falling back to create")
+            elif message_exists(
+                discord_client,
+                existing_channel_id,
+                existing_message_id,
+                context=f"verify {state_key} for {day_key}",
+            ):
+                print(f"REUSE: {state_key} for {day_key} (message_id={existing_message_id})")
+                run_counts["reused"] += 1
+                return
+
+        metadata = post_to_discord_with_metadata(message, capture_metadata=token_available)
+        if metadata and metadata.get("message_id"):
+            state_obj["message_id"] = metadata["message_id"]
+            state_obj["channel_id"] = metadata.get("channel_id")
+            state_obj["posted_at_utc"] = utc_now_iso()
+            print(f"CREATE: posted {state_key} for {day_key} (message_id={metadata['message_id']})")
+            run_counts["created"] += 1
+        else:
+            print(f"WARN: missing metadata for {state_key} on {day_key}")
+            run_counts["skipped"] += 1
+        save_discord_daily_posts(daily_posts)
+
+    header_state = run_state.setdefault("header", {})
+    placeholder_content = f"📅 Daily Picks - {format_daily_picks_footer_date(day_key)}\nVote 👍 on any game you want to try. Every vote advances to Step 2."
+    post_or_reconcile_simple(placeholder_content, "header", header_state)
+    sleep_briefly()
+
+    intro_state = run_state.setdefault("intro", {})
+    post_or_reconcile_simple("🎯 Daily Picks — vote with 👍 on your favorites", "intro", intro_state)
+    sleep_briefly()
+
+    section_items_by_key = {
+        "demo_playtest": demo_playtest_items,
+        "free": free_items,
+        "paid": paid_items,
+        "instagram": instagram_posts,
+    }
+    posted_section_keys = [section_key for section_key in DAILY_SECTION_ORDER if section_items_by_key.get(section_key)]
+    section_paid_flags = {"demo_playtest": False, "free": False, "paid": True, "instagram": False}
+
+    for section in DAILY_SECTION_CONFIG:
+        section_key = section["key"]
+        header_message = section["header"]
+        section_items = section_items_by_key.get(section_key, [])
+        is_paid = section_paid_flags.get(section_key, False)
+        source_type = section["source_type"]
+        if not section_items:
+            continue
+
+        section_headers = run_state.setdefault("section_headers", {})
+        section_state = section_headers.setdefault(section_key, {})
+        post_or_reconcile_simple(header_message, f"{section_key}_header", section_state)
+        sleep_briefly()
+
+        existing_items = day_entry.get("items")
+        if not isinstance(existing_items, list):
+            existing_items = []
+            day_entry["items"] = existing_items
+
+        for idx, item in enumerate(section_items, start=1):
+            title = item["title"] if section_key != "instagram" else f"@{item['username']}"
+            url = item["url"]
+            item_key = hashlib.sha256(f"{section_key}|{source_type}|{url}".encode("utf-8")).hexdigest()[:16]
+            existing_record = next(
+                (entry for entry in existing_items if isinstance(entry, dict) and entry.get("item_key") == item_key),
+                None,
+            )
+
+            content = (
+                format_instagram_item_message(item, idx)
+                if section_key == "instagram"
+                else format_steam_item_message(item, idx, paid=is_paid, demo_playtest=(section_key == "demo_playtest"))
+            )
+            metadata = None
+            is_new_message = False
+            if (
+                token_available
+                and discord_client
+                and isinstance(existing_record, dict)
+                and isinstance(existing_record.get("channel_id"), str)
+                and isinstance(existing_record.get("message_id"), str)
+            ):
+                existing_channel_id = str(existing_record["channel_id"])
+                existing_message_id = str(existing_record["message_id"])
+                if force_refresh_same_day or manual_run:
+                    try:
+                        payload = discord_client.edit_message(
+                            existing_channel_id,
+                            existing_message_id,
+                            content,
+                            context=f"edit {section_key} item {title} for {day_key}",
+                        )
+                        metadata = {
+                            "message_id": str(payload.get("id") or existing_message_id),
+                            "channel_id": str(payload.get("channel_id") or existing_channel_id),
+                        }
+                        print(f"REFRESH: updated {section_key} item {title} for {day_key}")
+                        run_counts["updated"] += 1
+                        # Update the existing record
+                        existing_record["description"] = item.get("caption") if section_key == "instagram" else item.get("description")
+                        existing_record["posted_at"] = utc_now_iso()
+                    except DiscordMessageNotFoundError:
+                        print(f"RECOVER: stale/deleted {section_key} item {title} for {day_key}; posting replacement")
+                    except Exception as error:
+                        print(
+                            f"WARN: failed to edit {section_key} item {title} for {day_key}: {error}; "
+                            "falling back to create"
+                        )
+                elif message_exists(
+                    discord_client,
+                    existing_channel_id,
+                    existing_message_id,
+                    context=f"verify {section_key} item for {day_key}",
+                ):
+                    metadata = {"message_id": existing_message_id, "channel_id": existing_channel_id}
+                    print(f"REUSE: {section_key} item {title} for {day_key}")
+                    run_counts["reused"] += 1
+                    # Update the existing record
+                    existing_record["description"] = item.get("caption") if section_key == "instagram" else item.get("description")
+                    existing_record["posted_at"] = utc_now_iso()
+
+            if metadata is None:
+                metadata = post_to_discord_with_metadata(content, capture_metadata=token_available)
+                is_new_message = True
+            if token_available and metadata and metadata.get("message_id") and metadata.get("channel_id"):
+                try:
+                    if discord_client and is_new_message:
+                        add_thumbs_up_reaction(discord_client, metadata["channel_id"], metadata["message_id"])
+                except Exception as e:
+                    print(f"ADD REACTION FAILED: title={title} | error={e}")
+                if is_new_message:
+                    record_posted_item(
+                        daily_posts=daily_posts,
+                        day_key=day_key,
+                        section=section_key,
+                        title=title,
+                        url=url,
+                        source_type=source_type,
+                        item_key=item_key,
+                        message_id=metadata["message_id"],
+                        channel_id=metadata["channel_id"],
+                        description=item.get("caption") if section_key == "instagram" else item.get("description"),
+                    )
+                    print(f"CREATE: posted {section_key} item {title} for {day_key}")
+                    run_counts["created"] += 1
+                else:
+                    print(f"REUSE: persisted existing {section_key} item {title} for {day_key}")
+            else:
+                print(f"WARN: missing metadata for {section_key} item title={title}")
+                run_counts["skipped"] += 1
+            sleep_briefly()
+
+    # Edit header with jump links now that sections are posted
+    if token_available and discord_client:
+        header_content = build_daily_picks_navigation_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
+        existing_message_id = header_state.get("message_id")
+        existing_channel_id = header_state.get("channel_id")
+        if existing_message_id and existing_channel_id:
+            try:
+                discord_client.edit_message(existing_channel_id, existing_message_id, header_content, context=f"edit header for {day_key}")
+                header_state["posted_at_utc"] = utc_now_iso()
+                print(f"EDIT: updated header for {day_key}")
+            except Exception as e:
+                print(f"WARN: failed to edit header for {day_key}: {e}")
+
+    footer_state = run_state.setdefault("footer", {})
+    footer_content = build_daily_picks_navigation_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
+    if footer_content:
+        post_or_reconcile_simple(footer_content, "footer", footer_state)
+        sleep_briefly()
+
+    if manual_run:
+        print(f"MANUAL RUN: daily picks done for {day_key}; skipping completed=True to preserve scheduled run eligibility")
+    else:
+        run_state["completed"] = True
+        run_state["completed_at_utc"] = utc_now_iso()
+        print(f"COMPLETE: daily picks state marked completed for {day_key}")
+    save_discord_daily_posts(daily_posts)
+    return run_counts, False, {
+        "run_state": run_state,
+        "items": day_entry.get("items") or [],
+        "posted_section_keys": posted_section_keys,
+    }
+
+
+def dedupe_by_app_id(items: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+    seen = set()
+    output = []
+    for source, app_id in items:
+        if app_id not in seen:
+            seen.add(app_id)
+            output.append((source, app_id))
+    return output
+
+
+def _normalize_instagram_game_key_fragment(text: str) -> str:
+    normalized = text.lower()
+    normalized = re.sub(r"#\w+", " ", normalized)
+    for pattern in INSTAGRAM_GAME_KEY_BOILERPLATE_PATTERNS:
+        normalized = re.sub(pattern, " ", normalized)
+    normalized = re.sub(r"[^a-z0-9\s]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def _is_low_confidence_instagram_title_candidate(key: str) -> bool:
+    tokens = key.split()
+    if len(tokens) > 6:
+        return True
+    return any(token in INSTAGRAM_GAME_KEY_GENERIC_PREFIX_TOKENS for token in tokens)
+
+
+def derive_instagram_game_key(caption: str) -> Optional[str]:
+    if not caption:
+        return None
+
+    raw_caption = caption.strip()
+    if not raw_caption or raw_caption == "(no caption)":
+        return None
+
+    quoted_or_bracketed_patterns = [
+        r"[\"“”]([^\"“”]{2,80})[\"“”]",
+        r"\[([^\[\]]{2,80})\]",
+        r"\(([^\(\)]{2,80})\)",
+    ]
+    for pattern in quoted_or_bracketed_patterns:
+        match = re.search(pattern, raw_caption)
+        if match:
+            key = _normalize_instagram_game_key_fragment(match.group(1))
+            if key:
+                return key
+
+    separator_match = re.search(r"\s[-|:]\s", raw_caption)
+    if separator_match:
+        candidate = raw_caption[:separator_match.start()].strip()
+        key = _normalize_instagram_game_key_fragment(candidate)
+        if key and len(key) >= 3 and re.search(r"[a-z]", key):
+            return key
+
+    boundary_start = None
+    for pattern in INSTAGRAM_GAME_KEY_FALLBACK_BOUNDARY_PATTERNS:
+        match = re.search(pattern, raw_caption, flags=re.IGNORECASE)
+        if not match:
+            continue
+        if boundary_start is None or match.start() < boundary_start:
+            boundary_start = match.start()
+
+    if boundary_start is not None:
+        candidate = raw_caption[:boundary_start].strip(" -|:–—•")
+        key = _normalize_instagram_game_key_fragment(candidate)
+        if key and len(key) >= 3 and re.search(r"[a-z]", key):
+            if not _is_low_confidence_instagram_title_candidate(key):
+                return key
+
+    return None
+
+
+def dedupe_instagram_posts(posts: List[dict]) -> List[dict]:
+    deduped_posts, _ = _dedupe_instagram_posts_with_debug(posts)
+    return deduped_posts
+
+
+def _dedupe_instagram_posts_with_debug(posts: List[dict]) -> Tuple[List[dict], Dict[str, object]]:
+    game_posts: Dict[str, dict] = {}
+    no_key_posts: List[dict] = []
+    removed_keys: List[str] = []
+
+    for post in posts:
+        key = derive_instagram_game_key(post.get("caption", ""))
+        if key is None:
+            no_key_posts.append(post)
+            continue
+
+        if key not in game_posts:
+            game_posts[key] = {
+                "usernames": [post["username"]],
+                "caption": post["caption"],
+                "url": post["url"],  # Keep the first URL
+            }
+        else:
+            # Merge usernames
+            if post["username"] not in game_posts[key]["usernames"]:
+                game_posts[key]["usernames"].append(post["username"])
+            if len(removed_keys) < 3:
+                removed_keys.append(key)
+
+    deduped_posts = []
+    for key, data in game_posts.items():
+        deduped_posts.append({
+            "username": ", ".join(sorted(data["usernames"])),  # Combine usernames
+            "caption": data["caption"],
+            "url": data["url"],
+        })
+
+    # Add posts without keys as-is
+    deduped_posts.extend(no_key_posts)
+
+    debug: Dict[str, object] = {
+        "fetched_count": len(posts),
+        "deduped_count": len(deduped_posts),
+        "removed_count": len(posts) - len(deduped_posts),
+    }
+    return deduped_posts, debug
+
+
+def prune_instagram_seen_state(data: object) -> Dict[str, List[str]]:
+    if not isinstance(data, dict):
+        return {}
+    cleaned: Dict[str, List[str]] = {}
+    for username, shortcodes in data.items():
+        if not isinstance(username, str) or not isinstance(shortcodes, list):
+            continue
+        valid_shortcodes = [code for code in shortcodes if isinstance(code, str) and code]
+        cleaned[username] = valid_shortcodes[-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
+    return cleaned
+
+def load_instagram_seen():
+    if not os.path.exists(INSTAGRAM_STATE_FILE):
+        return {}
+
+    try:
+        with open(INSTAGRAM_STATE_FILE, "r", encoding="utf-8") as f:
+            return prune_instagram_seen_state(json.load(f))
+    except Exception:
+        return {}
+
+
+def save_instagram_seen(data):
+    with open(INSTAGRAM_STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(prune_instagram_seen_state(data), f, indent=2)
+
+
+def fetch_instagram_posts():
+    if instaloader is None:
+        return []
+
+    seen = load_instagram_seen()
+    all_new_posts = []
+
+    loader = instaloader.Instaloader(
+        download_pictures=False,
+        download_videos=False,
+        download_video_thumbnails=False,
+        download_geotags=False,
+        download_comments=False,
+        save_metadata=False,
+        quiet=True,
+    )
+    instagram_username = os.getenv("INSTAGRAM_USERNAME")
+    session_file = "instaloader.session"
+
+    if not instagram_username:
+        print("INSTAGRAM_USERNAME missing; skipping Instagram")
+        return []
+
+    if not os.path.exists(session_file):
+        print("instaloader.session missing; skipping Instagram")
+        return []
+
+    try:
+        loader.load_session_from_file(instagram_username, session_file)
+        print(f"Loaded Instagram session for {instagram_username}")
+    except Exception as e:
+        print(f"Instagram session load failed: {e}")
+        _notify_health_monitor(
+            f"⚠️ Instagram session load failed for {instagram_username}: {e}\n"
+            f"Instagram session may have expired — re-authenticate and update INSTAGRAM_SESSION secret."
+        )
+        return []
+
+    # Session health check — verify the loaded session is still authenticated.
+    try:
+        session_username = loader.context.username
+        if not session_username:
+            print("WARN: Instagram session health check failed — context.username is empty; session may have expired")
+            _notify_health_monitor(
+                f"⚠️ Instagram session may have expired for {instagram_username}.\n"
+                f"context.username is empty after loading session. "
+                f"Re-authenticate and update the INSTAGRAM_SESSION secret."
+            )
+        else:
+            print(f"Instagram session health check OK: logged in as @{session_username}")
+    except Exception as e:
+        print(f"WARN: Instagram session health check raised an exception: {e}")
+
+    cutoff_utc = datetime.now(timezone.utc) - timedelta(days=INSTAGRAM_MAX_POST_AGE_DAYS)
+
+    for username in INSTAGRAM_CREATORS:
+        try:
+            if username not in seen:
+                seen[username] = []
+
+            profile = instaloader.Profile.from_username(loader.context, username)
+            count = 0
+            skipped_age = 0
+            skipped_seen = 0
+
+            for post in profile.get_posts():
+                # Posts are returned newest-first; stop as soon as we pass the age cutoff.
+                post_date = post.date_utc.replace(tzinfo=timezone.utc)
+                if post_date < cutoff_utc:
+                    age_days = (datetime.now(timezone.utc) - post_date).days
+                    print(
+                        f"INSTAGRAM AGE FILTER: @{username} post {post.shortcode} "
+                        f"date={post_date.date().isoformat()} age={age_days}d "
+                        f"(cutoff={INSTAGRAM_MAX_POST_AGE_DAYS}d); stopping iteration"
+                    )
+                    skipped_age += 1
+                    break
+
+                shortcode = post.shortcode
+
+                if shortcode in seen[username]:
+                    print(f"INSTAGRAM SEEN: @{username} post {shortcode} already seen; skipping")
+                    skipped_seen += 1
+                    continue
+
+                caption = (post.caption or "").replace("\n", " ").strip()
+                if len(caption) > 120:
+                    caption = caption[:117] + "..."
+
+                all_new_posts.append({
+                    "username": username,
+                    "caption": caption or "(no caption)",
+                    "url": f"https://www.instagram.com/p/{shortcode}/",
+                })
+
+                seen[username].append(shortcode)
+                count += 1
+
+                if count >= MAX_INSTAGRAM_POSTS_PER_ACCOUNT:
+                    break
+
+            seen[username] = seen[username][-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
+
+            if count == 0:
+                print(
+                    f"INSTAGRAM ZERO POSTS: @{username} returned 0 new posts "
+                    f"(skipped_seen={skipped_seen}, skipped_age={skipped_age})"
+                )
+            else:
+                print(f"INSTAGRAM: @{username} collected {count} new post(s) (skipped_seen={skipped_seen}, skipped_age={skipped_age})")
+
+        except Exception as e:
+            print(f"Instagram scrape failed for {username}: {e}")
+            continue
+
+    save_instagram_seen(seen)
+    print(f"Instagram posts found this run: {len(all_new_posts)}")
+    return all_new_posts
+    
+def load_daily_verification_artifact(path: str = DAILY_VERIFICATION_FILE) -> dict:
+    return load_json_object(path, default={})
+
+
+def verification_passed_for_day(day_key: str, artifact: dict) -> bool:
+    if not isinstance(artifact, dict):
+        return False
+    return artifact.get("day_key") == day_key and bool(artifact.get("pass"))
+
+
+def export_stop_go_result(
+    *,
+    day_key: str,
+    decision: str,
+    reason: str,
+    attempt: Optional[int] = None,
+    max_attempts: int = MAX_RETRY_ATTEMPTS,
+    verification_file: str = DAILY_VERIFICATION_FILE,
+    path: Optional[str] = None,
+) -> None:
+    """Write a machine-readable stop/go decision artifact for external orchestration."""
+    signal = decision
+    escalation_target = None
+    if decision == "give_up":
+        signal = "escalate_to_fixer"
+        escalation_target = "claude_code"
+
+    result = {
+        "day_key": day_key,
+        "decision": decision,
+        "signal": signal,
+        "reason": reason,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "verification_file": verification_file,
+        "orchestrator": "openhands",
+        "fixer": "claude_code",
+        "escalation_target": escalation_target,
+        "generated_at_utc": utc_now_iso(),
+    }
+    result_path = path or STOP_GO_RESULT_FILE
+    save_json_object_atomic(result_path, result)
+    print(
+        "STOP_GO_RESULT "
+        f"file={result_path} day_key={day_key} decision={decision} signal={signal} "
+        f"attempt={attempt if attempt is not None else 'na'}/{max_attempts} "
+        f"reason={reason}"
+    )
+
+
+def run_daily_workflow(*, force_refresh_same_day: bool = False, manual_run: bool = False) -> None:
+    state = load_state()
+    print(f"Daily run target date (UTC): {get_target_day_key()}")
+
+    start_page, end_page = get_page_window()
+    print(f"Current rotating page window: {start_page}-{end_page}")
+
+    free_candidates = (
+        collect_steam_free_candidates(start_page, end_page) +
+        collect_steam_demo_candidates(start_page, end_page) +
+        collect_steamdb_promo_candidates()
+    )
+    free_candidates = dedupe_by_app_id(free_candidates)
+
+    paid_candidates = collect_paid_candidates(start_page, end_page)
+    paid_candidates = dedupe_by_app_id(paid_candidates)
+
+    print(f"Free candidates collected: {len(free_candidates)}")
+    print(f"Paid candidates collected: {len(paid_candidates)}")
+    steam_candidates_scanned = len(free_candidates) + len(paid_candidates)
+
+    qualified_demo_playtest = []
+    qualified_free = []
+    qualified_paid = []
+    filtered_weak_reviews = 0
+    filtered_weak_group_fit = 0
+    filtered_low_signal_junk = 0
+    filtered_repost_cooldown = 0
+    debug_records: List[DebugRecord] = []
+
+    for source, app_id in free_candidates:
+        item = inspect_game(source, app_id)
+        sleep_briefly()
+
+        if not item:
+            continue
+        log_candidate_decision(item, phase="evaluated")
+        record: DebugRecord = {
+            "title": item["title"],
+            "type": item["type"],
+            "final_score": item["score"],
+            "review_sentiment": item.get("review_sentiment"),
+            "friend_group_signal": item.get("demo_friend_signal_score", 0),
+            "keep": bool(item["keep"]),
+            "reason_list": [],
+        }
+        if not item["keep"]:
+            reason_list = build_filter_reason_list(item)
+            if FILTER_REASON_WEAK_REVIEW in reason_list:
+                filtered_weak_reviews += 1
+            if FILTER_REASON_WEAK_GROUP_FIT in reason_list:
+                filtered_weak_group_fit += 1
+            if FILTER_REASON_LOW_SIGNAL_JUNK in reason_list:
+                filtered_low_signal_junk += 1
+            record["reason_list"] = reason_list
+            log_candidate_decision(item, phase="filtered_not_kept")
+            debug_records.append(record)
+            continue
+        if not can_repost(app_id, item["type"], state):
+            filtered_repost_cooldown += 1
+            record["reason_list"] = [FILTER_REASON_REPOST_COOLDOWN]
+            log_candidate_decision(item, phase="filtered_repost_cooldown")
+            debug_records.append(record)
+            continue
+
+        record["reason_list"] = [FILTER_REASON_QUALIFIED]
+        debug_records.append(record)
+        section_key = route_item_to_daily_section(item["type"])
+        if section_key == "demo_playtest":
+            qualified_demo_playtest.append(item)
+        elif section_key == "free":
+            qualified_free.append(item)
+
+    for source, app_id in paid_candidates:
+        item = inspect_game(source, app_id)
+        sleep_briefly()
+
+        if not item:
+            continue
+        log_candidate_decision(item, phase="evaluated")
+        record: DebugRecord = {
+            "title": item["title"],
+            "type": item["type"],
+            "final_score": item["score"],
+            "review_sentiment": item.get("review_sentiment"),
+            "friend_group_signal": item.get("demo_friend_signal_score", 0),
+            "keep": bool(item["keep"]),
+            "reason_list": [],
+        }
+        if item["type"] != "paid_under_20":
+            record["reason_list"] = [FILTER_REASON_BELOW_THRESHOLD]
+            debug_records.append(record)
+            continue
+        if not item["keep"]:
+            reason_list = build_filter_reason_list(item)
+            if FILTER_REASON_WEAK_REVIEW in reason_list:
+                filtered_weak_reviews += 1
+            if FILTER_REASON_WEAK_GROUP_FIT in reason_list:
+                filtered_weak_group_fit += 1
+            if FILTER_REASON_LOW_SIGNAL_JUNK in reason_list:
+                filtered_low_signal_junk += 1
+            record["reason_list"] = reason_list
+            log_candidate_decision(item, phase="filtered_not_kept")
+            debug_records.append(record)
+            continue
+        if not can_repost(app_id, item["type"], state):
+            filtered_repost_cooldown += 1
+            record["reason_list"] = [FILTER_REASON_REPOST_COOLDOWN]
+            log_candidate_decision(item, phase="filtered_repost_cooldown")
+            debug_records.append(record)
+            continue
+
+        record["reason_list"] = [FILTER_REASON_QUALIFIED]
+        debug_records.append(record)
+        if route_item_to_daily_section(item["type"]) == "paid":
+            qualified_paid.append(item)
+
+    qualified_free.sort(
+        key=lambda x: (
+            x["score"],
+            x.get("review_score", 0),
+            1 if x["type"] == "temporarily_free" else 0,
+        ),
+        reverse=True
+    )
+
+    qualified_demo_playtest.sort(
+        key=lambda x: (
+            x["score"],
+            x.get("demo_friend_signal_score", 0),
+            x.get("demo_freshness_bonus", 0),
+            x.get("review_score", 0),
+        ),
+        reverse=True
+    )
+
+    qualified_paid.sort(
+        key=lambda x: (
+            x["score"],
+            x.get("review_score", 0),
+        ),
+        reverse=True
+    )
+
+    qualified_demo_playtest = apply_light_diversity_rerank(qualified_demo_playtest)
+    qualified_free = apply_light_diversity_rerank(qualified_free)
+    qualified_paid = apply_light_diversity_rerank(qualified_paid)
+
+    demo_playtest_items = select_demo_playtest_items(qualified_demo_playtest, MAX_DEMO_PLAYTEST_POSTS)
+    free_items = qualified_free[:MAX_FREE_POSTS]
+    paid_items = qualified_paid[:MAX_PAID_POSTS]
+
+    print(f"Qualified demo/playtest items before cap: {len(qualified_demo_playtest)}")
+    print(f"Qualified free items before cap: {len(qualified_free)}")
+    print(f"Qualified paid items before cap: {len(qualified_paid)}")
+    print(
+        f"Demo/playtest quality floor for final section: score>={DEMO_PLAYTEST_QUALITY_FLOOR_SCORE} "
+        f"(cap={MAX_DEMO_PLAYTEST_POSTS})"
+    )
+
+    fetched_instagram_posts = fetch_instagram_posts()
+    instagram_posts, instagram_debug = _dedupe_instagram_posts_with_debug(fetched_instagram_posts)
+    print(
+        "Instagram dedupe: "
+        f"fetched={instagram_debug['fetched_count']} "
+        f"kept={instagram_debug['deduped_count']} "
+        f"removed={instagram_debug['removed_count']}"
+    )
+    force_refresh_same_day = force_refresh_same_day or get_force_refresh_same_day()
+    if force_refresh_same_day:
+        print("Daily picks run configured with FORCE_REFRESH_SAME_DAY=true")
+    manual_run = manual_run or is_manual_run()
+    if manual_run:
+        print("Daily picks run is a manual (workflow_dispatch) run — completed flag will not be set")
+    run_counts, rerun_protection_active, verification_state = post_daily_pick_messages(
+        demo_playtest_items,
+        free_items,
+        paid_items,
+        instagram_posts,
+        force_refresh_same_day=force_refresh_same_day,
+        manual_run=manual_run,
+    )
+
+    if not demo_playtest_items and not free_items and not paid_items:
+        print("No qualifying games found from Steam.")
+
+    for item in demo_playtest_items + free_items + paid_items:
+        update_state_for_post(item["id"], item["type"], state)
+
+    save_state(state)
+
+    total = len(demo_playtest_items) + len(free_items) + len(paid_items)
+    print(f"Posted {total} Steam item(s) to Discord.")
+    print(f"Demo/playtest items selected: {len(demo_playtest_items)}")
+    print(f"Free items selected: {len(free_items)}")
+    print(f"Paid items selected: {len(paid_items)}")
+
+    for item in demo_playtest_items:
+        log_candidate_decision(item, phase="selected")
+        print(
+            f"DEMO/PLAYTEST: {item['title']} ({item['type']}) "
+            f"score={item['score']} friend_signal={item.get('demo_friend_signal_score', 0)} "
+            f"freshness_bonus={item.get('demo_freshness_bonus', 0)} "
+            f"diversity_penalty={item.get('diversity_penalty', 0)}"
+        )
+
+    for item in free_items:
+        print(
+            f"FREE: {item['title']} ({item['type']}) "
+            f"score={item['score']} review_score={item.get('review_score', 0)}"
+        )
+
+    for item in paid_items:
+        print(
+            f"PAID: {item['title']} ({item['type']}) "
+            f"score={item['score']} review_score={item.get('review_score', 0)}"
+        )
+
+    reason_counts: Dict[str, int] = {}
+    for record in debug_records:
+        for reason in record["reason_list"]:
+            if reason == FILTER_REASON_QUALIFIED:
+                continue
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    top_filter_reasons = sorted(reason_counts.items(), key=lambda kv: kv[1], reverse=True)[:3]
+    selected_title_samples = {
+        "demo_playtest": [item["title"] for item in demo_playtest_items[:3]],
+        "free": [item["title"] for item in free_items[:3]],
+        "paid": [item["title"] for item in paid_items[:3]],
+    }
+
+    run_summary_lines = build_run_summary(
+        steam_candidates_scanned=steam_candidates_scanned,
+        demo_playtest_candidates_qualified=len(qualified_demo_playtest),
+        free_candidates_qualified=len(qualified_free),
+        paid_candidates_qualified=len(qualified_paid),
+        demo_playtest_posted=len(demo_playtest_items),
+        free_posted=len(free_items),
+        paid_posted=len(paid_items),
+        filtered_weak_reviews=filtered_weak_reviews,
+        filtered_weak_group_fit=filtered_weak_group_fit,
+        filtered_low_signal_junk=filtered_low_signal_junk,
+        filtered_repost_cooldown=filtered_repost_cooldown,
+        top_filter_reasons=top_filter_reasons,
+        selected_title_samples=selected_title_samples,
+    )
+    for line in run_summary_lines:
+        print(line)
+    export_daily_debug_summary(
+        debug_records,
+        run_summary_lines,
+        target_day_key=get_target_day_key(),
+        instagram_debug=instagram_debug,
+    )
+    post_discord_debug_summary(
+        day_key=get_target_day_key(),
+        run_counts=run_counts,
+        rerun_protection_active=rerun_protection_active,
+        force_refresh_same_day=force_refresh_same_day,
+    )
+    export_verification_artifact(
+        day_key=get_target_day_key(),
+        run_counts=run_counts,
+        rerun_protection_active=rerun_protection_active,
+        verification_state=verification_state,
+    )
+
+    next_start_page = get_next_start_page(start_page)
+    save_page_state(next_start_page)
+    next_end_page = min(next_start_page + PAGE_WINDOW_SIZE - 1, MAX_PAGE_LIMIT)
+    print(f"Next rotating page window saved: {next_start_page}-{next_end_page}")
+
+
+def main():
+    day_key = get_target_day_key()
+    artifact = load_daily_verification_artifact()
+    if verification_passed_for_day(day_key, artifact):
+        export_stop_go_result(
+            day_key=day_key,
+            decision="stop",
+            reason="verification_pass",
+            attempt=0,
+        )
+        print(
+            "STOP_GO decision=stop "
+            f"reason=verification_pass day_key={day_key} verification_file={DAILY_VERIFICATION_FILE}"
+        )
+        return
+
+    for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
+        if attempt > 1:
+            export_stop_go_result(
+                day_key=day_key,
+                decision="retry",
+                reason="verification_failed",
+                attempt=attempt,
+            )
+            print(
+                "STOP_GO decision=retry "
+                f"reason=verification_failed attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
+            )
+        run_daily_workflow(force_refresh_same_day=(attempt > 1))
+        artifact = load_daily_verification_artifact()
+        if verification_passed_for_day(day_key, artifact):
+            export_stop_go_result(
+                day_key=day_key,
+                decision="stop",
+                reason="verification_pass",
+                attempt=attempt,
+            )
+            print(
+                "STOP_GO decision=stop "
+                f"reason=verification_pass attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
+            )
+            return
+
+    export_stop_go_result(
+        day_key=day_key,
+        decision="give_up",
+        reason="max_retry_attempts_reached",
+        attempt=MAX_RETRY_ATTEMPTS,
+    )
+    print(
+        "STOP_GO decision=give_up "
+        f"reason=max_retry_attempts_reached attempts={MAX_RETRY_ATTEMPTS}/{MAX_RETRY_ATTEMPTS}"
+    )
+
+if __name__ == "__main__":
+    main()
+
+===== evening_winners.py =====
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+
+from daily_section_config import DAILY_SECTION_DISPLAY_LABELS, DAILY_SECTION_ORDER
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import load_json_object, save_json_object_atomic
+
+DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
+THUMBS_UP_EMOJI = "👍"
+THUMBS_UP_EMOJI_ENCODED = quote(THUMBS_UP_EMOJI, safe="")
+BOOKMARK_EMOJI = "🔖"
+BOOKMARK_EMOJI_ENCODED = quote(BOOKMARK_EMOJI, safe="")
+
+DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_WINNERS_CHANNEL_ID = os.getenv("DISCORD_WINNERS_CHANNEL_ID")
+DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+WINNERS_DATE_OVERRIDE_ENV = "WINNERS_DATE_UTC"
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
+WINNERS_LOOKBACK_DAYS = 10
+MAX_VOTERS_SHOWN_PER_GAME = 6
+DISCORD_MESSAGE_CHAR_LIMIT = 2000
+WINNERS_MESSAGE_TARGET_MAX = 1900
+
+# Winners intentionally mirror daily section ordering as product behavior,
+# not an incidental implementation detail.
+SECTION_CONFIG = DAILY_SECTION_DISPLAY_LABELS
+SECTION_ORDER = DAILY_SECTION_ORDER
+
+
+def load_discord_daily_posts() -> Dict[str, dict]:
+    return load_json_object(DISCORD_DAILY_POSTS_FILE, log=print)
+
+
+def save_discord_daily_posts(data: Dict[str, dict]) -> None:
+    save_json_object_atomic(DISCORD_DAILY_POSTS_FILE, data)
+
+
+def get_target_day_key() -> str:
+    manual_day = (os.getenv(WINNERS_DATE_OVERRIDE_ENV, "") or "").strip()
+    if not manual_day:
+        return datetime.now(timezone.utc).date().isoformat()
+    datetime.fromisoformat(manual_day)
+    return manual_day
+
+
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT block subsequent scheduled runs —
+    they always re-post fresh content even when winners are unchanged.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
+
+
+def get_thumbsup_count(message_payload: dict) -> int:
+    for reaction in message_payload.get("reactions", []):
+        emoji = reaction.get("emoji", {})
+        if emoji.get("name") == THUMBS_UP_EMOJI:
+            return int(reaction.get("count", 0))
+    return 0
+
+
+def get_lookback_day_keys(target_day_key: str, lookback_days: int = WINNERS_LOOKBACK_DAYS) -> List[str]:
+    target_date = datetime.fromisoformat(target_day_key).date()
+    return [
+        (target_date - timedelta(days=offset)).isoformat()
+        for offset in range(lookback_days)
+    ]
+
+
+def format_winners_footer_date(target_day_key: str) -> str:
+    target_day = datetime.fromisoformat(target_day_key).date()
+    return f"{target_day:%A, %B} {target_day.day}, {target_day:%Y}"
+
+
+def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def build_winners_header_placeholder(target_day_key: str) -> str:
+    date_str = format_winners_footer_date(target_day_key)
+    return "\n".join(
+        [
+            f"🏆 Daily Winners - {date_str}",
+            "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
+        ]
+    )
+
+
+def build_winners_navigation_header(
+    winners_state: dict,
+    *,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> str:
+    date_str = format_winners_footer_date(target_day_key)
+    lines = [
+        f"🏆 Daily Winners - {date_str}",
+        "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
+    ]
+
+    if not isinstance(guild_id, str) or not guild_id.strip() or not posted_section_keys:
+        return "\n".join(lines)
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Winners",
+        "free": "🎮 Free Winners",
+        "paid": "💸 Paid Winners",
+        "instagram": "📸 Creator Winners",
+    }
+    section_headers = winners_state.get("section_headers", {})
+    jump_lines = []
+    for section_key in SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            continue
+        channel_id = str(section_state.get("channel_id") or "").strip()
+        message_id = str(section_state.get("message_id") or "").strip()
+        if not channel_id or not message_id:
+            continue
+        section_label = section_labels.get(section_key)
+        if section_label:
+            jump_lines.append(
+                f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})"
+            )
+
+    if jump_lines:
+        lines.append("")
+        lines.extend(jump_lines)
+
+    return "\n".join(lines)
+
+
+def build_winners_section_header(section: str) -> str:
+    header_map = {
+        "demo_playtest": "🧪 Demo & Playtest Winners",
+        "free": "🎮 Free Winners",
+        "paid": "💸 Paid Winners",
+        "instagram": "📸 Creator Winners",
+    }
+    return header_map.get(section, SECTION_CONFIG.get(section, section))
+
+
+def build_winner_game_message(item: dict, *, section: str) -> str:
+    lines = [item["title"]]
+    description = resolve_winner_description_for_message(item, section=section)
+    if description:
+        lines.append(description)
+    lines.append(item["url"])
+    vote_word = "vote" if item["human_votes"] == 1 else "votes"
+    lines.append(f"👍 {item['human_votes']} {vote_word}")
+    lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
+    return "\n".join(lines)
+
+
+def build_winners_navigation_footer(
+    winners_state: dict,
+    *,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> Optional[str]:
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        print("WARN: DISCORD_GUILD_ID missing; skipping winners navigation footer.")
+        return None
+    intro_state = winners_state.get("intro")
+    if not isinstance(intro_state, dict):
+        return None
+    intro_channel_id = str(intro_state.get("channel_id") or "").strip()
+    intro_message_id = str(intro_state.get("message_id") or "").strip()
+    if not intro_channel_id or not intro_message_id:
+        return None
+
+    section_labels = {
+        "demo_playtest": "🧪 Demo & Playtest Winners",
+        "free": "🎮 Free Winners",
+        "paid": "💸 Paid Winners",
+        "instagram": "📸 Creator Winners",
+    }
+    section_headers = winners_state.get("section_headers", {})
+    date_str = format_winners_footer_date(target_day_key)
+    lines = [
+        f"🏆 Daily Winners - {date_str}",
+        "",
+        f"🏆 Top of Post ⟹ [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
+    ]
+    for section_key in SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            return None
+        channel_id = str(section_state.get("channel_id") or "").strip()
+        message_id = str(section_state.get("message_id") or "").strip()
+        if not channel_id or not message_id:
+            return None
+        section_label = section_labels.get(section_key)
+        if section_label:
+            lines.append(f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
+    return "\n".join(lines)
+
+
+def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
+    lines = ["🏆 Daily Game Picks — Winners", ""]
+    has_any_winners = False
+
+    for section in SECTION_ORDER:
+        items = winners_by_section.get(section, [])
+        if not items:
+            continue
+
+        has_any_winners = True
+        lines.append(SECTION_CONFIG[section])
+        for item in items:
+            lines.append(item["title"])
+            description = resolve_winner_description_for_message(item, section=section)
+            if description:
+                lines.append(description)
+            lines.append(item["url"])
+            vote_word = "vote" if item["human_votes"] == 1 else "votes"
+            lines.append(f"👍 {item['human_votes']} {vote_word}")
+            lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
+            lines.append("")
+
+    if not has_any_winners:
+        lines.append("_No votes yet today._")
+
+    return "\n".join(lines).strip()
+
+
+def _build_winner_item_lines(item: dict, *, section: str) -> List[str]:
+    lines = [item["title"]]
+    description = resolve_winner_description_for_message(item, section=section)
+    if description:
+        lines.append(description)
+    lines.append(item["url"])
+    vote_word = "vote" if item["human_votes"] == 1 else "votes"
+    lines.append(f"👍 {item['human_votes']} {vote_word}")
+    lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
+    lines.append("")
+    return lines
+
+
+def build_winners_message_chunks(
+    winners_by_section: Dict[str, List[dict]],
+    *,
+    target_max: int = WINNERS_MESSAGE_TARGET_MAX,
+    hard_limit: int = DISCORD_MESSAGE_CHAR_LIMIT,
+) -> List[str]:
+    full_message = build_winners_message(winners_by_section)
+    if len(full_message) <= hard_limit:
+        return [full_message]
+
+    header = "🏆 Daily Game Picks — Winners"
+    chunks: List[str] = []
+    current_lines: List[str] = [header, ""]
+    has_any_winners = any(isinstance(winners_by_section.get(section), list) and winners_by_section.get(section) for section in SECTION_ORDER)
+
+    def finalize_current_chunk() -> None:
+        if current_lines:
+            rendered = "\n".join(current_lines).strip()
+            if rendered:
+                chunks.append(rendered)
+
+    def can_fit(lines: List[str], extra_lines: List[str]) -> bool:
+        rendered = "\n".join(lines + extra_lines).strip()
+        return len(rendered) <= target_max
+
+    if not has_any_winners:
+        return [full_message]
+
+    for section in SECTION_ORDER:
+        items = winners_by_section.get(section, [])
+        if not items:
+            continue
+
+        section_header_lines = [SECTION_CONFIG[section]]
+        section_full_lines = section_header_lines[:]
+        for item in items:
+            section_full_lines.extend(_build_winner_item_lines(item, section=section))
+
+        if can_fit(current_lines, section_full_lines):
+            current_lines.extend(section_full_lines)
+            continue
+
+        if len("\n".join(current_lines).strip()) > len(header):
+            finalize_current_chunk()
+            current_lines = []
+
+        current_lines.extend(section_header_lines)
+        for item in items:
+            item_lines = _build_winner_item_lines(item, section=section)
+            if not can_fit(current_lines, item_lines):
+                finalize_current_chunk()
+                current_lines = [SECTION_CONFIG[section]]
+            current_lines.extend(item_lines)
+
+    finalize_current_chunk()
+    for chunk in chunks:
+        if len(chunk) > hard_limit:
+            raise RuntimeError("Winners chunk exceeded Discord character limit")
+    return chunks
+
+
+def build_winners_message_compact(winners_by_section: Dict[str, List[dict]]) -> str:
+    lines = ["🏆 Daily Game Picks — Winners", ""]
+    has_any_winners = False
+
+    for section in SECTION_ORDER:
+        items = winners_by_section.get(section, [])
+        if not items:
+            continue
+
+        has_any_winners = True
+        lines.append(SECTION_CONFIG[section])
+        for item in items:
+            vote_word = "vote" if item["human_votes"] == 1 else "votes"
+            lines.append(f"- {item['title']} ({item['human_votes']} {vote_word})")
+            lines.append(f"  {item['url']}")
+        lines.append("")
+
+    if not has_any_winners:
+        lines.append("_No votes yet today._")
+
+    return "\n".join(lines).strip()
+
+
+def normalize_winner_description_for_message(
+    description: Optional[str], max_length: int = 110
+) -> str:
+    if not isinstance(description, str):
+        return ""
+    cleaned = " ".join(description.split()).strip()
+    if not cleaned:
+        return ""
+    if len(cleaned) <= max_length:
+        return cleaned
+    return f"{cleaned[:max_length - 3].rstrip()}..."
+
+
+def build_instagram_legacy_description_fallback(item: dict) -> str:
+    title = str(item.get("title") or "").strip()
+    if title and not re.fullmatch(r"@[A-Za-z0-9._]+", title):
+        return title
+
+    creator = title if title else str(item.get("username") or "").strip()
+    url = str(item.get("url") or "").strip()
+    shortcode_match = re.search(r"instagram\.com/p/([^/?#]+)/?", url)
+    shortcode = shortcode_match.group(1) if shortcode_match else ""
+    if creator:
+        if shortcode:
+            return f"Instagram post from {creator} · post {shortcode} (caption unavailable in legacy state)"
+        return f"Instagram post from {creator} (caption unavailable in legacy state)"
+    return ""
+
+
+def resolve_winner_description_for_message(item: dict, *, section: Optional[str] = None) -> str:
+    normalized_description = normalize_winner_description_for_message(item.get("description"))
+    if normalized_description:
+        return normalized_description
+
+    resolved_section = section or str(item.get("section") or "").strip()
+    if resolved_section != "instagram":
+        return ""
+
+    fallback = build_instagram_legacy_description_fallback(item)
+    return normalize_winner_description_for_message(fallback)
+
+
+def resolve_display_name(user: dict) -> str:
+    if not isinstance(user, dict):
+        return "Unknown User"
+    global_name = (user.get("global_name") or "").strip()
+    if global_name:
+        return global_name
+    username = (user.get("username") or "").strip()
+    if username:
+        return username
+    user_id = str(user.get("id") or "").strip()
+    if user_id:
+        return f"User {user_id}"
+    return "Unknown User"
+
+
+def format_voter_names_for_message(names: List[str]) -> str:
+    if not names:
+        return "Unknown voters"
+    visible = names[:MAX_VOTERS_SHOWN_PER_GAME]
+    hidden_count = len(names) - len(visible)
+    joined = ", ".join(visible)
+    if hidden_count > 0:
+        return f"{joined}, +{hidden_count} more"
+    return joined
+
+
+def pick_winners_channel_id(items: List[dict]) -> Optional[str]:
+    return DISCORD_WINNERS_CHANNEL_ID
+
+
+def add_bookmark_reaction(
+    client: DiscordClient,
+    *,
+    channel_id: str,
+    message_id: str,
+    context: str,
+) -> None:
+    client.put_reaction(
+        channel_id,
+        message_id,
+        BOOKMARK_EMOJI_ENCODED,
+        context=context,
+    )
+
+
+def fetch_human_voter_names(
+    client: DiscordClient,
+    *,
+    channel_id: str,
+    message_id: str,
+    bot_user_id: Optional[str],
+    context: str,
+) -> List[str]:
+    names: List[str] = []
+    seen_user_ids: set[str] = set()
+    after: Optional[str] = None
+
+    while True:
+        users = client.get_reaction_users(
+            channel_id,
+            message_id,
+            THUMBS_UP_EMOJI_ENCODED,
+            context=context,
+            limit=100,
+            after=after,
+        )
+        if not users:
+            break
+        for user in users:
+            user_id = str(user.get("id") or "").strip()
+            if not user_id or user_id in seen_user_ids:
+                continue
+            seen_user_ids.add(user_id)
+            if bot_user_id and user_id == bot_user_id:
+                continue
+            names.append(resolve_display_name(user))
+        if len(users) < 100:
+            break
+        last_user_id = str(users[-1].get("id") or "").strip()
+        if not last_user_id:
+            break
+        after = last_user_id
+
+    return names
+
+
+
+
+def build_winner_identity_key(item: dict) -> str:
+    dedupe_key = str(item.get("url") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+
+    dedupe_key = str(item.get("item_key") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+
+    channel_id = str(item.get("channel_id") or "").strip()
+    message_id = str(item.get("message_id") or "").strip()
+    return f"{channel_id}:{message_id}"
+
+
+def collect_recent_announced_winner_keys(
+    daily_posts: Dict[str, dict],
+    *,
+    target_day_key: str,
+    lookback_days: int = WINNERS_LOOKBACK_DAYS,
+) -> set[str]:
+    announced_keys: set[str] = set()
+    for bucket_key in get_lookback_day_keys(target_day_key, lookback_days)[1:]:
+        bucket = daily_posts.get(bucket_key, {})
+        if not isinstance(bucket, dict):
+            continue
+        winners_state = bucket.get("winners_state")
+        if not isinstance(winners_state, dict):
+            continue
+        winner_keys = winners_state.get("winner_keys")
+        if not isinstance(winner_keys, list):
+            continue
+        for winner_key in winner_keys:
+            normalized = str(winner_key).strip()
+            if normalized:
+                announced_keys.add(normalized)
+    return announced_keys
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _build_winners_by_section_from_entries(entries: List[dict]) -> Dict[str, List[dict]]:
+    winners_by_section: Dict[str, List[dict]] = {key: [] for key in SECTION_ORDER}
+    for entry in entries:
+        section = str(entry.get("section") or "").strip()
+        if section not in winners_by_section:
+            continue
+        winners_by_section[section].append(
+            {
+                "title": entry.get("title", "Untitled"),
+                "url": entry.get("url", ""),
+                "description": entry.get("description"),
+                "human_votes": _coerce_int(entry.get("human_votes"), 0),
+                "voter_names": entry.get("voter_names", []),
+            }
+        )
+    return winners_by_section
+
+
+def collect_recent_announced_winner_index(
+    daily_posts: Dict[str, dict],
+    *,
+    target_day_key: str,
+    lookback_days: int = WINNERS_LOOKBACK_DAYS,
+) -> Dict[str, dict]:
+    announced_index: Dict[str, dict] = {}
+    for bucket_key in get_lookback_day_keys(target_day_key, lookback_days)[1:]:
+        bucket = daily_posts.get(bucket_key, {})
+        if not isinstance(bucket, dict):
+            continue
+        winners_state = bucket.get("winners_state")
+        if not isinstance(winners_state, dict):
+            continue
+        winner_entries = winners_state.get("winner_entries")
+        if isinstance(winner_entries, list):
+            for entry in winner_entries:
+                if not isinstance(entry, dict):
+                    continue
+                winner_key = str(entry.get("winner_key") or "").strip()
+                if not winner_key or winner_key in announced_index:
+                    continue
+                announced_index[winner_key] = {
+                    "day_key": bucket_key,
+                    "human_votes": _coerce_int(entry.get("human_votes"), 0),
+                    "can_update_state": True,
+                }
+            continue
+
+        winner_keys = winners_state.get("winner_keys")
+        if not isinstance(winner_keys, list):
+            continue
+        winner_vote_counts = winners_state.get("winner_vote_counts")
+        normalized_vote_counts = winner_vote_counts if isinstance(winner_vote_counts, dict) else {}
+        for winner_key in winner_keys:
+            normalized = str(winner_key).strip()
+            if not normalized or normalized in announced_index:
+                continue
+            announced_index[normalized] = {
+                "day_key": bucket_key,
+                "human_votes": _coerce_int(normalized_vote_counts.get(normalized), 0),
+                "can_update_state": False,
+            }
+    return announced_index
+
+
+def update_existing_winner_entry_if_needed(
+    daily_posts: Dict[str, dict],
+    *,
+    key: str,
+    candidate: dict,
+    announced_info: dict,
+) -> bool:
+    if not announced_info.get("can_update_state"):
+        return False
+    if candidate["human_votes"] <= _coerce_int(announced_info.get("human_votes"), 0):
+        return False
+
+    day_key = str(announced_info.get("day_key") or "").strip()
+    if not day_key:
+        return False
+    bucket = daily_posts.get(day_key, {})
+    if not isinstance(bucket, dict):
+        return False
+    winners_state = bucket.get("winners_state")
+    if not isinstance(winners_state, dict):
+        return False
+    winner_entries = winners_state.get("winner_entries")
+    if not isinstance(winner_entries, list):
+        return False
+
+    updated = False
+    for entry in winner_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_key = str(entry.get("winner_key") or "").strip()
+        if entry_key != key:
+            continue
+        entry["section"] = candidate["section"]
+        entry["title"] = candidate["title"]
+        entry["url"] = candidate["url"]
+        entry["description"] = candidate.get("description")
+        entry["human_votes"] = candidate["human_votes"]
+        entry["voter_names"] = candidate["voter_names"]
+        updated = True
+        break
+
+    if not updated:
+        return False
+
+    winners_state["winner_vote_counts"] = {
+        str(entry.get("winner_key") or "").strip(): _coerce_int(entry.get("human_votes"), 0)
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    }
+    winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+    return True
+
+
+def upsert_winners_messages_for_day(
+    client: DiscordClient,
+    *,
+    daily_posts: Dict[str, dict],
+    day_key: str,
+    winners_channel_id: str,
+) -> bool:
+    bucket = daily_posts.get(day_key, {})
+    if not isinstance(bucket, dict):
+        return False
+    winners_state = bucket.get("winners_state")
+    if not isinstance(winners_state, dict):
+        return False
+    winner_entries = winners_state.get("winner_entries")
+    if not isinstance(winner_entries, list):
+        return False
+
+    winner_entries_by_key = {
+        str(entry.get("winner_key") or "").strip(): entry
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    }
+    if not winner_entries_by_key:
+        return False
+    publish_winners_for_entries(
+        client,
+        winners_state=winners_state,
+        winners_channel_id=winners_channel_id,
+        day_key=day_key,
+        winner_entries_by_key=winner_entries_by_key,
+    )
+    winners_state["winner_keys"] = sorted(
+        str(entry.get("winner_key") or "").strip()
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    )
+    winners_state["winner_vote_counts"] = {
+        str(entry.get("winner_key") or "").strip(): _coerce_int(entry.get("human_votes"), 0)
+        for entry in winner_entries
+        if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
+    }
+    return True
+
+
+def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
+    payload = client.post_message(channel_id, message, context="post winners message")
+    message_id = str(payload.get("id", ""))
+    if not message_id:
+        raise RuntimeError("Discord response missing winners message id")
+    return message_id
+
+
+def normalize_winners_message_ids(winners_state: dict) -> List[str]:
+    message_ids = winners_state.get("message_ids")
+    if isinstance(message_ids, list):
+        normalized = [str(message_id).strip() for message_id in message_ids if str(message_id).strip()]
+        if normalized:
+            return normalized
+    message_id = winners_state.get("message_id")
+    if isinstance(message_id, str) and message_id.strip():
+        return [message_id.strip()]
+    return []
+
+
+def _ensure_post_or_edit_message(
+    client: DiscordClient,
+    *,
+    channel_id: str,
+    state_entry: dict,
+    content: str,
+    context_prefix: str,
+) -> dict:
+    existing_message_id = str(state_entry.get("message_id") or "").strip()
+    existing_channel_id = str(state_entry.get("channel_id") or channel_id).strip() or channel_id
+    if existing_message_id:
+        try:
+            client.get_message(existing_channel_id, existing_message_id, context=f"verify {context_prefix}")
+            client.edit_message(existing_channel_id, existing_message_id, content, context=f"edit {context_prefix}")
+            state_entry["message_id"] = existing_message_id
+            state_entry["channel_id"] = existing_channel_id
+            return state_entry
+        except DiscordMessageNotFoundError:
+            print(f"RECOVER: stale/deleted {context_prefix}; posting replacement")
+    payload = client.post_message(channel_id, content, context=f"post {context_prefix}")
+    message_id = str(payload.get("id") or "").strip()
+    if not message_id:
+        raise RuntimeError(f"Discord response missing message id for {context_prefix}")
+    state_entry["message_id"] = message_id
+    state_entry["channel_id"] = str(payload.get("channel_id") or channel_id)
+    return state_entry
+
+
+def publish_winners_for_entries(
+    client: DiscordClient,
+    *,
+    winners_state: dict,
+    winners_channel_id: str,
+    day_key: str,
+    winner_entries_by_key: Dict[str, dict],
+) -> None:
+    intro_state = winners_state.setdefault("intro", {})
+    section_headers = winners_state.setdefault("section_headers", {})
+    winner_messages = winners_state.setdefault("winner_messages", {})
+    footer_state = winners_state.setdefault("footer", {})
+    if not isinstance(section_headers, dict):
+        section_headers = {}
+        winners_state["section_headers"] = section_headers
+    if not isinstance(winner_messages, dict):
+        winner_messages = {}
+        winners_state["winner_messages"] = winner_messages
+
+    # Post header placeholder first (without jump links) — edited after sections post
+    _ensure_post_or_edit_message(
+        client,
+        channel_id=winners_channel_id,
+        state_entry=intro_state,
+        content=build_winners_header_placeholder(day_key),
+        context_prefix=f"winners intro for {day_key}",
+    )
+
+    posted_section_keys: List[str] = []
+    ordered_keys: List[str] = []
+    for section in SECTION_ORDER:
+        section_entries = [
+            (winner_key, entry)
+            for winner_key, entry in winner_entries_by_key.items()
+            if str(entry.get("section") or "").strip() == section
+        ]
+        if not section_entries:
+            continue
+        posted_section_keys.append(section)
+        section_state = section_headers.setdefault(section, {})
+        _ensure_post_or_edit_message(
+            client,
+            channel_id=winners_channel_id,
+            state_entry=section_state,
+            content=build_winners_section_header(section),
+            context_prefix=f"winners section header {section} for {day_key}",
+        )
+        for winner_key, entry in section_entries:
+            message_state = winner_messages.setdefault(winner_key, {})
+            _ensure_post_or_edit_message(
+                client,
+                channel_id=winners_channel_id,
+                state_entry=message_state,
+                content=build_winner_game_message(entry, section=section),
+                context_prefix=f"winner game {winner_key} for {day_key}",
+            )
+            add_bookmark_reaction(
+                client,
+                channel_id=str(message_state.get("channel_id") or winners_channel_id),
+                message_id=str(message_state.get("message_id") or ""),
+                context=f"add bookmark reaction for winner {winner_key}",
+            )
+            ordered_keys.append(winner_key)
+
+    for stale_key in list(winner_messages.keys()):
+        if stale_key in winner_entries_by_key:
+            continue
+        stale_state = winner_messages.get(stale_key)
+        if isinstance(stale_state, dict):
+            stale_channel_id = str(stale_state.get("channel_id") or winners_channel_id).strip()
+            stale_message_id = str(stale_state.get("message_id") or "").strip()
+            if stale_channel_id and stale_message_id:
+                try:
+                    client.edit_message(
+                        stale_channel_id,
+                        stale_message_id,
+                        "_(Winner no longer active for this day due to late-vote reconciliation.)_",
+                        context=f"clear stale winner game {stale_key} for {day_key}",
+                    )
+                except DiscordMessageNotFoundError:
+                    pass
+
+    # Edit header to add jump links now that all section messages exist
+    header_content = build_winners_navigation_header(
+        winners_state,
+        guild_id=DISCORD_GUILD_ID,
+        target_day_key=day_key,
+        posted_section_keys=posted_section_keys,
+    )
+    intro_message_id = str(intro_state.get("message_id") or "").strip()
+    intro_channel_id = str(intro_state.get("channel_id") or winners_channel_id).strip()
+    if intro_message_id and intro_channel_id:
+        try:
+            client.edit_message(
+                intro_channel_id,
+                intro_message_id,
+                header_content,
+                context=f"edit winners header with jump links for {day_key}",
+            )
+        except DiscordMessageNotFoundError:
+            print(f"WARN: winners header message missing; skip header jump-link edit for {day_key}")
+        except Exception as e:
+            print(f"WARN: failed to edit winners header for {day_key}: {e}")
+
+    footer_content = build_winners_navigation_footer(
+        winners_state,
+        guild_id=DISCORD_GUILD_ID,
+        target_day_key=day_key,
+        posted_section_keys=posted_section_keys,
+    )
+    if footer_content:
+        _ensure_post_or_edit_message(
+            client,
+            channel_id=winners_channel_id,
+            state_entry=footer_state,
+            content=footer_content,
+            context_prefix=f"winners footer for {day_key}",
+        )
+
+    message_ids: List[str] = []
+    intro_id = str(intro_state.get("message_id") or "").strip()
+    if intro_id:
+        message_ids.append(intro_id)
+    for section in SECTION_ORDER:
+        if section not in posted_section_keys:
+            continue
+        sid = str(section_headers.get(section, {}).get("message_id") or "").strip()
+        if sid:
+            message_ids.append(sid)
+        for winner_key in ordered_keys:
+            entry = winner_entries_by_key.get(winner_key, {})
+            if str(entry.get("section") or "").strip() != section:
+                continue
+            mid = str(winner_messages.get(winner_key, {}).get("message_id") or "").strip()
+            if mid:
+                message_ids.append(mid)
+    footer_id = str(footer_state.get("message_id") or "").strip()
+    if footer_id:
+        message_ids.append(footer_id)
+    if message_ids:
+        winners_state["message_id"] = message_ids[0]
+        winners_state["message_ids"] = message_ids
+
+
+def main() -> None:
+    if not DISCORD_BOT_TOKEN:
+        raise RuntimeError("DISCORD_BOT_TOKEN is not set.")
+    day_key = get_target_day_key()
+    manual_run = is_manual_run()
+    if manual_run:
+        print("Evening winners run is a manual (workflow_dispatch) run — idempotency skips bypassed")
+    print(f"Starting evening winners for day={day_key}")
+
+    daily_posts = load_discord_daily_posts()
+    today_entry = daily_posts.get(day_key, {})
+    if not isinstance(today_entry, dict):
+        today_entry = {}
+        daily_posts[day_key] = today_entry
+    lookback_day_keys = get_lookback_day_keys(day_key)
+    items: List[dict] = []
+    for bucket_key in lookback_day_keys:
+        bucket = daily_posts.get(bucket_key, {})
+        if not isinstance(bucket, dict):
+            continue
+        bucket_items = bucket.get("items", [])
+        if isinstance(bucket_items, list):
+            items.extend(bucket_items)
+
+    winners_channel_id = pick_winners_channel_id(items)
+    if not winners_channel_id:
+        raise RuntimeError(
+            "Winners destination channel id is not set. "
+            "Set DISCORD_WINNERS_CHANNEL_ID."
+        )
+
+    with requests.Session() as session:
+        session.headers.update(
+            {
+                "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+                "Content-Type": "application/json",
+            }
+        )
+        client = DiscordClient(session)
+        bot_user = client.get_current_user(context="fetch bot user for winners vote filtering")
+        bot_user_id = str(bot_user.get("id") or "").strip() or None
+
+        deduped_winners: Dict[str, dict] = {}
+        for item in items:
+            section = item.get("section")
+            channel_id = item.get("channel_id")
+            message_id = item.get("message_id")
+            dedupe_key = build_winner_identity_key(item)
+
+            if section not in SECTION_CONFIG:
+                continue
+            if not channel_id or not message_id:
+                continue
+
+            try:
+                message_payload = client.get_message(
+                    channel_id=str(channel_id),
+                    message_id=str(message_id),
+                    context=f"fetch votes for {item.get('title', 'item')}",
+                )
+            except DiscordMessageNotFoundError:
+                print(f"RECOVER: stale/deleted daily item message skipped (message_id={message_id})")
+                continue
+
+            raw_thumbsup_count = get_thumbsup_count(message_payload)
+            human_votes = raw_thumbsup_count - 1
+
+            if human_votes < 1:
+                continue
+            voter_names = fetch_human_voter_names(
+                client,
+                channel_id=str(channel_id),
+                message_id=str(message_id),
+                bot_user_id=bot_user_id,
+                context=f"fetch voters for {item.get('title', 'item')}",
+            )
+
+            existing = deduped_winners.get(dedupe_key)
+            candidate = {
+                "section": section,
+                "title": item.get("title", "Untitled"),
+                "url": item.get("url", ""),
+                "description": item.get("description"),
+                "human_votes": human_votes,
+                "voter_names": voter_names,
+                "channel_id": str(channel_id),
+                "message_id": str(message_id),
+            }
+            if existing is None or candidate["human_votes"] > existing["human_votes"]:
+                deduped_winners[dedupe_key] = candidate
+
+        recently_announced_winner_index = collect_recent_announced_winner_index(
+            daily_posts,
+            target_day_key=day_key,
+        )
+        prior_days_requiring_updates: set[str] = set()
+        new_winners_by_key: Dict[str, dict] = {}
+        for key, winner in deduped_winners.items():
+            announced_info = recently_announced_winner_index.get(key)
+            if not announced_info:
+                new_winners_by_key[key] = winner
+                continue
+            updated = update_existing_winner_entry_if_needed(
+                daily_posts,
+                key=key,
+                candidate=winner,
+                announced_info=announced_info,
+            )
+            if updated:
+                prior_days_requiring_updates.add(str(announced_info.get("day_key") or "").strip())
+        deduped_winners = new_winners_by_key
+
+        winners_state = today_entry.get("winners_state")
+        if not isinstance(winners_state, dict):
+            winners_state = {}
+            today_entry["winners_state"] = winners_state
+
+        current_winner_keys = sorted(deduped_winners.keys())
+        current_winner_vote_counts = {
+            key: int(deduped_winners[key]["human_votes"])
+            for key in current_winner_keys
+        }
+        previous_message_ids = normalize_winners_message_ids(winners_state)
+        previous_winner_keys = winners_state.get("winner_keys")
+        if not isinstance(previous_winner_keys, list):
+            previous_winner_keys = []
+        previous_winner_vote_counts = winners_state.get("winner_vote_counts")
+        had_previous_vote_snapshot = isinstance(previous_winner_vote_counts, dict)
+        if not had_previous_vote_snapshot:
+            previous_winner_vote_counts = {}
+        normalized_previous_vote_counts = {
+            str(key): int(value)
+            for key, value in previous_winner_vote_counts.items()
+            if str(key)
+        }
+        previous_winner_entries = winners_state.get("winner_entries")
+        has_previous_winner_entries = isinstance(previous_winner_entries, list)
+
+        if not current_winner_keys and not previous_message_ids:
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            if prior_days_requiring_updates:
+                save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
+            return
+
+        keys_unchanged = sorted(str(key) for key in previous_winner_keys) == current_winner_keys
+        vote_counts_unchanged = normalized_previous_vote_counts == current_winner_vote_counts
+        current_winner_entries = [
+            {
+                "winner_key": key,
+                "section": deduped_winners[key]["section"],
+                "title": deduped_winners[key]["title"],
+                "url": deduped_winners[key]["url"],
+                "description": deduped_winners[key].get("description"),
+                "human_votes": deduped_winners[key]["human_votes"],
+                "voter_names": deduped_winners[key]["voter_names"],
+            }
+            for key in current_winner_keys
+        ]
+
+        if keys_unchanged and not had_previous_vote_snapshot and not manual_run:
+            winners_state["winner_vote_counts"] = current_winner_vote_counts
+            winners_state["winner_entries"] = current_winner_entries
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no newly eligible winners for {day_key} (backfilled vote snapshot)")
+            return
+
+        if keys_unchanged and vote_counts_unchanged and has_previous_winner_entries and not manual_run:
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            if prior_days_requiring_updates:
+                save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no newly eligible winners for {day_key}")
+            return
+
+        if keys_unchanged and vote_counts_unchanged and not manual_run:
+            winners_state["winner_entries"] = current_winner_entries
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+                upsert_winners_messages_for_day(
+                    client,
+                    daily_posts=daily_posts,
+                    day_key=prior_day,
+                    winners_channel_id=winners_channel_id,
+                )
+            save_discord_daily_posts(daily_posts)
+            print(f"SKIP: no newly eligible winners for {day_key}")
+            return
+
+        publish_winners_for_entries(
+            client,
+            winners_state=winners_state,
+            winners_channel_id=winners_channel_id,
+            day_key=day_key,
+            winner_entries_by_key={entry["winner_key"]: entry for entry in current_winner_entries},
+        )
+        winners_state["last_action"] = "edit" if previous_message_ids else "create"
+        winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+        if not previous_message_ids:
+            winners_state["posted_at_utc"] = datetime.now(timezone.utc).isoformat()
+        winners_state["winner_keys"] = current_winner_keys
+        winners_state["winner_vote_counts"] = current_winner_vote_counts
+        winners_state["winner_entries"] = current_winner_entries
+        for prior_day in sorted(key for key in prior_days_requiring_updates if key and key != day_key):
+            upsert_winners_messages_for_day(
+                client,
+                daily_posts=daily_posts,
+                day_key=prior_day,
+                winners_channel_id=winners_channel_id,
+            )
+        save_discord_daily_posts(daily_posts)
+
+
+if __name__ == "__main__":
+    main()
+
+===== gaming_library.py =====
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+
+from discord_api import (
+    DiscordClient,
+    DiscordMessageNotFoundError,
+    DiscordPermissionError,
+    PERM_ADD_REACTIONS,
+    PERM_MANAGE_MESSAGES,
+    PERM_READ_MESSAGE_HISTORY,
+    PERM_SEND_MESSAGES,
+)
+from state_utils import load_json_object, save_json_object_atomic
+
+GAMING_LIBRARY_FILE = "gaming_library.json"
+DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
+DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_GAMING_LIBRARY_CHANNEL_ID = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID")
+DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
+GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
+LIBRARY_DATE_OVERRIDE_ENV = "LIBRARY_DATE_UTC"
+
+STATUS_ACTIVE = "active"
+STATUS_PAUSED = "paused"
+STATUS_DROPPED = "dropped"
+ALLOWED_STATUSES = {STATUS_ACTIVE, STATUS_PAUSED, STATUS_DROPPED}
+
+BOOKMARK_EMOJI = "🔖"
+BOOKMARK_EMOJI_ENCODED = quote(BOOKMARK_EMOJI, safe="")
+STATUS_TO_EMOJI = {
+    STATUS_ACTIVE: "✅",
+    STATUS_PAUSED: "⏸️",
+    STATUS_DROPPED: "❌",
+}
+EMOJI_TO_STATUS = {emoji: status for status, emoji in STATUS_TO_EMOJI.items()}
+EMOJI_TO_STATUS_ENCODED = {quote(emoji, safe=""): status for emoji, status in EMOJI_TO_STATUS.items()}
+MENTION_USER_ID_PATTERN = re.compile(r"^<@!?(\d+)>$")
+
+# Category constants for grouping games in library posts
+CATEGORY_DEMO_PLAYTEST = "demo_playtest"
+CATEGORY_FREE_PICKS = "free_picks"
+CATEGORY_PAID_PICKS = "paid_picks"
+CATEGORY_CREATOR_PICKS = "creator_picks"
+CATEGORY_OTHER = "other"
+
+CATEGORY_DISPLAY = {
+    CATEGORY_DEMO_PLAYTEST: "🧪 Demo & Playtest",
+    CATEGORY_FREE_PICKS: "🎮 Free Picks",
+    CATEGORY_PAID_PICKS: "💸 Paid Picks",
+    CATEGORY_CREATOR_PICKS: "📸 Creator Picks",
+    CATEGORY_OTHER: "🎮 Other",
+}
+
+# Ordered display sequence
+CATEGORY_ORDER = [
+    CATEGORY_DEMO_PLAYTEST,
+    CATEGORY_FREE_PICKS,
+    CATEGORY_PAID_PICKS,
+    CATEGORY_CREATOR_PICKS,
+    CATEGORY_OTHER,
+]
+
+COMMAND_REFERENCE_MESSAGE = """\
+📋 Bot Commands — step-3-review-existing-games
+`!add @user GameName` — assign a player to a game
+`!remove @user GameName` — unassign a player from a game
+`!rename GameName NewName` — rename a game
+`!unassign @user` — remove a player from all games
+`!archive GameName` — manually archive a game
+`!addgame GameName SteamURL @user1 @user2` — add game directly to library
+
+React on any game message to update your status:
+✅ Playing · ⏸️ Paused · ❌ Dropped\
+"""
+
+
+def is_manual_run() -> bool:
+    """Return True when triggered by workflow_dispatch (manual/test run).
+
+    Manual runs post to Discord but do NOT mark the day as completed so that
+    the subsequent scheduled run always executes cleanly.
+    """
+    event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
+    return event == "workflow_dispatch"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def classify_game_category(game: Dict[str, Any]) -> str:
+    """Return the display category for a game based on its source type/section."""
+    source_type = str(game.get("source_type") or "").lower()
+    source_section = str(game.get("source_section") or "").lower()
+    if source_type in ("instagram", "creator") or source_section in ("instagram", "creator"):
+        return CATEGORY_CREATOR_PICKS
+    if source_type in ("steam_demo", "demo") or source_section in ("demo", "playtest") or "demo" in source_type or "playtest" in source_type:
+        return CATEGORY_DEMO_PLAYTEST
+    if source_type in ("paid", "paid_candidate") or source_section in ("paid",):
+        return CATEGORY_PAID_PICKS
+    if source_type in ("steam_free", "free", "winner_promotion") or source_section in ("free", "free_picks"):
+        return CATEGORY_FREE_PICKS
+    return CATEGORY_OTHER
+
+
+def _suppress_steam_url(url: str) -> str:
+    """Wrap Steam store URLs in <> to suppress Discord embed cards."""
+    url = url.strip()
+    if url.startswith("https://store.steampowered.com") or url.startswith("http://store.steampowered.com"):
+        return f"<{url}>"
+    return url
+
+
+def _extract_game_name_from_caption(caption: str, steam_url: str) -> Optional[str]:
+    """Try to extract an actual game name from an Instagram post caption or Steam URL.
+
+    Returns the extracted name, or None if one cannot be determined.
+    """
+    if steam_url:
+        match = re.search(r"store\.steampowered\.com/app/\d+/([^/?#]+)", steam_url)
+        if match:
+            raw = match.group(1).replace("_", " ").strip()
+            if raw and raw.lower() not in ("", "app"):
+                return raw
+    if caption:
+        # Look for patterns like "Game Name — check it out" or "New game: Game Name"
+        # Just take first non-empty line up to any separator
+        first_line = caption.strip().splitlines()[0] if caption.strip() else ""
+        # Remove common Instagram fluff from start
+        for prefix in ("new game:", "game:", "check out", "check this out", "play"):
+            if first_line.lower().startswith(prefix):
+                first_line = first_line[len(prefix):].strip()
+                break
+        # Trim at common separators
+        for sep in (" — ", " - ", " | ", "!", "?", "#"):
+            if sep in first_line:
+                first_line = first_line[:first_line.index(sep)].strip()
+        if first_line and len(first_line) >= 3:
+            return first_line
+    return None
+
+
+def get_target_day_key() -> str:
+    manual_day = (os.getenv(LIBRARY_DATE_OVERRIDE_ENV, "") or "").strip()
+    if manual_day:
+        datetime.fromisoformat(manual_day)
+        return manual_day
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def load_gaming_library(path: str = GAMING_LIBRARY_FILE) -> Dict[str, Any]:
+    state = load_json_object(path, log=print)
+    if not isinstance(state.get("games"), dict):
+        state["games"] = {}
+    if not isinstance(state.get("daily_posts"), dict):
+        state["daily_posts"] = {}
+    if not isinstance(state.get("version"), int):
+        state["version"] = 1
+    return state
+
+
+def save_gaming_library(state: Dict[str, Any], path: str = GAMING_LIBRARY_FILE) -> None:
+    save_json_object_atomic(path, state)
+
+
+def load_discord_daily_posts(path: str = DISCORD_DAILY_POSTS_FILE) -> Dict[str, Any]:
+    return load_json_object(path, log=print)
+
+
+def compute_daily_delta(state: Dict[str, Any]) -> str:
+    current_games = state.get("games", {})
+    previous_games = state.get("previous_day_games", {})
+
+    new_games = []
+    status_changes = []
+    pending_items: List[str] = []
+
+    # Per-player game count: count assignments across all active (non-archived) games.
+    player_game_counts: Dict[str, int] = {}
+
+    for key, game in current_games.items():
+        if not isinstance(game, dict):
+            continue
+        if game.get("archived"):
+            continue
+        curr_assignments = game.get("assignments", {})
+        game_name = game.get("canonical_name", "Untitled")
+
+        # Count this game toward each assigned player.
+        for user_id in curr_assignments:
+            player_game_counts[user_id] = player_game_counts.get(user_id, 0) + 1
+
+        if key not in previous_games:
+            new_games.append(game_name)
+        else:
+            prev_assignments = previous_games[key].get("assignments", {})
+            for user_id, curr_ass in curr_assignments.items():
+                if not isinstance(curr_ass, dict):
+                    continue
+                prev_ass = prev_assignments.get(user_id)
+                if isinstance(prev_ass, dict) and curr_ass.get("status") != prev_ass.get("status"):
+                    user_mention = f"<@{user_id}>"
+                    old_status = prev_ass.get("status", "unknown")
+                    new_status = curr_ass.get("status", "unknown")
+                    status_changes.append(f"{user_mention} changed {game_name}: {old_status} → {new_status}")
+                # Pending: assigned with active status but never updated (no reaction recorded yet).
+                if curr_ass.get("status") == STATUS_ACTIVE:
+                    updated = curr_ass.get("updated_at_utc")
+                    created = game.get("created_at_utc")
+                    if updated == created:
+                        pending_items.append(f"⏳ <@{user_id}> has not reacted on {game_name}")
+
+    lines = []
+
+    # Per-player summary at the top.
+    if player_game_counts:
+        lines.append("👥 Players:")
+        for user_id, count in sorted(player_game_counts.items()):
+            lines.append(f"  • <@{user_id}> — {count} game{'s' if count != 1 else ''} assigned")
+
+    if new_games:
+        lines.append(f"🎉 {len(new_games)} Games added to library today (bookmarked from Step 2)")
+    if status_changes:
+        lines.append(f"🔄 {len(status_changes)} Status changes since yesterday:")
+        for change in status_changes[:5]:  # limit to 5
+            lines.append(f"  • {change}")
+    if pending_items:
+        for item in pending_items[:10]:  # limit to 10 to avoid message bloat
+            lines.append(item)
+    if not new_games and not status_changes and not pending_items:
+        lines.append("No changes since yesterday")
+
+    return "\n".join(lines)
+
+
+def _extract_steam_app_id(url: str) -> Optional[str]:
+    match = re.search(r"store\.steampowered\.com/app/(\d+)", url or "")
+    if match:
+        return match.group(1)
+    return None
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")
+
+
+def build_identity_key(canonical_name: str, url: str) -> str:
+    app_id = _extract_steam_app_id(url)
+    if app_id:
+        return f"steam:{app_id}"
+    if url:
+        return f"url:{url.strip().lower()}"
+    return f"name:{_slugify(canonical_name)}"
+
+
+def ensure_game_entry(
+    state: Dict[str, Any],
+    *,
+    canonical_name: str,
+    url: str,
+    source_type: Optional[str] = None,
+    source_section: Optional[str] = None,
+    source_metadata: Optional[Dict[str, Any]] = None,
+    archived: bool = False,
+) -> Dict[str, Any]:
+    identity_key = build_identity_key(canonical_name, url)
+    games = state.setdefault("games", {})
+    game = games.get(identity_key)
+    if not isinstance(game, dict):
+        game = {
+            "identity_key": identity_key,
+            "canonical_name": canonical_name,
+            "url": url,
+            "source_type": source_type,
+            "source_section": source_section,
+            "source_metadata": source_metadata or {},
+            "assignments": {},
+            "archived": archived,
+            "created_at_utc": utc_now_iso(),
+            "updated_at_utc": utc_now_iso(),
+        }
+        games[identity_key] = game
+    else:
+        if canonical_name:
+            game["canonical_name"] = canonical_name
+        if url:
+            game["url"] = url
+        if source_type:
+            game["source_type"] = source_type
+        if source_section:
+            game["source_section"] = source_section
+        if source_metadata:
+            existing_meta = game.get("source_metadata")
+            if not isinstance(existing_meta, dict):
+                existing_meta = {}
+            existing_meta.update(source_metadata)
+            game["source_metadata"] = existing_meta
+        game["updated_at_utc"] = utc_now_iso()
+    return game
+
+
+def assign_user(game: Dict[str, Any], user_id: str, status: str = STATUS_ACTIVE) -> None:
+    if status not in ALLOWED_STATUSES:
+        raise RuntimeError(f"Invalid status: {status}")
+    assignments = game.setdefault("assignments", {})
+    assignments[str(user_id)] = {"status": status, "updated_at_utc": utc_now_iso()}
+    game["updated_at_utc"] = utc_now_iso()
+
+
+def assign_user_if_changed(game: Dict[str, Any], user_id: str, status: str = STATUS_ACTIVE) -> bool:
+    assignments = game.setdefault("assignments", {})
+    existing = assignments.get(str(user_id))
+    if isinstance(existing, dict) and str(existing.get("status") or "") == status:
+        return False
+    assign_user(game, user_id, status)
+    return True
+
+
+def unassign_user(game: Dict[str, Any], user_id: str) -> None:
+    assignments = game.setdefault("assignments", {})
+    assignments.pop(str(user_id), None)
+    game["updated_at_utc"] = utc_now_iso()
+
+
+def set_user_status(game: Dict[str, Any], user_id: str, status: str) -> None:
+    if status not in ALLOWED_STATUSES:
+        raise RuntimeError(f"Invalid status: {status}")
+    assignments = game.setdefault("assignments", {})
+    current = assignments.get(str(user_id), {})
+    if not isinstance(current, dict):
+        current = {}
+    current["status"] = status
+    current["updated_at_utc"] = utc_now_iso()
+    assignments[str(user_id)] = current
+    game["updated_at_utc"] = utc_now_iso()
+
+
+def refresh_archive_state(game: Dict[str, Any]) -> None:
+    assignments = game.get("assignments", {})
+    if not isinstance(assignments, dict) or not assignments:
+        return
+    statuses = []
+    for assignment in assignments.values():
+        if isinstance(assignment, dict):
+            statuses.append(str(assignment.get("status") or STATUS_ACTIVE))
+    if statuses and all(status == STATUS_DROPPED for status in statuses):
+        game["archived"] = True
+    game["updated_at_utc"] = utc_now_iso()
+
+
+def list_visible_games_for_reminder(state: Dict[str, Any]) -> List[Dict[str, Any]]:
+    visible = []
+    for game in state.get("games", {}).values():
+        if not isinstance(game, dict):
+            continue
+        assignments = game.get("assignments", {})
+        if not isinstance(assignments, dict):
+            assignments = {}
+        visible_assignments = {
+            uid: assignment
+            for uid, assignment in assignments.items()
+            if isinstance(assignment, dict) and assignment.get("status") in {STATUS_ACTIVE, STATUS_PAUSED}
+        }
+        archived = bool(game.get("archived"))
+        if archived and not visible_assignments:
+            continue
+        game_copy = dict(game)
+        game_copy["visible_assignments"] = visible_assignments
+        visible.append(game_copy)
+
+    visible.sort(
+        key=lambda g: (
+            -len(g.get("visible_assignments", {})),
+            str(g.get("canonical_name") or "").lower(),
+        )
+    )
+    return visible
+
+
+def _discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def build_library_footer(
+    *,
+    day_key: str,
+    header_channel_id: str,
+    header_message_id: str,
+    guild_id: Optional[str],
+) -> str:
+    """Build a navigation footer string linking back to the header."""
+    base = (
+        f"📚 Gaming Library — {day_key}\n"
+        "React ✅ active · ⏸️ paused · ❌ dropped to update your status."
+    )
+    if not isinstance(guild_id, str) or not guild_id.strip() or not header_message_id:
+        return base
+    link = _discord_message_link(guild_id, header_channel_id, header_message_id)
+    return base + f"\n⟹ [Top of Post]({link})"
+
+
+def build_library_header_placeholder(target_day_key: str) -> str:
+    return (
+        f"📚 Gaming Library — {target_day_key}\n"
+        "React on each game: ✅ active · ⏸️ paused · ❌ dropped"
+    )
+
+
+def build_library_navigation_header(
+    target_day_key: str,
+    *,
+    guild_id: Optional[str],
+    channel_id: str,
+    posted_section_keys: Dict[str, str],
+) -> str:
+    """Build header with jump links to each active category section."""
+    base = build_library_header_placeholder(target_day_key)
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        return base
+    jump_parts = []
+    for category in CATEGORY_ORDER:
+        section_key = f"section:{category}"
+        msg_id = posted_section_keys.get(section_key)
+        if msg_id:
+            label = CATEGORY_DISPLAY[category]
+            link = _discord_message_link(guild_id, channel_id, msg_id)
+            jump_parts.append(f"⟹ [{label}]({link})")
+    if not jump_parts:
+        return base
+    return base + "\n" + " · ".join(jump_parts)
+
+
+def build_daily_library_messages(state: Dict[str, Any], target_day_key: str) -> List[Dict[str, str]]:
+    visible_games = list_visible_games_for_reminder(state)
+
+    # Group by category
+    by_category: Dict[str, List[Dict[str, Any]]] = {}
+    for game in visible_games:
+        cat = classify_game_category(game)
+        by_category.setdefault(cat, []).append(game)
+
+    active_categories = [c for c in CATEGORY_ORDER if c in by_category]
+
+    messages: List[Dict[str, str]] = []
+
+    # Header placeholder (will be edited after sections are posted)
+    messages.append({"type": "header", "content": build_library_header_placeholder(target_day_key)})
+
+    if not visible_games:
+        messages[0]["content"] = f"📚 Gaming Library — {target_day_key}\n\n_No active library games for today._"
+    else:
+        for category in active_categories:
+            section_label = CATEGORY_DISPLAY[category]
+            messages.append({
+                "type": "section_header",
+                "section_key": f"section:{category}",
+                "identity_key": f"section:{category}",
+                "content": f"**{section_label}**",
+            })
+            for game in by_category[category]:
+                name = game.get("canonical_name", "Untitled")
+                lines = [f"🎮 {name}"]
+                url = str(game.get("url") or "").strip()
+                if url:
+                    lines.append(_suppress_steam_url(url))
+                lines.append("Players:")
+                visible_assignments = game.get("visible_assignments", {})
+                conflict_users = game.get("conflicting_users", [])
+                if visible_assignments:
+                    for user_id, assignment in visible_assignments.items():
+                        status = str(assignment.get("status") or STATUS_ACTIVE)
+                        emoji = STATUS_TO_EMOJI.get(status, "✅")
+                        lines.append(f"- <@{user_id}> {emoji} ({status})")
+                else:
+                    lines.append("- _No active players_")
+                for user_id in conflict_users:
+                    lines.append(f"- ⚠️ <@{user_id}> — conflicting reactions, defaulted to Active")
+                messages.append({"type": "game", "identity_key": game["identity_key"], "content": "\n".join(lines)})
+
+    # Add delta summary
+    delta_content = compute_daily_delta(state)
+    messages.append({"type": "delta", "content": f"📊 Daily Delta Summary\n\n{delta_content}"})
+
+    return messages
+
+
+def _post_or_edit_message(
+    client: DiscordClient,
+    channel_id: str,
+    content: str,
+    *,
+    context: str,
+    existing_info: Optional[Dict[str, str]],
+) -> tuple[Dict[str, Any], bool]:
+    """Post or edit a message. Returns (payload, is_new_message)."""
+    existing_channel_id = str((existing_info or {}).get("channel_id") or channel_id).strip()
+    existing_message_id = str((existing_info or {}).get("message_id") or "").strip()
+    if existing_message_id:
+        try:
+            payload = client.edit_message(existing_channel_id, existing_message_id, content, context=context)
+            return payload, False
+        except DiscordMessageNotFoundError:
+            pass
+    payload = client.post_message(channel_id, content, context=context)
+    return payload, True
+
+
+def post_daily_library_reminder(
+    state: Dict[str, Any],
+    *,
+    day_key: str,
+    channel_id: str,
+    client: DiscordClient,
+    manual_run: bool = False,
+) -> bool:
+    daily_posts = state.setdefault("daily_posts", {})
+    day_entry = daily_posts.setdefault(day_key, {})
+    existing_messages = day_entry.get("messages")
+    if not isinstance(existing_messages, dict):
+        existing_messages = {}
+
+    messages = build_daily_library_messages(state, day_key)
+    reconciled_messages: Dict[str, Dict[str, str]] = {}
+    changed = False
+
+    for message in messages:
+        message_key = str(message.get("identity_key", message["type"]))
+        existing_info = existing_messages.get(message_key)
+        payload, is_new_message = _post_or_edit_message(
+            client,
+            channel_id,
+            message["content"],
+            context=f"post/edit gaming library {message['type']} for {day_key}",
+            existing_info=existing_info,
+        )
+        changed = True
+
+        message_id = str(payload.get("id") or "")
+        if not message_id:
+            raise RuntimeError("Discord response missing id for gaming library message")
+        if message.get("type") == "game" and is_new_message:
+            for emoji in ("✅", "⏸️", "❌"):
+                client.put_reaction(
+                    str(payload.get("channel_id") or channel_id),
+                    message_id,
+                    quote(emoji, safe=""),
+                    context=f"add gaming library status reaction {emoji} for {day_key}",
+                )
+        reconciled_messages[message_key] = {"message_id": message_id, "channel_id": str(payload.get("channel_id") or channel_id)}
+
+    # --- Edit header with jump links after all sections are posted ---
+    header_info = reconciled_messages.get("header", {})
+    header_ch_id = str(header_info.get("channel_id") or channel_id).strip()
+    header_msg_id = str(header_info.get("message_id") or "").strip()
+    posted_section_keys = {key: info["message_id"] for key, info in reconciled_messages.items() if key.startswith("section:")}
+    if posted_section_keys and header_msg_id:
+        nav_header = build_library_navigation_header(
+            day_key,
+            guild_id=DISCORD_GUILD_ID,
+            channel_id=header_ch_id,
+            posted_section_keys=posted_section_keys,
+        )
+        client.edit_message(header_ch_id, header_msg_id, nav_header, context=f"update gaming library header with jump links for {day_key}")
+
+    # --- Footer ---
+    footer_content = build_library_footer(
+        day_key=day_key,
+        header_channel_id=header_ch_id,
+        header_message_id=header_msg_id,
+        guild_id=DISCORD_GUILD_ID,
+    )
+    footer_payload, _ = _post_or_edit_message(
+        client,
+        channel_id,
+        footer_content,
+        context=f"post/edit gaming library footer for {day_key}",
+        existing_info=existing_messages.get("footer"),
+    )
+    footer_msg_id = str(footer_payload.get("id") or "")
+    if not footer_msg_id:
+        raise RuntimeError("Discord response missing id for gaming library footer")
+    reconciled_messages["footer"] = {
+        "message_id": footer_msg_id,
+        "channel_id": str(footer_payload.get("channel_id") or channel_id),
+    }
+
+    day_entry["messages"] = reconciled_messages
+    if manual_run:
+        print(f"MANUAL RUN: gaming library daily post done for {day_key}; skipping completed=True to preserve scheduled run eligibility")
+    else:
+        day_entry["completed"] = True
+        day_entry["completed_at_utc"] = utc_now_iso()
+    return changed
+
+
+def _build_winner_identity_key(item: Dict[str, Any]) -> str:
+    dedupe_key = str(item.get("url") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+    dedupe_key = str(item.get("item_key") or "").strip()
+    if dedupe_key:
+        return dedupe_key
+    return f"{item.get('channel_id')}:{item.get('message_id')}"
+
+
+def sync_promotions_from_winners(state: Dict[str, Any], daily_posts: Dict[str, Any], client: DiscordClient, bot_user_id: Optional[str]) -> int:
+    promoted_count = 0
+    items_index: Dict[str, Dict[str, Any]] = {}
+    for day_entry in daily_posts.values():
+        if not isinstance(day_entry, dict):
+            continue
+        items = day_entry.get("items", [])
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict):
+                items_index[_build_winner_identity_key(item)] = item
+
+    for day_entry in daily_posts.values():
+        if not isinstance(day_entry, dict):
+            continue
+        winners_state = day_entry.get("winners_state")
+        if not isinstance(winners_state, dict):
+            continue
+        winner_entries = winners_state.get("winner_entries")
+        if not isinstance(winner_entries, list):
+            continue
+
+        for winner in winner_entries:
+            if not isinstance(winner, dict):
+                continue
+            winner_key = str(winner.get("winner_key") or "").strip()
+            if not winner_key:
+                continue
+            winner_messages = winners_state.get("winner_messages")
+            winner_message = winner_messages.get(winner_key) if isinstance(winner_messages, dict) else None
+            channel_id = str((winner_message or {}).get("channel_id") or "").strip()
+            message_id = str((winner_message or {}).get("message_id") or "").strip()
+            source_item = items_index.get(winner_key)
+            if (not channel_id or not message_id) and isinstance(source_item, dict):
+                channel_id = str(source_item.get("channel_id") or "").strip()
+                message_id = str(source_item.get("message_id") or "").strip()
+            if not channel_id or not message_id:
+                continue
+
+            users = client.get_reaction_users(
+                channel_id,
+                message_id,
+                BOOKMARK_EMOJI_ENCODED,
+                context=f"library bookmark users {winner_key}",
+                limit=100,
+            )
+            human_user_ids = [str(user.get("id") or "").strip() for user in users if str(user.get("id") or "").strip() and str(user.get("id") or "").strip() != bot_user_id]
+            if not human_user_ids:
+                continue
+
+            raw_title = str(winner.get("title") or (source_item or {}).get("title") or "").strip()
+            url = str(winner.get("url") or (source_item or {}).get("url") or "").strip()
+            # Enhancement 6: for Instagram sources, try to extract a better game name
+            item_source_type = str((source_item or {}).get("source_type") or "").lower()
+            if item_source_type in ("instagram", "creator"):
+                caption = str((source_item or {}).get("description") or "").strip()
+                extracted = _extract_game_name_from_caption(caption, url)
+                if extracted:
+                    canonical_name = extracted
+                else:
+                    # raw_title is typically the creator's username, not a game name
+                    canonical_name = "⚠️ Name needed — use !rename command"
+            else:
+                canonical_name = raw_title or "Untitled"
+            source_metadata = {
+                "winner_key": winner_key,
+                "description": winner.get("description") or (source_item or {}).get("description"),
+                "daily_section": (source_item or {}).get("section"),
+            }
+            identity_key = build_identity_key(canonical_name, url)
+            game_preexisted = identity_key in state.setdefault("games", {})
+            game = ensure_game_entry(
+                state,
+                canonical_name=canonical_name,
+                url=url,
+                source_type=str((source_item or {}).get("source_type") or "winner_promotion"),
+                source_section=str((source_item or {}).get("section") or ""),
+                source_metadata=source_metadata,
+            )
+            assignment_changed = False
+            for user_id in human_user_ids:
+                if assign_user_if_changed(game, user_id, STATUS_ACTIVE):
+                    assignment_changed = True
+            game["archived"] = False
+            refresh_archive_state(game)
+            if (not game_preexisted) or assignment_changed:
+                promoted_count += 1
+    return promoted_count
+
+
+def normalize_user_id_token(user_id_like: str) -> str:
+    token = str(user_id_like or "").strip()
+    if not token:
+        return ""
+    if token.isdigit():
+        return token
+    mention_match = MENTION_USER_ID_PATTERN.fullmatch(token)
+    if mention_match:
+        return mention_match.group(1)
+    return ""
+
+
+def sync_statuses_from_library_posts(state: Dict[str, Any], client: DiscordClient, bot_user_id: Optional[str]) -> int:
+    updates = 0
+    daily_posts = state.get("daily_posts", {})
+    if not isinstance(daily_posts, dict):
+        return 0
+
+    games = state.get("games", {})
+    if not isinstance(games, dict):
+        return 0
+
+    for day_entry in daily_posts.values():
+        if not isinstance(day_entry, dict):
+            continue
+        messages = day_entry.get("messages")
+        if not isinstance(messages, dict):
+            continue
+        for identity_key, message_info in messages.items():
+            if identity_key in {"header", "intro", "footer", "delta"} or identity_key.startswith("section:"):
+                continue
+            if not isinstance(message_info, dict):
+                continue
+            channel_id = str(message_info.get("channel_id") or "").strip()
+            message_id = str(message_info.get("message_id") or "").strip()
+            if not channel_id or not message_id:
+                continue
+            game = games.get(identity_key)
+            if not isinstance(game, dict):
+                continue
+
+            # Collect all status reactions per user
+            user_reactions: Dict[str, List[str]] = {}
+            for encoded_emoji, status in EMOJI_TO_STATUS_ENCODED.items():
+                users = client.get_reaction_users(
+                    channel_id,
+                    message_id,
+                    encoded_emoji,
+                    context=f"library status users {identity_key} {status}",
+                    limit=100,
+                )
+                for user in users:
+                    user_id = str(user.get("id") or "").strip()
+                    if not user_id or user_id == bot_user_id:
+                        continue
+                    user_reactions.setdefault(user_id, []).append(status)
+
+            # Enhancement 9: detect conflicts (multiple status reactions)
+            conflict_users: List[str] = []
+            for user_id, statuses in user_reactions.items():
+                if len(statuses) > 1:
+                    # Conflicting reactions — reset to active
+                    conflict_users.append(user_id)
+                    set_user_status(game, user_id, STATUS_ACTIVE)
+                    updates += 1
+                else:
+                    set_user_status(game, user_id, statuses[0])
+                    updates += 1
+            game["conflicting_users"] = conflict_users
+
+            # E5: Default any assigned player with no valid status to Active.
+            # This covers players assigned before they react, and any legacy data
+            # where a status field is missing or empty.
+            assignments = game.get("assignments", {})
+            if isinstance(assignments, dict):
+                for user_id, assignment in assignments.items():
+                    if not isinstance(assignment, dict):
+                        continue
+                    if assignment.get("status") not in ALLOWED_STATUSES:
+                        set_user_status(game, user_id, STATUS_ACTIVE)
+                        updates += 1
+
+            refresh_archive_state(game)
+    return updates
+
+
+COMMAND_CHECKMARK_ENCODED = quote("✅", safe="")
+
+
+def _parse_command_line(text: str) -> Optional[tuple[str, List[str]]]:
+    """Parse a bot command from a message line. Returns (command, args) or None."""
+    text = text.strip()
+    if not text.startswith("!"):
+        return None
+    parts = text.split()
+    if not parts:
+        return None
+    return parts[0].lower(), parts[1:]
+
+
+def process_library_commands(
+    state: Dict[str, Any],
+    client: DiscordClient,
+    channel_id: str,
+    bot_user_id: Optional[str],
+) -> int:
+    """Read unprocessed !command messages from the channel and apply them to state.
+
+    Returns the number of commands successfully processed.
+    """
+    processed_ids: List[str] = state.setdefault("processed_command_ids", [])
+    processed_set = set(processed_ids)
+    processed_count = 0
+
+    messages = client.get_channel_messages(channel_id, context="library command scan", limit=100)
+    # Messages are returned newest-first; process oldest-first
+    for msg in reversed(messages):
+        msg_id = str(msg.get("id") or "").strip()
+        if not msg_id or msg_id in processed_set:
+            continue
+        author = msg.get("author") or {}
+        author_id = str(author.get("id") or "").strip()
+        if author_id == bot_user_id:
+            continue
+        content = str(msg.get("content") or "").strip()
+        parsed = _parse_command_line(content)
+        if not parsed:
+            continue
+        command, args = parsed
+        ok = False
+        try:
+            ok = _apply_library_command(state, command, args)
+        except Exception:
+            pass
+        if ok:
+            processed_ids.append(msg_id)
+            processed_set.add(msg_id)
+            processed_count += 1
+            try:
+                client.put_reaction(channel_id, msg_id, COMMAND_CHECKMARK_ENCODED, context=f"ack command {msg_id}")
+            except Exception:
+                pass
+
+    return processed_count
+
+
+def _apply_library_command(state: Dict[str, Any], command: str, args: List[str]) -> bool:
+    """Apply a single parsed library command to state. Returns True if applied."""
+    games = state.setdefault("games", {})
+
+    if command == "!add":
+        # !add @user GameName...
+        if len(args) < 2:
+            return False
+        user_token = args[0]
+        user_id = normalize_user_id_token(user_token)
+        if not user_id:
+            return False
+        game_name = " ".join(args[1:])
+        game = _find_game_by_name(games, game_name)
+        if game is None:
+            game = ensure_game_entry(state, canonical_name=game_name, url="", source_type="manual", source_section="manual")
+        assign_user(game, user_id, STATUS_ACTIVE)
+        game["archived"] = False
+        return True
+
+    elif command == "!remove":
+        # !remove @user GameName...
+        if len(args) < 2:
+            return False
+        user_token = args[0]
+        user_id = normalize_user_id_token(user_token)
+        if not user_id:
+            return False
+        game_name = " ".join(args[1:])
+        game = _find_game_by_name(games, game_name)
+        if game is None:
+            return False
+        unassign_user(game, user_id)
+        refresh_archive_state(game)
+        return True
+
+    elif command == "!rename":
+        # !rename OldName NewName (split at last space as new name)
+        if len(args) < 2:
+            return False
+        # Try to match the longest prefix as existing game name
+        game = None
+        new_name = ""
+        for split_at in range(len(args) - 1, 0, -1):
+            candidate_name = " ".join(args[:split_at])
+            candidate_new = " ".join(args[split_at:])
+            found = _find_game_by_name(games, candidate_name)
+            if found is not None:
+                game = found
+                new_name = candidate_new
+                break
+        if game is None or not new_name:
+            return False
+        game["canonical_name"] = new_name
+        game["updated_at_utc"] = utc_now_iso()
+        return True
+
+    elif command == "!unassign":
+        # !unassign @user
+        if not args:
+            return False
+        user_id = normalize_user_id_token(args[0])
+        if not user_id:
+            return False
+        for game in games.values():
+            if isinstance(game, dict):
+                unassign_user(game, user_id)
+                refresh_archive_state(game)
+        return True
+
+    elif command == "!archive":
+        # !archive GameName...
+        if not args:
+            return False
+        game_name = " ".join(args)
+        game = _find_game_by_name(games, game_name)
+        if game is None:
+            return False
+        game["archived"] = True
+        game["updated_at_utc"] = utc_now_iso()
+        return True
+
+    elif command == "!addgame":
+        # !addgame GameName SteamURL @user1 @user2...
+        # First arg that looks like a URL is the steam URL boundary
+        if not args:
+            return False
+        url_idx = None
+        for i, arg in enumerate(args):
+            if arg.startswith("http"):
+                url_idx = i
+                break
+        if url_idx is None or url_idx == 0:
+            return False
+        game_name = " ".join(args[:url_idx])
+        url = args[url_idx]
+        user_tokens = args[url_idx + 1:]
+        user_ids = [normalize_user_id_token(t) for t in user_tokens]
+        user_ids = [u for u in user_ids if u]
+        game = ensure_game_entry(state, canonical_name=game_name, url=url, source_type="manual", source_section="manual")
+        for user_id in user_ids:
+            assign_user(game, user_id, STATUS_ACTIVE)
+        game["archived"] = False
+        refresh_archive_state(game)
+        return True
+
+    return False
+
+
+def _find_game_by_name(games: Dict[str, Any], name: str) -> Optional[Dict[str, Any]]:
+    """Find a game by canonical name (case-insensitive). Returns the game dict or None."""
+    name_lower = name.lower().strip()
+    for game in games.values():
+        if isinstance(game, dict) and game.get("canonical_name", "").lower() == name_lower:
+            return game
+    return None
+
+
+def _notify_health_monitor(message: str) -> None:
+    """Post a warning to the Discord health monitor webhook (best-effort, never raises)."""
+    url = DISCORD_HEALTH_MONITOR_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json={"content": message}, timeout=10)
+    except Exception:
+        pass
+
+
+def _check_channel_permissions(
+    client: DiscordClient,
+    channel_id: str,
+    guild_id: str,
+    context: str,
+    *,
+    bot_user_id: str = "",
+) -> None:
+    """Preflight check: warn if the bot is missing required permissions in a channel.
+
+    Logs a warning and notifies the health monitor if any required permission is
+    missing.  Always returns — the caller continues regardless.
+    """
+    required = {
+        "Send Messages": PERM_SEND_MESSAGES,
+        "Add Reactions": PERM_ADD_REACTIONS,
+        "Read Message History": PERM_READ_MESSAGE_HISTORY,
+        "Manage Messages": PERM_MANAGE_MESSAGES,
+    }
+    try:
+        effective = client.check_bot_permissions(channel_id, guild_id, bot_user_id=bot_user_id)
+    except Exception as exc:
+        print(f"WARN: {context} — could not check bot permissions: {exc}")
+        return
+
+    if effective == 0:
+        print(f"WARN: {context} — could not determine bot permissions for channel {channel_id}")
+        return
+
+    missing = [name for name, flag in required.items() if not (effective & flag)]
+    if not missing:
+        return
+
+    warning = (
+        f"⚠️ {context} — Bot is missing Discord permissions in <#{channel_id}>: "
+        + ", ".join(missing)
+        + ". The bot will attempt to continue but errors may occur."
+    )
+    print(f"WARN: {warning}")
+    _notify_health_monitor(
+        f"⚠️ Gaming Library — Missing Discord Permissions\n\n"
+        f"Context: {context}\n"
+        f"Channel: <#{channel_id}>\n"
+        f"Missing: {', '.join(missing)}\n\n"
+        f"The bot will attempt to continue but errors may occur. "
+        f"Please grant the required permissions to the bot in that channel."
+    )
+
+
+def ensure_command_reference_pinned(
+    state: Dict[str, Any],
+    client: DiscordClient,
+    channel_id: str,
+) -> None:
+    """Post the command reference message and pin it if not already done."""
+    pinned_info = state.get("command_reference_message")
+    existing_msg_id = str((pinned_info or {}).get("message_id") or "").strip()
+    if existing_msg_id:
+        # Already pinned — edit to keep current
+        try:
+            client.edit_message(channel_id, existing_msg_id, COMMAND_REFERENCE_MESSAGE, context="update command reference")
+        except DiscordMessageNotFoundError:
+            existing_msg_id = ""
+    if not existing_msg_id:
+        payload = client.post_message(channel_id, COMMAND_REFERENCE_MESSAGE, context="post command reference")
+        msg_id = str(payload.get("id") or "").strip()
+        if msg_id:
+            try:
+                client.pin_message(channel_id, msg_id, context="pin command reference")
+            except DiscordPermissionError as exc:
+                warning = (
+                    f"⚠️ Bot is missing permission to pin messages in <#{channel_id}>. "
+                    f"The command reference was posted (message ID {msg_id}) but could not be pinned. "
+                    f"Please grant the bot 'Manage Messages' permission in this channel."
+                )
+                print(f"WARN: pin command reference — {exc}")
+                try:
+                    client.post_message(channel_id, warning, context="post pin permission warning")
+                except Exception:
+                    pass
+                _notify_health_monitor(
+                    f"⚠️ Gaming Library — Missing Pin Permission\n\n"
+                    f"Channel: <#{channel_id}>\n"
+                    f"The bot posted the command reference (message ID {msg_id}) but cannot pin it. "
+                    f"Please grant 'Manage Messages' permission to the bot in that channel."
+                )
+            except Exception:
+                pass
+            state["command_reference_message"] = {"message_id": msg_id, "channel_id": channel_id}
+
+
+def run_discord_sync(state_path: str = GAMING_LIBRARY_FILE, daily_posts_path: str = DISCORD_DAILY_POSTS_FILE) -> Dict[str, int]:
+    if not DISCORD_BOT_TOKEN:
+        raise RuntimeError("DISCORD_BOT_TOKEN is not set")
+
+    channel_id = DISCORD_GAMING_LIBRARY_CHANNEL_ID
+    state = load_gaming_library(state_path)
+    daily_posts = load_discord_daily_posts(daily_posts_path)
+
+    with requests.Session() as session:
+        session.headers.update({
+            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+            "Content-Type": "application/json",
+        })
+        client = DiscordClient(session)
+        bot_user = client.get_current_user(context="fetch bot user for gaming library")
+        bot_user_id = str(bot_user.get("id") or "").strip() or None
+
+        if channel_id and DISCORD_GUILD_ID:
+            _check_channel_permissions(
+                client, channel_id, DISCORD_GUILD_ID, "gaming library sync",
+                bot_user_id=bot_user_id or "",
+            )
+
+        promotions = sync_promotions_from_winners(state, daily_posts, client, bot_user_id)
+        status_updates = sync_statuses_from_library_posts(state, client, bot_user_id)
+        commands_processed = 0
+        if channel_id:
+            commands_processed = process_library_commands(state, client, channel_id, bot_user_id)
+            ensure_command_reference_pinned(state, client, channel_id)
+
+    save_gaming_library(state, state_path)
+    return {"promotions": promotions, "status_updates": status_updates, "commands_processed": commands_processed}
+
+
+def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
+    if not DISCORD_BOT_TOKEN:
+        raise RuntimeError("DISCORD_BOT_TOKEN is not set")
+
+    state = load_gaming_library(state_path)
+    day_key = get_target_day_key()
+    channel_id = DISCORD_GAMING_LIBRARY_CHANNEL_ID
+    if not channel_id:
+        raise RuntimeError("DISCORD_GAMING_LIBRARY_CHANNEL_ID is not set")
+
+    manual_run = is_manual_run()
+    if manual_run:
+        print("Gaming library daily post is a manual (workflow_dispatch) run — completed flag will not be set")
+
+    # Save previous day's games for delta comparison
+    state["previous_day_games"] = dict(state.get("games", {}))
+
+    with requests.Session() as session:
+        session.headers.update({
+            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+            "Content-Type": "application/json",
+        })
+        client = DiscordClient(session)
+        if DISCORD_GUILD_ID:
+            _check_channel_permissions(
+                client, channel_id, DISCORD_GUILD_ID, "gaming library daily post",
+            )
+        posted = post_daily_library_reminder(state, day_key=day_key, channel_id=channel_id, client=client, manual_run=manual_run)
+
+    save_gaming_library(state, state_path)
+    return posted
+
+
+def manage_library(
+    *,
+    operation: str,
+    canonical_name: str = "",
+    url: str = "",
+    source_type: str = "",
+    source_section: str = "",
+    source_caption: str = "",
+    identity_key: str = "",
+    user_ids: Optional[List[str]] = None,
+    status: str = STATUS_ACTIVE,
+    archive: Optional[bool] = None,
+    state_path: str = GAMING_LIBRARY_FILE,
+) -> bool:
+    state = load_gaming_library(state_path)
+    normalized_user_ids: List[str] = []
+    for user_id_like in user_ids or []:
+        normalized = normalize_user_id_token(str(user_id_like))
+        if normalized:
+            normalized_user_ids.append(normalized)
+    user_ids = normalized_user_ids
+
+    if operation == "add":
+        game = ensure_game_entry(
+            state,
+            canonical_name=canonical_name,
+            url=url,
+            source_type=source_type or "manual",
+            source_section=source_section or "manual",
+            source_metadata={"original_caption": source_caption} if source_caption else {},
+        )
+        for user_id in user_ids:
+            assign_user(game, user_id, status)
+        if archive is not None:
+            game["archived"] = bool(archive)
+        refresh_archive_state(game)
+    else:
+        target_key = identity_key or build_identity_key(canonical_name, url)
+        game = state.get("games", {}).get(target_key)
+        if not isinstance(game, dict):
+            raise RuntimeError(f"Game not found for key={target_key}")
+
+        if operation == "rename":
+            if not canonical_name:
+                raise RuntimeError("canonical_name is required for rename")
+            game["canonical_name"] = canonical_name
+            game["updated_at_utc"] = utc_now_iso()
+        elif operation == "assign":
+            for user_id in user_ids:
+                assign_user(game, user_id, status)
+            game["archived"] = False
+        elif operation == "unassign":
+            for user_id in user_ids:
+                unassign_user(game, user_id)
+        elif operation == "set_status":
+            for user_id in user_ids:
+                set_user_status(game, user_id, status)
+        elif operation == "archive":
+            game["archived"] = True
+        elif operation == "unarchive":
+            game["archived"] = False
+        else:
+            raise RuntimeError(f"Unsupported operation: {operation}")
+        refresh_archive_state(game)
+
+    save_gaming_library(state, state_path)
+    return True
+
+===== discord_api.py =====
+"""Small Discord API helper utilities with retry and recovery signals."""
+
+import time
+from typing import Any
+
+import requests
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+DISCORD_MESSAGE_HARD_LIMIT = 2000
+DISCORD_MESSAGE_TARGET_LIMIT = 1900
+DEFAULT_TIMEOUT_SECONDS = 30
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+# Discord permission bitflags
+PERM_ADMINISTRATOR = 1 << 3
+PERM_ADD_REACTIONS = 1 << 6
+PERM_VIEW_CHANNEL = 1 << 10
+PERM_SEND_MESSAGES = 1 << 11
+PERM_MANAGE_MESSAGES = 1 << 13
+PERM_READ_MESSAGE_HISTORY = 1 << 16
+
+
+def split_discord_content(
+    content: str,
+    *,
+    target_limit: int = DISCORD_MESSAGE_TARGET_LIMIT,
+    hard_limit: int = DISCORD_MESSAGE_HARD_LIMIT,
+) -> list[str]:
+    """Split long content into Discord-safe chunks with readable boundaries."""
+    text = str(content)
+    if len(text) <= hard_limit:
+        return [text]
+
+    if target_limit <= 0 or hard_limit <= 0:
+        raise ValueError("Discord chunk limits must be positive")
+    if target_limit > hard_limit:
+        target_limit = hard_limit
+
+    chunks: list[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= hard_limit:
+            chunks.append(remaining)
+            break
+
+        window = remaining[:target_limit]
+        split_at = _best_split_index(window)
+        if split_at <= 0:
+            split_at = target_limit
+
+        chunk = remaining[:split_at].rstrip("\n")
+        if not chunk:
+            chunk = remaining[:target_limit]
+            split_at = len(chunk)
+
+        if len(chunk) > hard_limit:
+            chunk = chunk[:hard_limit]
+            split_at = len(chunk)
+
+        chunks.append(chunk)
+        remaining = remaining[split_at:].lstrip("\n")
+
+    for chunk in chunks:
+        if len(chunk) > hard_limit:
+            raise ValueError("Generated Discord chunk exceeded hard limit")
+
+    return chunks
+
+
+def _best_split_index(window: str) -> int:
+    for token in ("\n\n", "\n- ", "\n* ", "\n• ", "\n"):
+        idx = window.rfind(token)
+        if idx > 0:
+            return idx + len(token)
+    return window.rfind(" ")
+
+
+class DiscordApiError(RuntimeError):
+    def __init__(self, message: str, response: requests.Response | None = None):
+        super().__init__(message)
+        self.response = response
+
+
+class DiscordMessageNotFoundError(DiscordApiError):
+    pass
+
+
+class DiscordPermissionError(DiscordApiError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        channel_id: str = "",
+        permission: str = "",
+        response: requests.Response | None = None,
+    ):
+        super().__init__(message, response=response)
+        self.channel_id = channel_id
+        self.permission = permission
+
+
+class DiscordClient:
+    def __init__(self, session: requests.Session, *, timeout: int = DEFAULT_TIMEOUT_SECONDS, max_retries: int = 5):
+        self.session = session
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+    def request(self, method: str, url: str, *, context: str, json_payload: dict[str, Any] | None = None, params: dict[str, Any] | None = None) -> requests.Response:
+        last_error: Exception | None = None
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.session.request(method=method, url=url, json=json_payload, params=params, timeout=self.timeout)
+            except requests.RequestException as error:
+                last_error = error
+                if attempt == self.max_retries:
+                    raise DiscordApiError(f"{context} failed after retries: {error}") from error
+                sleep_seconds = float(attempt)
+                print(f"DISCORD RETRY: {context}; attempt={attempt}/{self.max_retries}; request exception={error}; sleeping {sleep_seconds:.1f}s")
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code in RETRY_STATUSES:
+                if attempt == self.max_retries:
+                    self._raise_for_status(response, context)
+                sleep_seconds = self._get_retry_after_seconds(response, attempt)
+                print(f"DISCORD RETRY: {context}; attempt={attempt}/{self.max_retries}; status={response.status_code}; sleeping {sleep_seconds:.1f}s")
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code == 403:
+                raise DiscordPermissionError(
+                    f"{context}: Discord returned 403 Forbidden — bot is missing permissions",
+                    response=response,
+                )
+
+            if response.status_code == 404 and self._is_unknown_message(response):
+                raise DiscordMessageNotFoundError(f"{context}: Discord message not found", response=response)
+
+            self._raise_for_status(response, context)
+            return response
+
+        raise DiscordApiError(f"{context} exhausted retries unexpectedly: {last_error}")
+
+    def get_message(self, channel_id: str, message_id: str, *, context: str) -> dict[str, Any]:
+        response = self.request("GET", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context)
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def get_current_user(self, *, context: str) -> dict[str, Any]:
+        response = self.request("GET", f"{DISCORD_API_BASE}/users/@me", context=context)
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def get_reaction_users(
+        self,
+        channel_id: str,
+        message_id: str,
+        encoded_emoji: str,
+        *,
+        context: str,
+        limit: int = 100,
+        after: str | None = None,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if after:
+            params["after"] = after
+        response = self.request(
+            "GET",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{encoded_emoji}",
+            context=context,
+            params=params,
+        )
+        return self._parse_json_array(response, f"{context} JSON")
+
+    def post_message(self, channel_id: str, content: str, *, context: str) -> dict[str, Any]:
+        response = self.request("POST", f"{DISCORD_API_BASE}/channels/{channel_id}/messages", context=context, json_payload={"content": content})
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def edit_message(self, channel_id: str, message_id: str, content: str, *, context: str) -> dict[str, Any]:
+        response = self.request("PATCH", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context, json_payload={"content": content})
+        return self._parse_json_object(response, f"{context} JSON")
+
+    def put_reaction(self, channel_id: str, message_id: str, encoded_emoji: str, *, context: str) -> None:
+        self.request("PUT", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{encoded_emoji}/@me", context=context)
+
+    def get_channel_messages(
+        self,
+        channel_id: str,
+        *,
+        context: str,
+        limit: int = 100,
+        before: str | None = None,
+        after: str | None = None,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if before:
+            params["before"] = before
+        if after:
+            params["after"] = after
+        response = self.request("GET", f"{DISCORD_API_BASE}/channels/{channel_id}/messages", context=context, params=params)
+        return self._parse_json_array(response, f"{context} JSON")
+
+    def pin_message(self, channel_id: str, message_id: str, *, context: str) -> None:
+        self.request("PUT", f"{DISCORD_API_BASE}/channels/{channel_id}/pins/{message_id}", context=context)
+
+    def check_bot_permissions(self, channel_id: str, guild_id: str, *, bot_user_id: str = "") -> int:
+        """Return the bot's effective permission bitfield for the given channel.
+
+        Fetches guild member roles, role permissions, and channel permission overwrites,
+        then computes the effective bitfield.  Returns 0 on any API error (best-effort
+        check — the caller should treat 0 as "permissions unknown").
+        """
+        try:
+            member_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/guilds/{guild_id}/members/@me",
+                context="check bot guild member",
+            )
+            member = self._parse_json_object(member_resp, "guild member JSON")
+            bot_role_ids: set[str] = {str(r) for r in member.get("roles", [])}
+
+            roles_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/guilds/{guild_id}/roles",
+                context="check guild roles",
+            )
+            roles = self._parse_json_array(roles_resp, "guild roles JSON")
+
+            base_permissions = 0
+            for role in roles:
+                role_id = str(role.get("id", ""))
+                perms = int(role.get("permissions", 0))
+                if role_id == str(guild_id) or role_id in bot_role_ids:
+                    base_permissions |= perms
+
+            if base_permissions & PERM_ADMINISTRATOR:
+                return (1 << 53) - 1  # all permissions
+
+            channel_resp = self.request(
+                "GET",
+                f"{DISCORD_API_BASE}/channels/{channel_id}",
+                context="check channel overwrites",
+            )
+            channel = self._parse_json_object(channel_resp, "channel JSON")
+            overwrites: list[dict[str, Any]] = [
+                ow for ow in channel.get("permission_overwrites", []) if isinstance(ow, dict)
+            ]
+
+            if not bot_user_id:
+                bot_user = self.get_current_user(context="check bot user for permissions")
+                bot_user_id = str(bot_user.get("id", ""))
+
+            role_allow = role_deny = member_allow = member_deny = 0
+            for ow in overwrites:
+                ow_id = str(ow.get("id", ""))
+                ow_type = int(ow.get("type", -1))
+                ow_allow = int(ow.get("allow", 0))
+                ow_deny = int(ow.get("deny", 0))
+                if ow_type == 0 and (ow_id == str(guild_id) or ow_id in bot_role_ids):
+                    role_allow |= ow_allow
+                    role_deny |= ow_deny
+                elif ow_type == 1 and ow_id == bot_user_id:
+                    member_allow |= ow_allow
+                    member_deny |= ow_deny
+
+            permissions = (base_permissions & ~role_deny) | role_allow
+            permissions = (permissions & ~member_deny) | member_allow
+            return permissions
+        except (DiscordApiError, ValueError, TypeError, KeyError):
+            return 0
+
+    @staticmethod
+    def _parse_json_object(response: requests.Response, context: str) -> dict[str, Any]:
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise DiscordApiError(f"{context} was not valid JSON") from error
+        if not isinstance(payload, dict):
+            raise DiscordApiError(f"{context} did not return an object")
+        return payload
+
+    @staticmethod
+    def _parse_json_array(response: requests.Response, context: str) -> list[dict[str, Any]]:
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise DiscordApiError(f"{context} was not valid JSON") from error
+        if not isinstance(payload, list):
+            raise DiscordApiError(f"{context} did not return an array")
+        parsed: list[dict[str, Any]] = []
+        for item in payload:
+            if isinstance(item, dict):
+                parsed.append(item)
+        return parsed
+
+    @staticmethod
+    def _get_retry_after_seconds(response: requests.Response, attempt: int) -> float:
+        header_value = response.headers.get("Retry-After")
+        if header_value is not None:
+            try:
+                return max(float(header_value), 0.0)
+            except ValueError:
+                pass
+
+        try:
+            payload = response.json()
+            retry_after = payload.get("retry_after")
+            if isinstance(retry_after, (int, float)):
+                return max(float(retry_after), 0.0)
+        except ValueError:
+            pass
+
+        return float(attempt)
+
+    @staticmethod
+    def _is_unknown_message(response: requests.Response) -> bool:
+        try:
+            payload = response.json()
+        except ValueError:
+            return False
+        return isinstance(payload, dict) and int(payload.get("code", 0)) == 10008
+
+    @staticmethod
+    def _raise_for_status(response: requests.Response, context: str) -> None:
+        if response.ok:
+            return
+        body = response.text[:500]
+        raise DiscordApiError(f"{context} failed: HTTP {response.status_code}; body={body}", response=response)
+
+===== scripts/sync_gaming_library.py =====
+from gaming_library import run_discord_sync
+
+
+if __name__ == "__main__":
+    result = run_discord_sync()
+    print(result)
+
+===== scripts/sync_weekly_schedule_responses.py =====
+"""Sync weekly scheduling reactions from Discord into durable JSON state."""
+
+import json
+import hashlib
+import os
+import sys
+import time
+import urllib.parse
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import requests
+
+from discord_api import DiscordClient, DiscordMessageNotFoundError, split_discord_content
+from scripts.scheduling_labels import DAY_NAMES, format_day_label
+from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+REQUEST_TIMEOUT_SECONDS = 30
+USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
+WEEKLY_SCHEDULE_MESSAGES_FILE = "data/scheduling/weekly_schedule_messages.json"
+WEEKLY_SCHEDULE_RESPONSES_FILE = "data/scheduling/weekly_schedule_responses.json"
+WEEKLY_SCHEDULE_SUMMARY_FILE = "data/scheduling/weekly_schedule_summary.json"
+EXPECTED_SCHEDULE_ROSTER_FILE = "data/scheduling/expected_schedule_roster.json"
+WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE = "data/scheduling/weekly_schedule_bot_outputs.json"
+
+AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
+SUMMARY_SLOT_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝"]
+SUMMARY_DISPLAY_ORDER: list[str] = ["✅", "🌅", "☀️", "🌙", "📝", "❌"]
+MAX_SUMMARY_LINE_LENGTH = 185
+NEW_YORK_TIMEZONE = ZoneInfo("America/New_York")
+
+
+def normalize_message_ids(output_state: dict[str, Any], single_key: str, list_key: str) -> list[str]:
+    """Read message ids with backward compatibility for legacy single-id state."""
+    raw_ids = output_state.get(list_key)
+    if isinstance(raw_ids, list):
+        normalized = [str(message_id).strip() for message_id in raw_ids if str(message_id).strip()]
+        if normalized:
+            return normalized
+
+    raw_single = output_state.get(single_key)
+    if isinstance(raw_single, str) and raw_single.strip():
+        return [raw_single.strip()]
+
+    return []
+
+
+def upsert_message_chunks(
+    client: DiscordClient,
+    channel_id: str,
+    chunks: list[str],
+    previous_message_ids: list[str],
+    *,
+    context_prefix: str,
+    stale_placeholder: str,
+) -> list[str]:
+    """Create/edit chunked Discord messages while preserving idempotent reruns."""
+    valid_existing_ids: list[str] = []
+    for index, existing_message_id in enumerate(previous_message_ids, start=1):
+        try:
+            client.get_message(
+                channel_id,
+                existing_message_id,
+                context=f"verify {context_prefix} chunk {index}/{len(previous_message_ids)}",
+            )
+            valid_existing_ids.append(existing_message_id)
+        except DiscordMessageNotFoundError:
+            print(
+                f"RECOVER: stale/deleted {context_prefix} chunk "
+                f"(message_id={existing_message_id}); replacing chunk set"
+            )
+            valid_existing_ids = []
+            break
+
+    resulting_ids: list[str] = []
+    for index, chunk in enumerate(chunks):
+        if index < len(valid_existing_ids):
+            message_id = valid_existing_ids[index]
+            client.edit_message(
+                channel_id,
+                message_id,
+                chunk,
+                context=f"edit {context_prefix} chunk {index + 1}/{len(chunks)}",
+            )
+            resulting_ids.append(message_id)
+        else:
+            payload = client.post_message(
+                channel_id,
+                chunk,
+                context=f"post {context_prefix} chunk {index + 1}/{len(chunks)}",
+            )
+            message_id = str(payload.get("id", ""))
+            if not message_id:
+                fail(f"Discord response JSON did not include id for {context_prefix} chunk")
+            resulting_ids.append(message_id)
+
+    for stale_index in range(len(chunks), len(valid_existing_ids)):
+        stale_id = valid_existing_ids[stale_index]
+        client.edit_message(
+            channel_id,
+            stale_id,
+            stale_placeholder,
+            context=f"clear stale {context_prefix} chunk {stale_index + 1}/{len(valid_existing_ids)}",
+        )
+
+    return resulting_ids
+
+
+def fail(message: str) -> None:
+    """Print an error and exit with a non-zero status."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require_env(name: str) -> str:
+    """Return a required environment variable or exit if it is missing."""
+    value = os.getenv(name)
+    if not value:
+        fail(f"Missing required environment variable: {name}")
+    return value
+
+
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean environment variable with common truthy values."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def check_response(response: requests.Response, context: str) -> None:
+    """Exit with details when a Discord API response is not successful."""
+    if not response.ok:
+        print(f"ERROR: {context}", file=sys.stderr)
+        print(f"HTTP status: {response.status_code}", file=sys.stderr)
+        print(f"Response body: {response.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_json_file(path: str) -> dict[str, Any]:
+    """Load a JSON object from disk."""
+    return load_json_object(path, log=print)
+
+
+def save_json_file(path: str, data: dict[str, Any]) -> None:
+    """Write a JSON object to disk using atomic persistence."""
+    try:
+        save_json_object_atomic(path, data)
+    except OSError as error:
+        fail(f"Failed to write {path}: {error}")
+
+
+def prune_weeks(data: dict[str, Any], keep_last: int = 12) -> dict[str, Any]:
+    """Keep only the latest N week entries ordered by week key."""
+    return prune_latest_keys(data, keep_last=keep_last)
+
+
+def build_current_user_url() -> str:
+    """Build the Discord API URL for fetching the current bot user."""
+    return f"{DISCORD_API_BASE}/users/@me"
+
+
+def build_reaction_users_url(channel_id: str, message_id: str, emoji: str) -> str:
+    """Build the Discord API URL for listing users of a specific message reaction."""
+    encoded_emoji = urllib.parse.quote(emoji, safe="")
+    return (
+        f"{DISCORD_API_BASE}/channels/{channel_id}/messages/"
+        f"{message_id}/reactions/{encoded_emoji}"
+    )
+
+
+def get_bot_user_id(session: requests.Session) -> str:
+    """Fetch and return the current bot user id."""
+    response = session.get(build_current_user_url(), timeout=REQUEST_TIMEOUT_SECONDS)
+    check_response(response, "Failed to fetch current bot user")
+
+    try:
+        payload: dict[str, Any] = response.json()
+    except ValueError:
+        fail("Discord response was not valid JSON when fetching current bot user")
+
+    user_id = payload.get("id")
+    if not user_id:
+        fail("Discord response JSON did not include bot user id")
+
+    return str(user_id)
+
+
+def fetch_reaction_users(
+    session: requests.Session, channel_id: str, message_id: str, emoji: str
+) -> list[dict[str, Any]]:
+    """Fetch all users who reacted with a specific emoji, handling pagination."""
+    all_users: list[dict[str, Any]] = []
+    after_user_id: str | None = None
+
+    while True:
+        params: dict[str, Any] = {"limit": 100}
+        if after_user_id:
+            params["after"] = after_user_id
+
+        for attempt in range(1, 4):
+            response = session.get(
+                build_reaction_users_url(channel_id, message_id, emoji),
+                params=params,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            if response.status_code != 429:
+                break
+
+            retry_after_seconds = 1.0
+            try:
+                payload_429: dict[str, Any] = response.json()
+                retry_after_value = payload_429.get("retry_after")
+                if isinstance(retry_after_value, (int, float)):
+                    retry_after_seconds = float(retry_after_value)
+                elif isinstance(retry_after_value, str):
+                    retry_after_seconds = float(retry_after_value)
+            except (ValueError, TypeError):
+                retry_after_seconds = 1.0
+
+            if retry_after_seconds < 0:
+                retry_after_seconds = 1.0
+
+            if attempt < 3:
+                print(
+                    f"Rate limited fetching reaction users for emoji {emoji}, "
+                    f"sleeping {retry_after_seconds} seconds before retry"
+                )
+                time.sleep(retry_after_seconds)
+
+        check_response(response, f"Failed to fetch reaction users: {emoji}")
+
+        try:
+            payload = response.json()
+        except ValueError:
+            fail(f"Discord response was not valid JSON when fetching reaction users: {emoji}")
+
+        if not isinstance(payload, list):
+            fail(f"Discord reaction users response was not a list for emoji: {emoji}")
+
+        if not payload:
+            break
+
+        page_users: list[dict[str, Any]] = []
+        for raw_user in payload:
+            if not isinstance(raw_user, dict):
+                fail(f"Discord reaction users payload included a non-object for emoji: {emoji}")
+            page_users.append(raw_user)
+
+        all_users.extend(page_users)
+        after_user_id = str(page_users[-1].get("id", ""))
+        if not after_user_id or len(page_users) < 100:
+            break
+
+    return all_users
+
+
+def build_channel_messages_url(channel_id: str) -> str:
+    """Build the Discord API URL for listing messages in a channel."""
+    return f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+
+
+def build_create_message_url(channel_id: str) -> str:
+    """Build the Discord API URL for posting a message in a channel."""
+    return f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+
+
+def build_edit_message_url(channel_id: str, message_id: str) -> str:
+    """Build the Discord API URL for editing an existing channel message."""
+    return f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
+
+
+def fetch_channel_messages(session: requests.Session, channel_id: str) -> list[dict[str, Any]]:
+    """Fetch all messages in a channel, handling pagination."""
+    all_messages: list[dict[str, Any]] = []
+    before_message_id: str | None = None
+
+    while True:
+        params: dict[str, Any] = {"limit": 100}
+        if before_message_id:
+            params["before"] = before_message_id
+
+        response = session.get(
+            build_channel_messages_url(channel_id),
+            params=params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        check_response(response, f"Failed to fetch channel messages for channel_id={channel_id}")
+
+        try:
+            payload = response.json()
+        except ValueError:
+            fail(f"Discord response was not valid JSON when fetching channel {channel_id} messages")
+
+        if not isinstance(payload, list):
+            fail(f"Discord messages response was not a list for channel_id={channel_id}")
+        if not payload:
+            break
+
+        page_messages: list[dict[str, Any]] = []
+        for raw_message in payload:
+            if not isinstance(raw_message, dict):
+                fail(f"Discord messages payload included a non-object for channel_id={channel_id}")
+            page_messages.append(raw_message)
+
+        all_messages.extend(page_messages)
+        before_message_id = str(page_messages[-1].get("id", ""))
+        if not before_message_id or len(page_messages) < 100:
+            break
+
+    return all_messages
+
+
+def collect_latest_custom_replies_by_day(
+    channel_messages: list[dict[str, Any]], day_message_ids: set[str]
+) -> dict[str, dict[str, str]]:
+    """Collect latest non-empty reply text per (day_message_id, user_id)."""
+    latest_reply_ids: dict[str, dict[str, int]] = {}
+    latest_reply_texts: dict[str, dict[str, str]] = {}
+
+    for message in channel_messages:
+        author = message.get("author")
+        if not isinstance(author, dict):
+            continue
+        if bool(author.get("bot")):
+            continue
+
+        user_id = str(author.get("id", ""))
+        if not user_id:
+            continue
+
+        message_reference = message.get("message_reference")
+        if not isinstance(message_reference, dict):
+            continue
+
+        referenced_message_id = str(message_reference.get("message_id", ""))
+        if not referenced_message_id or referenced_message_id not in day_message_ids:
+            continue
+
+        content = normalize_optional_text(message.get("content"))
+        if content is None:
+            continue
+
+        message_id = str(message.get("id", ""))
+        try:
+            message_snowflake = int(message_id)
+        except (TypeError, ValueError):
+            continue
+
+        day_latest_reply_ids = latest_reply_ids.setdefault(referenced_message_id, {})
+        day_latest_reply_texts = latest_reply_texts.setdefault(referenced_message_id, {})
+        existing_id = day_latest_reply_ids.get(user_id)
+        if existing_id is None or message_snowflake > existing_id:
+            day_latest_reply_ids[user_id] = message_snowflake
+            day_latest_reply_texts[user_id] = content
+
+    return latest_reply_texts
+
+
+def build_weekly_summary(weekly_responses: dict[str, Any]) -> dict[str, Any]:
+    """Build derived weekly summary with day/slot overlap and voter details."""
+    summary_by_week: dict[str, Any] = {}
+
+    for week_key, week_data in weekly_responses.items():
+        if not isinstance(week_data, dict):
+            continue
+
+        users = week_data.get("users")
+        if not isinstance(users, dict):
+            continue
+
+        day_counts: dict[str, int] = {day: 0 for day in DAY_NAMES}
+        slot_counts: dict[str, dict[str, int]] = {
+            day: {slot: 0 for slot in SUMMARY_SLOT_ORDER} for day in DAY_NAMES
+        }
+        slot_voters: dict[str, dict[str, list[dict[str, str]]]] = {
+            day: {slot: [] for slot in SUMMARY_SLOT_ORDER} for day in DAY_NAMES
+        }
+
+        for user_id, user_data in users.items():
+            if not isinstance(user_data, dict):
+                continue
+
+            display_name = normalize_optional_text(user_data.get("global_name")) or normalize_optional_text(
+                user_data.get("username")
+            )
+            if display_name is None:
+                display_name = f"User {user_id}"
+
+            days = user_data.get("days")
+            if not isinstance(days, dict):
+                continue
+
+            for day_name in DAY_NAMES:
+                day_entry = days.get(day_name, {})
+                reactions: list[str] = []
+                if isinstance(day_entry, dict):
+                    raw_reactions = day_entry.get("reactions", [])
+                    if isinstance(raw_reactions, list):
+                        reactions = [reaction for reaction in raw_reactions if isinstance(reaction, str)]
+                elif isinstance(day_entry, list):
+                    reactions = [reaction for reaction in day_entry if isinstance(reaction, str)]
+
+                reaction_set = set(reactions)
+                if reaction_set.intersection(SUMMARY_SLOT_ORDER):
+                    day_counts[day_name] += 1
+
+                for slot in SUMMARY_SLOT_ORDER:
+                    if slot in reaction_set:
+                        slot_counts[day_name][slot] += 1
+                        slot_voters[day_name][slot].append(
+                            {
+                                "user_id": str(user_id),
+                                "display_name": display_name,
+                            }
+                        )
+
+        best_overlap_day, best_overlap_slot = max(
+            [(day_name, slot) for day_name in DAY_NAMES for slot in SUMMARY_SLOT_ORDER],
+            key=lambda item: (
+                slot_counts[item[0]][item[1]],
+                -DAY_NAMES.index(item[0]),
+                -SUMMARY_SLOT_ORDER.index(item[1]),
+            ),
+        )
+
+        summary_by_week[week_key] = {
+            "week_key": week_key,
+            "date_range": week_data.get("date_range"),
+            "summary": {
+                "day_counts": day_counts,
+                "slot_counts": slot_counts,
+                "slot_voters": slot_voters,
+                "best_overlap": {
+                    "day": best_overlap_day,
+                    "slot": best_overlap_slot,
+                    "count": slot_counts[best_overlap_day][best_overlap_slot],
+                },
+            },
+        }
+
+    return prune_weeks(summary_by_week, keep_last=12)
+
+
+def normalize_optional_text(value: Any) -> str | None:
+    """Return a stripped string value when present, otherwise None."""
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def get_week_channel_id(week_data: dict[str, Any], week_key: str) -> str:
+    """Return channel_id from weekly state with a fallback for legacy thread_id data."""
+    channel_id = week_data.get("channel_id")
+    if isinstance(channel_id, str) and channel_id:
+        return channel_id
+
+    legacy_thread_id = week_data.get("thread_id")
+    if isinstance(legacy_thread_id, str) and legacy_thread_id:
+        print(
+            f"Legacy thread_id detected for {week_key}; "
+            "using it as channel_id for backward compatibility"
+        )
+        return legacy_thread_id
+
+    fail(f"Missing or invalid channel_id for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+
+
+def compute_missing_user_ids_for_week(
+    week_responses: dict[str, Any], roster: dict[str, Any]
+) -> list[str]:
+    """Return sorted active roster user IDs with no reactions on every day."""
+    users = roster.get("users")
+    if not isinstance(users, dict):
+        fail(f"Missing or invalid users object in {EXPECTED_SCHEDULE_ROSTER_FILE}")
+
+    week_users = week_responses.get("users")
+    if not isinstance(week_users, dict):
+        fail("Missing or invalid users object in current week responses")
+
+    missing_user_ids: list[str] = []
+    for user_id in sorted(users, key=lambda value: int(value)):
+        roster_user = users.get(user_id)
+        if not isinstance(roster_user, dict):
+            continue
+        if roster_user.get("is_active") is not True:
+            continue
+
+        response_user = week_users.get(user_id)
+        has_any_reaction = False
+        if isinstance(response_user, dict):
+            days = response_user.get("days")
+            if isinstance(days, dict):
+                for day_name in DAY_NAMES:
+                    day_entry = days.get(day_name)
+                    if not isinstance(day_entry, dict):
+                        continue
+                    reactions = day_entry.get("reactions")
+                    if isinstance(reactions, list) and any(
+                        isinstance(reaction, str) and reaction in AVAILABILITY_REACTIONS
+                        for reaction in reactions
+                    ):
+                        has_any_reaction = True
+                        break
+
+        if not has_any_reaction:
+            missing_user_ids.append(user_id)
+
+    return missing_user_ids
+
+
+def format_reminder_message(date_range: str, missing_user_ids: list[str]) -> str:
+    """Build a deterministic reminder message for users missing availability reactions."""
+    display_lines = [f"- <@{user_id}>" for user_id in missing_user_ids]
+
+    lines = [
+        f"⏰ Still waiting on availability for {date_range}",
+        "",
+        "Please react on the day messages if you have not responded yet:",
+        "",
+        *display_lines,
+    ]
+    return "\n".join(lines)
+
+
+def parse_week_start_date(week_key: str) -> date | None:
+    """Parse a week key like YYYY-MM-DD_to_YYYY-MM-DD."""
+    try:
+        start_text, _, _ = week_key.partition("_to_")
+        return datetime.strptime(start_text, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def parse_start_date_from_date_range(date_range: str) -> date | None:
+    """Parse date range text like 'Apr 13–19, 2026' and return its start date."""
+    cleaned = date_range.replace("—", "–")
+    try:
+        month_day, _, year_text = cleaned.partition(",")
+        month_text, _, day_range = month_day.strip().partition(" ")
+        start_day_text, _, _ = day_range.partition("–")
+        if not month_text or not start_day_text or not year_text.strip():
+            return None
+        return datetime.strptime(
+            f"{month_text} {start_day_text.strip()} {year_text.strip()}",
+            "%b %d %Y",
+        ).date()
+    except ValueError:
+        return None
+
+
+def compute_week_dates_from_summary(week_summary: dict[str, Any]) -> dict[str, date]:
+    """Map weekday names to concrete dates using week key or date range context."""
+    week_key = week_summary.get("week_key")
+    if isinstance(week_key, str):
+        start = parse_week_start_date(week_key)
+        if start is not None:
+            return {
+                day_name: start + timedelta(days=index)
+                for index, day_name in enumerate(DAY_NAMES)
+            }
+
+    date_range = week_summary.get("date_range")
+    if isinstance(date_range, str):
+        maybe_start = parse_start_date_from_date_range(date_range)
+        if maybe_start is not None:
+            return {
+                day_name: maybe_start + timedelta(days=index)
+                for index, day_name in enumerate(DAY_NAMES)
+            }
+
+    return {}
+
+
+def count_active_roster_users(roster: dict[str, Any]) -> int:
+    """Return the number of active users from the expected roster."""
+    users = roster.get("users")
+    if not isinstance(users, dict):
+        fail(f"Missing or invalid users object in {EXPECTED_SCHEDULE_ROSTER_FILE}")
+    return sum(
+        1
+        for user in users.values()
+        if isinstance(user, dict) and user.get("is_active") is True
+    )
+
+
+def format_summary_last_updated_line(synced_at_utc: datetime) -> str:
+    """Format a compact New York last-updated line for summary output."""
+    ny_time = synced_at_utc.astimezone(NEW_YORK_TIMEZONE)
+    month_day = f"{ny_time.strftime('%b')} {ny_time.day}"
+    hour_12 = ((ny_time.hour - 1) % 12) + 1
+    minute = f"{ny_time.minute:02d}"
+    am_pm = ny_time.strftime("%p")
+    return f"*Last updated: {month_day}, {hour_12}:{minute} {am_pm} ET*"
+
+
+def format_summary_message(
+    date_range: str,
+    week_summary: dict[str, Any],
+    *,
+    responded_count: int,
+    active_user_count: int,
+    synced_at_utc: datetime,
+) -> str:
+    """Build a richer deterministic summary message from weekly summary data."""
+    summary = week_summary.get("summary")
+    if not isinstance(summary, dict):
+        fail("Missing or invalid summary object for current week")
+
+    day_counts = summary.get("day_counts")
+    slot_counts = summary.get("slot_counts")
+    slot_voters = summary.get("slot_voters")
+
+    if not isinstance(day_counts, dict):
+        fail("Missing or invalid day_counts in current week summary")
+    if not isinstance(slot_counts, dict):
+        fail("Missing or invalid slot_counts in current week summary")
+    if not isinstance(slot_voters, dict):
+        slot_voters = {}
+
+    week_dates = compute_week_dates_from_summary(week_summary)
+
+    def day_with_date_label(day_name: str) -> str:
+        day_date = week_dates.get(day_name)
+        if day_date is None:
+            return day_name
+        return format_day_label(day_name, day_date)
+
+    def format_voter_line(day_name: str, slot: str, slot_count: int) -> str:
+        raw_day_slot_voters = slot_voters.get(day_name)
+        raw_voters = []
+        if isinstance(raw_day_slot_voters, dict):
+            raw_voters = raw_day_slot_voters.get(slot, [])
+
+        voter_names: list[str] = []
+        seen_names: set[str] = set()
+        if isinstance(raw_voters, list):
+            for raw_voter in raw_voters:
+                if not isinstance(raw_voter, dict):
+                    continue
+                display_name = normalize_optional_text(raw_voter.get("display_name"))
+                if display_name is None or display_name in seen_names:
+                    continue
+                seen_names.add(display_name)
+                voter_names.append(display_name)
+
+        base_prefix = f"{slot} {slot_count} — "
+        if not voter_names:
+            return f"{base_prefix}(names unavailable)"
+
+        full_line = f"{base_prefix}{', '.join(voter_names)}"
+        if len(full_line) <= MAX_SUMMARY_LINE_LENGTH:
+            return full_line
+
+        kept_names: list[str] = []
+        for index, name in enumerate(voter_names):
+            remaining_after = len(voter_names) - (index + 1)
+            candidate_names = ", ".join([*kept_names, name])
+            if remaining_after > 0:
+                candidate_line = f"{base_prefix}{candidate_names}, +{remaining_after} more"
+            else:
+                candidate_line = f"{base_prefix}{candidate_names}"
+            if len(candidate_line) <= MAX_SUMMARY_LINE_LENGTH:
+                kept_names.append(name)
+            else:
+                break
+
+        if not kept_names:
+            return f"{base_prefix}+{len(voter_names)} more"
+
+        remaining = len(voter_names) - len(kept_names)
+        if remaining > 0:
+            return f"{base_prefix}{', '.join(kept_names)}, +{remaining} more"
+        return f"{base_prefix}{', '.join(kept_names)}"
+
+    def build_day_slot_lines(day_name: str) -> list[str]:
+        raw_day_slot_counts = slot_counts.get(day_name)
+        if not isinstance(raw_day_slot_counts, dict):
+            raw_day_slot_counts = {}
+
+        ordered_lines: list[str] = []
+        for slot in SUMMARY_DISPLAY_ORDER:
+            slot_count = int(raw_day_slot_counts.get(slot, 0))
+            if slot_count > 0:
+                ordered_lines.append(format_voter_line(day_name, slot, slot_count))
+        return ordered_lines
+
+    chronological_day_lines: list[str] = []
+    for index, day_name in enumerate(DAY_NAMES):
+        chronological_day_lines.append(f"**{day_with_date_label(day_name)}**")
+        day_slot_lines = build_day_slot_lines(day_name)
+        if day_slot_lines:
+            chronological_day_lines.extend(day_slot_lines)
+        else:
+            chronological_day_lines.append("No responses")
+        if index < len(DAY_NAMES) - 1:
+            chronological_day_lines.append("")
+
+    missing_count = max(active_user_count - responded_count, 0)
+    response_status_line = (
+        f"*{responded_count} of {active_user_count} people responded • "
+        f"{missing_count} still missing*"
+    )
+    last_updated_line = format_summary_last_updated_line(synced_at_utc)
+    lines = [
+        f"📊 Availability Summary — {date_range}",
+        "",
+        response_status_line,
+        last_updated_line,
+        "",
+        *chronological_day_lines,
+    ]
+
+    message = "\n".join(lines)
+    if len(message) <= 2000:
+        return message
+
+    fallback_lines = [
+        f"📊 Availability Summary — {date_range}",
+        "",
+        response_status_line,
+        last_updated_line,
+        "",
+        *(f"**{day_with_date_label(day_name)}**" for day_name in DAY_NAMES),
+        "",
+        "_Detailed voter names were truncated to fit Discord message limits._",
+    ]
+    return "\n".join(fallback_lines)
+
+
+def compute_summary_data_signature(
+    week_summary: dict[str, Any],
+    responded_count: int,
+    active_user_count: int,
+    missing_user_ids: list[str],
+) -> str:
+    """Hash meaningful summary inputs to detect real summary-data changes."""
+    normalized_missing_user_ids = sorted(missing_user_ids)
+    signature_payload = {
+        "week_summary": week_summary,
+        "responded_count": responded_count,
+        "active_user_count": active_user_count,
+        "missing_user_ids": normalized_missing_user_ids,
+    }
+    stable_payload = json.dumps(signature_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(stable_payload.encode("utf-8")).hexdigest()
+
+
+def parse_iso_utc_datetime(value: Any) -> datetime | None:
+    """Parse an ISO timestamp into an aware UTC datetime."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def post_channel_message(session: requests.Session, channel_id: str, content: str) -> str:
+    """Post a message to a Discord channel and return the new message id."""
+    response = session.post(
+        build_create_message_url(channel_id),
+        json={"content": content},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    check_response(response, f"Failed to post channel message for channel_id={channel_id}")
+
+    try:
+        payload: dict[str, Any] = response.json()
+    except ValueError:
+        fail("Discord response was not valid JSON when posting channel message")
+
+    message_id = payload.get("id")
+    if not message_id:
+        fail("Discord response JSON did not include posted message id")
+
+    return str(message_id)
+
+
+def edit_channel_message(
+    session: requests.Session, channel_id: str, message_id: str, content: str
+) -> None:
+    """Edit an existing Discord channel message in place."""
+    response = session.patch(
+        build_edit_message_url(channel_id, message_id),
+        json={"content": content},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    check_response(
+        response,
+        f"Failed to edit channel message for channel_id={channel_id}, message_id={message_id}",
+    )
+
+
+def current_new_york_local_date() -> str:
+    """Return the current New York calendar date in ISO format."""
+    return datetime.now(NEW_YORK_TIMEZONE).date().isoformat()
+
+
+def main() -> None:
+    """Fetch and persist reaction responses for recorded scheduled weeks."""
+    token = require_env("DISCORD_SCHEDULING_BOT_TOKEN")
+
+    weekly_messages = load_json_file(WEEKLY_SCHEDULE_MESSAGES_FILE)
+    existing_weekly_responses = load_json_file(WEEKLY_SCHEDULE_RESPONSES_FILE)
+    roster = load_json_file(EXPECTED_SCHEDULE_ROSTER_FILE)
+    weekly_bot_outputs = load_json_file(WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE)
+    if not weekly_messages:
+        print("No weekly message state found; nothing to sync")
+        return
+
+    target_week_key = normalize_optional_text(os.getenv("TARGET_WEEK_KEY"))
+    rebuild_summary_only = env_flag("REBUILD_SUMMARY_ONLY", default=False)
+    dry_run = env_flag("DRY_RUN", default=False)
+
+    if target_week_key:
+        if target_week_key not in weekly_messages:
+            fail(
+                f"TARGET_WEEK_KEY={target_week_key} not found in {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+            )
+        week_keys = [target_week_key]
+    else:
+        week_keys = sorted(weekly_messages.keys())[-12:]
+
+    weekly_responses: dict[str, Any] = {}
+    for week_key, week_payload in existing_weekly_responses.items():
+        if isinstance(week_payload, dict):
+            weekly_responses[week_key] = week_payload
+
+    if rebuild_summary_only:
+        print(
+            f"Rebuild-only mode enabled; skipping reaction fetch for {len(week_keys)} "
+            f"week(s): {', '.join(week_keys)}"
+        )
+    else:
+        print(f"Starting weekly schedule response sync for {len(week_keys)} week(s)")
+        with requests.Session() as session:
+            session.headers.update(
+                {
+                    "Authorization": f"Bot {token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": USER_AGENT,
+                }
+            )
+
+            bot_user_id = get_bot_user_id(session)
+            print(f"Fetched bot user (user_id={bot_user_id})")
+
+            for week_key in week_keys:
+                latest_week_data = weekly_messages.get(week_key)
+                if not isinstance(latest_week_data, dict):
+                    fail(f"Invalid week payload for {week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+
+                channel_id = get_week_channel_id(latest_week_data, week_key)
+                date_range = latest_week_data.get("date_range")
+                days = latest_week_data.get("days")
+
+                if not date_range or not isinstance(date_range, str):
+                    fail(
+                        f"Missing or invalid date_range for {week_key} "
+                        f"in {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+                    )
+                if not isinstance(days, dict):
+                    fail(
+                        f"Missing or invalid days mapping for {week_key} "
+                        f"in {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+                    )
+
+                users_map: dict[str, dict[str, Any]] = {}
+                day_message_ids = {str(day_id) for day_id in days.values() if day_id}
+                channel_messages = fetch_channel_messages(session, channel_id)
+                latest_custom_replies = collect_latest_custom_replies_by_day(
+                    channel_messages, day_message_ids
+                )
+                for day_name in DAY_NAMES:
+                    day_message_id = days.get(day_name)
+                    if not day_message_id:
+                        fail(
+                            f"Missing message ID for {day_name} in week {week_key} "
+                            f"from {WEEKLY_SCHEDULE_MESSAGES_FILE}"
+                        )
+
+                    for reaction in AVAILABILITY_REACTIONS:
+                        reaction_users = fetch_reaction_users(
+                            session, channel_id, str(day_message_id), reaction
+                        )
+                        for user in reaction_users:
+                            user_id = str(user.get("id", ""))
+                            if not user_id:
+                                continue
+
+                            if user_id == bot_user_id:
+                                continue
+                            if bool(user.get("bot")):
+                                continue
+
+                            if user_id not in users_map:
+                                users_map[user_id] = {
+                                    "username": normalize_optional_text(user.get("username")),
+                                    "global_name": normalize_optional_text(user.get("global_name")),
+                                    "days": {
+                                        day: {
+                                            "reactions": [],
+                                            "custom_reply": None,
+                                        }
+                                        for day in DAY_NAMES
+                                    },
+                                }
+                            else:
+                                if users_map[user_id]["username"] is None:
+                                    users_map[user_id]["username"] = normalize_optional_text(
+                                        user.get("username")
+                                    )
+                                if users_map[user_id]["global_name"] is None:
+                                    users_map[user_id]["global_name"] = normalize_optional_text(
+                                        user.get("global_name")
+                                    )
+
+                            day_entry = users_map[user_id]["days"][day_name]
+                            if reaction not in day_entry["reactions"]:
+                                day_entry["reactions"].append(reaction)
+
+                            if reaction == "📝":
+                                custom_reply = latest_custom_replies.get(str(day_message_id), {}).get(
+                                    user_id
+                                )
+                                day_entry["custom_reply"] = custom_reply
+
+                stable_users_map = {
+                    user_id: users_map[user_id]
+                    for user_id in sorted(users_map, key=lambda value: int(value))
+                }
+                weekly_responses[week_key] = {
+                    "date_range": date_range,
+                    "users": stable_users_map,
+                }
+                print(f"Synced week {week_key}")
+
+    pruned_weekly_responses = prune_weeks(weekly_responses, keep_last=12)
+    save_json_file(WEEKLY_SCHEDULE_RESPONSES_FILE, pruned_weekly_responses)
+    weekly_summary = build_weekly_summary(pruned_weekly_responses)
+    save_json_file(WEEKLY_SCHEDULE_SUMMARY_FILE, weekly_summary)
+
+    posting_week_key = target_week_key or sorted(pruned_weekly_responses.keys())[-1]
+    posting_week_messages = weekly_messages.get(posting_week_key)
+    posting_week_responses = pruned_weekly_responses.get(posting_week_key)
+    posting_week_summary = weekly_summary.get(posting_week_key)
+    if not isinstance(posting_week_messages, dict):
+        fail(f"Missing week payload for {posting_week_key} in {WEEKLY_SCHEDULE_MESSAGES_FILE}")
+    if not isinstance(posting_week_responses, dict):
+        fail(f"Missing week payload for {posting_week_key} in {WEEKLY_SCHEDULE_RESPONSES_FILE}")
+    if not isinstance(posting_week_summary, dict):
+        fail(f"Missing week payload for {posting_week_key} in {WEEKLY_SCHEDULE_SUMMARY_FILE}")
+
+    channel_id = get_week_channel_id(posting_week_messages, posting_week_key)
+    date_range = posting_week_messages.get("date_range")
+    if not isinstance(date_range, str) or not date_range:
+        fail(f"Missing or invalid date_range for {posting_week_key}")
+
+    missing_user_ids = compute_missing_user_ids_for_week(posting_week_responses, roster)
+    active_user_count = count_active_roster_users(roster)
+    # "Responded" means active roster users minus users still missing per reminder logic.
+    responded_active_user_count = max(active_user_count - len(missing_user_ids), 0)
+    summary_synced_at_utc = datetime.now(timezone.utc)
+    week_outputs = weekly_bot_outputs.get(posting_week_key)
+    if not isinstance(week_outputs, dict):
+        week_outputs = {}
+
+    with requests.Session() as posting_session:
+        posting_session.headers.update(
+            {
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+            }
+        )
+        discord_client = DiscordClient(posting_session)
+
+        previous_summary_message_ids = normalize_message_ids(
+            week_outputs,
+            "summary_message_id",
+            "summary_message_ids",
+        )
+        previous_summary_message_content = week_outputs.get("summary_message_content")
+        previous_summary_data_signature = normalize_optional_text(
+            week_outputs.get("summary_data_signature")
+        )
+        previous_summary_last_synced_at_utc = parse_iso_utc_datetime(
+            week_outputs.get("summary_last_synced_at_utc")
+        )
+        current_summary_data_signature = compute_summary_data_signature(
+            posting_week_summary,
+            responded_count=responded_active_user_count,
+            active_user_count=active_user_count,
+            missing_user_ids=missing_user_ids,
+        )
+        is_legacy_summary_without_signature = (
+            previous_summary_data_signature is None
+            and isinstance(previous_summary_message_content, str)
+            and bool(previous_summary_message_content)
+        )
+        summary_data_changed = (
+            previous_summary_data_signature != current_summary_data_signature
+            if previous_summary_data_signature is not None
+            else not is_legacy_summary_without_signature
+        )
+
+        if summary_data_changed:
+            effective_summary_synced_at_utc = summary_synced_at_utc
+            week_outputs["summary_last_synced_at_utc"] = (
+                effective_summary_synced_at_utc.isoformat()
+            )
+        else:
+            effective_summary_synced_at_utc = previous_summary_last_synced_at_utc
+
+        if (
+            not summary_data_changed
+            and isinstance(previous_summary_message_content, str)
+            and previous_summary_message_content
+        ):
+            summary_message = previous_summary_message_content
+        else:
+            if effective_summary_synced_at_utc is None:
+                effective_summary_synced_at_utc = summary_synced_at_utc
+            summary_message = format_summary_message(
+                date_range,
+                posting_week_summary,
+                responded_count=responded_active_user_count,
+                active_user_count=active_user_count,
+                synced_at_utc=effective_summary_synced_at_utc,
+            )
+
+        week_outputs["summary_data_signature"] = current_summary_data_signature
+
+        summary_chunks = split_discord_content(summary_message)
+
+        if dry_run:
+            print(f"DRY_RUN: summary preview for {posting_week_key}")
+            print(summary_message)
+            print(f"DRY_RUN: skipping Discord summary and reminder mutations for {posting_week_key}")
+        elif not previous_summary_message_ids:
+            summary_message_ids = upsert_message_chunks(
+                discord_client,
+                channel_id,
+                summary_chunks,
+                [],
+                context_prefix=f"summary for {posting_week_key}",
+                stale_placeholder="_(Summary content moved to earlier message chunks.)_",
+            )
+            week_outputs["summary_posted"] = True
+            week_outputs["summary_message_id"] = summary_message_ids[0]
+            week_outputs["summary_message_ids"] = summary_message_ids
+            week_outputs["summary_message_content"] = summary_message
+            print(
+                f"CREATE: posted summary for week {posting_week_key} "
+                f"(message_ids={summary_message_ids})"
+            )
+        elif previous_summary_message_content != summary_message:
+            try:
+                summary_message_ids = upsert_message_chunks(
+                    discord_client,
+                    channel_id,
+                    summary_chunks,
+                    previous_summary_message_ids,
+                    context_prefix=f"summary for {posting_week_key}",
+                    stale_placeholder="_(Summary content moved to earlier message chunks.)_",
+                )
+                week_outputs["summary_posted"] = True
+                week_outputs["summary_message_id"] = summary_message_ids[0]
+                week_outputs["summary_message_ids"] = summary_message_ids
+                week_outputs["summary_message_content"] = summary_message
+                print(
+                    f"EDIT: updated summary for week {posting_week_key} "
+                    f"(message_ids={summary_message_ids})"
+                )
+            except DiscordMessageNotFoundError:
+                summary_message_ids = upsert_message_chunks(
+                    discord_client,
+                    channel_id,
+                    summary_chunks,
+                    [],
+                    context_prefix=f"recover summary for {posting_week_key}",
+                    stale_placeholder="_(Summary content moved to earlier message chunks.)_",
+                )
+                week_outputs["summary_posted"] = True
+                week_outputs["summary_message_id"] = summary_message_ids[0]
+                week_outputs["summary_message_ids"] = summary_message_ids
+                week_outputs["summary_message_content"] = summary_message
+                print(
+                    f"RECOVER: posted replacement summary for week {posting_week_key} "
+                    f"(message_ids={summary_message_ids})"
+                )
+        else:
+            print(f"SKIP: summary unchanged for week {posting_week_key}; skipping summary edit")
+
+        if not dry_run:
+            previous_missing_users = week_outputs.get("reminder_missing_users")
+            if not isinstance(previous_missing_users, list):
+                previous_missing_users = []
+            previous_missing_users = [str(user_id) for user_id in previous_missing_users]
+            last_reminder_local_date = normalize_optional_text(
+                week_outputs.get("last_reminder_local_date")
+            )
+            reminder_local_date = current_new_york_local_date()
+
+            if missing_user_ids:
+                if missing_user_ids != previous_missing_users:
+                    if last_reminder_local_date == reminder_local_date:
+                        print(
+                            f"SKIP: reminder already posted on New York date "
+                            f"{reminder_local_date} for week {posting_week_key}; skipping reminder post"
+                        )
+                    else:
+                        reminder_message = format_reminder_message(date_range, missing_user_ids)
+                        reminder_chunks = split_discord_content(reminder_message)
+                        reminder_message_ids = normalize_message_ids(
+                            week_outputs,
+                            "reminder_message_id",
+                            "reminder_message_ids",
+                        )
+                        updated_reminder_ids = upsert_message_chunks(
+                            discord_client,
+                            channel_id,
+                            reminder_chunks,
+                            reminder_message_ids,
+                            context_prefix=f"reminder for {posting_week_key}",
+                            stale_placeholder="_(Reminder content moved to earlier message chunks.)_",
+                        )
+                        week_outputs["reminder_message_id"] = updated_reminder_ids[0]
+                        week_outputs["reminder_message_ids"] = updated_reminder_ids
+                        week_outputs["reminder_missing_users"] = missing_user_ids
+                        week_outputs["last_reminder_local_date"] = reminder_local_date
+                        print(
+                            f"CREATE: posted reminder for week {posting_week_key} "
+                            f"(message_ids={updated_reminder_ids}, missing={len(missing_user_ids)}, "
+                            f"ny_date={reminder_local_date})"
+                        )
+                else:
+                    print(
+                        f"SKIP: reminder unchanged for week {posting_week_key}; "
+                        "skipping reminder post"
+                    )
+            else:
+                week_outputs["reminder_missing_users"] = []
+                print(f"SKIP: no missing users for week {posting_week_key}; skipping reminder post")
+
+    weekly_bot_outputs[posting_week_key] = week_outputs
+    pruned_bot_outputs = prune_weeks(weekly_bot_outputs, keep_last=12)
+    save_json_file(WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE, pruned_bot_outputs)
+    print(
+        f"Saved weekly schedule responses for {len(pruned_weekly_responses)} week(s) "
+        f"to {WEEKLY_SCHEDULE_RESPONSES_FILE}"
+    )
+    print(
+        f"Saved weekly schedule summary for {len(weekly_summary)} week(s) "
+        f"to {WEEKLY_SCHEDULE_SUMMARY_FILE}"
+    )
+    print(
+        f"Saved weekly schedule bot outputs for {len(pruned_bot_outputs)} week(s) "
+        f"to {WEEKLY_SCHEDULE_BOT_OUTPUTS_FILE}"
+    )
+    print("Finished successfully")
+
+
+if __name__ == "__main__":
+    main()
+
+===== scripts/read_discord_channel.py =====
+<file does not exist>
+
+===== .github/workflows/daily.yml =====
+name: Steam Free Games
+
+on:
+  workflow_dispatch:
+    inputs:
+      daily_date_utc:
+        description: "Optional UTC date key (YYYY-MM-DD) for manual rerun state targeting"
+        required: false
+        type: string
+      force_refresh_same_day:
+        description: "When true, reconcile/edit same-day Discord posts instead of skipping completed runs"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # GitHub Actions cron uses UTC only (no timezone/DST support).
+    # This runs at 13:00 UTC year-round: 9:00 AM in New York during EDT, 8:00 AM during EST.
+    - cron: "0 13 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download repository
+        uses: actions/checkout@v5
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install packages
+        run: pip install -r requirements.txt
+
+      - name: Restore Instagram session
+        shell: bash
+        run: |
+          echo "${{ secrets.INSTAGRAM_SESSION_B64 }}" | base64 -d > instaloader.session
+
+      - name: Sanity-check state files
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+        run: python scripts/check_state_sanity.py
+
+      - name: Upload state sanity artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: state-sanity-${{ github.run_id }}
+          path: state_sanity.json
+          if-no-files-found: ignore
+
+      - name: Run Steam script
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_DEBUG_CHANNEL_ID: ${{ secrets.DISCORD_DEBUG_CHANNEL_ID }}
+          INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
+          FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: python main.py
+
+      - name: Verify Discord output
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
+        run: python scripts/verify_discord_output.py
+
+      - name: Upload verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-verification-${{ github.run_id }}
+          path: daily_verification.json
+          if-no-files-found: ignore
+
+      - name: Upload Discord verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-verification-${{ github.run_id }}
+          path: discord_verification.json
+          if-no-files-found: ignore
+
+      - name: Save updated state files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add seen_ids.json page_state.json instagram_seen.json
+          if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
+
+          if ! git diff --cached --quiet; then
+            git commit -m "Update bot state"
+            git stash --include-untracked || true
+            git pull --rebase origin main
+            git stash pop || true
+          fi
+          git push
+
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: run-script
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DAILY_DATE_UTC: ${{ inputs.daily_date_utc || '' }}
+          FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+
+          target = os.environ.get("DAILY_DATE_UTC")
+          force = str(os.environ.get("FORCE_REFRESH_SAME_DAY", "")).strip().lower() in {"1", "true", "yes", "on"}
+          details = f"daily_date_utc={target}" if target else "daily_date_utc=(default)"
+          details = f"{details}, force_refresh_same_day={'true' if force else 'false'}"
+          print(json.dumps({
+              "content": (
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"
+
+===== .github/workflows/evening-winners.yml =====
+name: Daily Game Picks Winners
+
+on:
+  workflow_dispatch:
+    inputs:
+      winners_date_utc:
+        description: "Optional UTC date key (YYYY-MM-DD) for manual winners rerun"
+        required: false
+        type: string
+  schedule:
+    # GitHub Actions cron uses UTC only (no timezone/DST support).
+    # This runs at 23:00 UTC year-round: 7:00 PM in New York during EDT, 6:00 PM during EST.
+    - cron: "0 23 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  run-evening-winners:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download repository
+        uses: actions/checkout@v5
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install packages
+        run: pip install -r requirements.txt
+
+      - name: Run evening winners script
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: python evening_winners.py
+
+      - name: Save updated winners state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
+
+          if ! git diff --cached --quiet; then
+            git commit -m "Update winners state"
+            git stash --include-untracked || true
+            git pull --rebase origin main
+            git stash pop || true
+          fi
+          git push
+
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: run-evening-winners
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WINNERS_DATE_UTC: ${{ inputs.winners_date_utc || '' }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+
+          target = os.environ.get("WINNERS_DATE_UTC")
+          details = f"winners_date_utc={target}" if target else "winners_date_utc=(default)"
+          print(json.dumps({
+              "content": (
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"
+
+===== .github/workflows/gaming-library-daily.yml =====
+name: Gaming Library Daily Reminder
+
+on:
+  workflow_dispatch:
+    inputs:
+      library_date_utc:
+        description: "Optional UTC date key (YYYY-MM-DD) for manual rerun"
+        required: false
+        type: string
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gaming-library-state
+  cancel-in-progress: false
+
+jobs:
+  run-gaming-library-daily:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download repository
+        uses: actions/checkout@v5
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install packages
+        run: pip install -r requirements.txt
+
+      - name: Post daily gaming library reminder
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: python scripts/post_daily_gaming_library.py
+
+      - name: Verify gaming library output
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
+        run: python scripts/verify_gaming_library.py
+
+      - name: Upload gaming library verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gaming-library-verification-${{ github.run_id }}
+          path: gaming_library_verification.json
+          if-no-files-found: ignore
+
+      - name: Save updated gaming library state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -f gaming_library.json ]; then git add gaming_library.json; fi
+
+          if ! git diff --cached --quiet; then
+            git commit -m "Update gaming library daily state"
+            git stash --include-untracked || true
+            git pull --rebase origin main
+            git stash pop || true
+          fi
+          git push
+
+      - name: Notify Discord health monitor on failure
+        if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          JOB_NAME: run-gaming-library-daily
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LIBRARY_DATE_UTC: ${{ inputs.library_date_utc || '' }}
+        run: |
+          payload="$(python - <<'PY'
+          import json
+          import os
+
+          target = os.environ.get("LIBRARY_DATE_UTC")
+          details = f"library_date_utc={target}" if target else "library_date_utc=(default)"
+          print(json.dumps({
+              "content": (
+                  "🔴 XiannGPT Bot Failure\n\n"
+                  f"Workflow: {os.environ['WORKFLOW_NAME']}\n"
+                  f"Job: {os.environ['JOB_NAME']}\n"
+                  "Status: failed\n"
+                  f"Context: {details}\n"
+                  f"Run: {os.environ['RUN_URL']}"
+              )
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            --header "Content-Type: application/json" \
+            --header "User-Agent: steam-discord-free-games-health-monitor/1.0" \
+            --data "${payload}" \
+            --request POST \
+            "${DISCORD_HEALTH_MONITOR_WEBHOOK_URL}")"
+
+          if [[ "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Discord webhook POST succeeded: HTTP ${http_status}"
+          else
+            echo "Discord webhook POST failed: HTTP ${http_status}" >&2
+            if [[ -s "${response_file}" ]]; then
+              cat "${response_file}" >&2
+            fi
+            rm -f "${response_file}"
+            exit 1
+          fi
+
+          rm -f "${response_file}"
+


### PR DESCRIPTION
### Motivation
- Provide a single, reviewable snapshot of the repository's key bot and workflow files to make auditing and debugging easier by capturing exact raw file contents in one place.

### Description
- Create `repo_dump.txt` at the repository root containing the exact raw contents of the requested files in the specified order and including the placeholder `<file does not exist>` for `scripts/read_discord_channel.py` when the file is absent.

### Testing
- Verified presence/absence of each source file with the existence check `for f in ...; do if [ -f "$f" ]; then echo "exists $f"; else echo "missing $f"; fi; done` and confirmed `scripts/read_discord_channel.py` is missing. (succeeded)
- Built `repo_dump.txt` by concatenating each file section into the output and validated the result with `wc -l repo_dump.txt` and sample `nl`/`sed` checks. (succeeded)
- Committed the new file with `git add repo_dump.txt && git commit -m "Add repo_dump.txt with raw contents of key bot files"` and opened a PR titled `Add repo_dump.txt containing raw bot file contents`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03940e0b48326a2200effd3424144)