### PR TITLE
feat: add scripts/read_discord_channel.py — autonomous validation loop foundation (#213)

### DIFF
--- a/scripts/read_discord_channel.py
+++ b/scripts/read_discord_channel.py
@@ -1,0 +1,296 @@
+"""Read Discord channel messages and save snapshots to data/.
+
+Fetches the last 50 messages from up to 5 channels and writes each to a
+structured JSON file under data/:
+  - data/snapshot_step1.json
+  - data/snapshot_step2.json
+  - data/snapshot_step3.json
+  - data/snapshot_schedule.json
+  - data/snapshot_health.json
+
+Channel IDs are resolved from environment variables:
+  DISCORD_BOT_TOKEN            — required for all reads
+  DISCORD_STEP1_CHANNEL_ID     — step-1 channel; falls back to webhook lookup
+  DISCORD_WEBHOOK_URL          — used to look up step-1 channel if DISCORD_STEP1_CHANNEL_ID unset
+  DISCORD_WINNERS_CHANNEL_ID   — step-2
+  DISCORD_GAMING_LIBRARY_CHANNEL_ID — step-3
+  DISCORD_SCHEDULING_CHANNEL_ID — schedule channel
+  DISCORD_HEALTH_MONITOR_CHANNEL_ID — health monitor channel; falls back to webhook lookup
+  DISCORD_HEALTH_MONITOR_WEBHOOK_URL — used if DISCORD_HEALTH_MONITOR_CHANNEL_ID unset
+
+Usage:
+    # Fetch all 5 channels
+    PYTHONPATH=. DISCORD_BOT_TOKEN=<token> python scripts/read_discord_channel.py
+
+    # Fetch a specific channel by name
+    PYTHONPATH=. DISCORD_BOT_TOKEN=<token> python scripts/read_discord_channel.py --channel step1
+
+    # Fetch with custom message limit
+    PYTHONPATH=. DISCORD_BOT_TOKEN=<token> python scripts/read_discord_channel.py --limit 20
+
+Exit codes:
+    0 — all requested channels fetched (or gracefully skipped)
+    1 — DISCORD_BOT_TOKEN not set
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from discord_api import DISCORD_API_BASE, DiscordApiError, DiscordClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_MESSAGE_LIMIT = 50
+
+CHANNEL_STEP1 = "step-1-vote-on-games-to-test"
+CHANNEL_STEP2 = "step-2-test-then-vote-to-keep"
+CHANNEL_STEP3 = "step-3-review-existing-games"
+CHANNEL_SCHEDULE = "update-weekly-schedule-here"
+CHANNEL_HEALTH = "xiann-gpt-bot-health-monitor"
+
+DATA_DIR = ROOT / "data"
+
+SNAPSHOT_FILES = {
+    "step1": DATA_DIR / "snapshot_step1.json",
+    "step2": DATA_DIR / "snapshot_step2.json",
+    "step3": DATA_DIR / "snapshot_step3.json",
+    "schedule": DATA_DIR / "snapshot_schedule.json",
+    "health": DATA_DIR / "snapshot_health.json",
+}
+
+CHANNEL_NAMES = {
+    "step1": CHANNEL_STEP1,
+    "step2": CHANNEL_STEP2,
+    "step3": CHANNEL_STEP3,
+    "schedule": CHANNEL_SCHEDULE,
+    "health": CHANNEL_HEALTH,
+}
+
+
+# ---------------------------------------------------------------------------
+# Channel ID resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_webhook_channel_id(webhook_url: str, client: DiscordClient) -> str | None:
+    """Resolve the channel_id for a Discord webhook by calling the webhook URL.
+
+    The Discord API returns the webhook object (including channel_id) when
+    you GET the webhook URL with no auth header required.
+    """
+    if not webhook_url:
+        return None
+    try:
+        response = client.request("GET", webhook_url, context="resolve webhook channel_id")
+        payload = response.json()
+        if isinstance(payload, dict):
+            channel_id = payload.get("channel_id")
+            if channel_id:
+                return str(channel_id)
+    except (DiscordApiError, Exception) as exc:
+        print(f"WARN: could not resolve channel_id from webhook URL: {exc}")
+    return None
+
+
+def resolve_channel_ids(client: DiscordClient) -> dict[str, str | None]:
+    """Return a dict mapping channel key → channel_id (or None if unresolvable)."""
+    ids: dict[str, str | None] = {}
+
+    # Step 1 — prefer explicit env var; fall back to webhook lookup
+    step1_channel = (os.getenv("DISCORD_STEP1_CHANNEL_ID") or "").strip() or None
+    if not step1_channel:
+        webhook_url = (os.getenv("DISCORD_WEBHOOK_URL") or "").strip()
+        if webhook_url:
+            step1_channel = _resolve_webhook_channel_id(webhook_url, client)
+            if step1_channel:
+                print(f"INFO: resolved step-1 channel_id={step1_channel} from DISCORD_WEBHOOK_URL")
+            else:
+                print("WARN: DISCORD_STEP1_CHANNEL_ID not set and webhook lookup failed — step-1 will be skipped")
+        else:
+            print("WARN: DISCORD_STEP1_CHANNEL_ID and DISCORD_WEBHOOK_URL not set — step-1 will be skipped")
+    ids["step1"] = step1_channel
+
+    ids["step2"] = (os.getenv("DISCORD_WINNERS_CHANNEL_ID") or "").strip() or None
+    if not ids["step2"]:
+        print("WARN: DISCORD_WINNERS_CHANNEL_ID not set — step-2 will be skipped")
+
+    ids["step3"] = (os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID") or "").strip() or None
+    if not ids["step3"]:
+        print("WARN: DISCORD_GAMING_LIBRARY_CHANNEL_ID not set — step-3 will be skipped")
+
+    ids["schedule"] = (os.getenv("DISCORD_SCHEDULING_CHANNEL_ID") or "").strip() or None
+    if not ids["schedule"]:
+        print("WARN: DISCORD_SCHEDULING_CHANNEL_ID not set — schedule will be skipped")
+
+    # Health monitor — prefer explicit channel ID; fall back to webhook lookup
+    health_channel = (os.getenv("DISCORD_HEALTH_MONITOR_CHANNEL_ID") or "").strip() or None
+    if not health_channel:
+        health_webhook_url = (os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL") or "").strip()
+        if health_webhook_url:
+            health_channel = _resolve_webhook_channel_id(health_webhook_url, client)
+            if health_channel:
+                print(f"INFO: resolved health-monitor channel_id={health_channel} from DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
+            else:
+                print("WARN: DISCORD_HEALTH_MONITOR_CHANNEL_ID not set and webhook lookup failed — health will be skipped")
+        else:
+            print("WARN: DISCORD_HEALTH_MONITOR_CHANNEL_ID and DISCORD_HEALTH_MONITOR_WEBHOOK_URL not set — health will be skipped")
+    ids["health"] = health_channel
+
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Snapshot building
+# ---------------------------------------------------------------------------
+
+def _format_reaction(reaction: dict[str, Any]) -> dict[str, Any]:
+    emoji = reaction.get("emoji", {})
+    emoji_name = emoji.get("name", "")
+    emoji_id = emoji.get("id")
+    count = int(reaction.get("count", 0))
+    return {"emoji": emoji_name, "count": count, **({"emoji_id": emoji_id} if emoji_id else {})}
+
+
+def _format_message(msg: dict[str, Any]) -> dict[str, Any]:
+    author = msg.get("author", {})
+    author_name = author.get("global_name") or author.get("username") or ""
+    reactions = [_format_reaction(r) for r in msg.get("reactions", [])]
+    return {
+        "id": str(msg.get("id", "")),
+        "author": author_name,
+        "content": msg.get("content", ""),
+        "timestamp": msg.get("timestamp", ""),
+        "reactions": reactions,
+    }
+
+
+def fetch_channel_snapshot(
+    client: DiscordClient,
+    channel_key: str,
+    channel_id: str,
+    *,
+    limit: int = DEFAULT_MESSAGE_LIMIT,
+) -> dict[str, Any]:
+    """Fetch up to `limit` messages from a channel and return a snapshot dict."""
+    channel_name = CHANNEL_NAMES[channel_key]
+    fetched_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"  Fetching {channel_name} (channel_id={channel_id}, limit={limit})...")
+
+    messages = client.get_channel_messages(
+        channel_id,
+        context=f"read_discord_channel {channel_name}",
+        limit=limit,
+    )
+
+    formatted = [_format_message(m) for m in messages]
+    print(f"  → fetched {len(formatted)} messages")
+
+    return {
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "fetched_at": fetched_at,
+        "messages": formatted,
+    }
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+def write_snapshot(channel_key: str, snapshot: dict[str, Any]) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = SNAPSHOT_FILES[channel_key]
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, indent=2, ensure_ascii=False)
+    print(f"  → wrote {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fetch Discord channel messages and save snapshots.")
+    parser.add_argument(
+        "--channel",
+        choices=list(SNAPSHOT_FILES.keys()),
+        default=None,
+        help="Fetch only this channel. Omit to fetch all 5 channels.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_MESSAGE_LIMIT,
+        help=f"Maximum messages to fetch per channel (default: {DEFAULT_MESSAGE_LIMIT}).",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if not token:
+        print("ERROR: DISCORD_BOT_TOKEN is not set.")
+        sys.exit(1)
+
+    session = requests.Session()
+    session.headers.update({
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    })
+    client = DiscordClient(session)
+
+    # Determine which channels to fetch
+    if args.channel:
+        channels_to_fetch = [args.channel]
+    else:
+        channels_to_fetch = list(SNAPSHOT_FILES.keys())
+
+    print("Resolving channel IDs...")
+    channel_ids = resolve_channel_ids(client)
+
+    errors: list[str] = []
+
+    for key in channels_to_fetch:
+        channel_id = channel_ids.get(key)
+        if not channel_id:
+            print(f"SKIP: {key} — no channel_id available")
+            continue
+
+        print(f"\nFetching {key}...")
+        try:
+            snapshot = fetch_channel_snapshot(client, key, channel_id, limit=args.limit)
+            write_snapshot(key, snapshot)
+        except DiscordApiError as exc:
+            msg = f"ERROR fetching {key} (channel_id={channel_id}): {exc}"
+            print(msg)
+            errors.append(msg)
+        except Exception as exc:
+            msg = f"ERROR fetching {key} (channel_id={channel_id}): unexpected error: {exc}"
+            print(msg)
+            errors.append(msg)
+
+    if errors:
+        print(f"\nCompleted with {len(errors)} error(s):")
+        for err in errors:
+            print(f"  {err}")
+    else:
+        print("\nAll channels fetched successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/read_discord_channel.py
+++ b/scripts/read_discord_channel.py
@@ -8,19 +8,30 @@ structured JSON file under data/:
   - data/snapshot_schedule.json
   - data/snapshot_health.json
 
+There are two separate bot tokens in this repo:
+  DISCORD_BOT_TOKEN           — used for step-1, step-2, step-3, and health-monitor reads
+  DISCORD_SCHEDULING_BOT_TOKEN — used for the weekly schedule channel
+
 Channel IDs are resolved from environment variables:
-  DISCORD_BOT_TOKEN            — required for all reads
+  DISCORD_BOT_TOKEN            — required for step-1/step-2/step-3 reads
+  DISCORD_SCHEDULING_BOT_TOKEN — required for schedule channel read
   DISCORD_STEP1_CHANNEL_ID     — step-1 channel; falls back to webhook lookup
   DISCORD_WEBHOOK_URL          — used to look up step-1 channel if DISCORD_STEP1_CHANNEL_ID unset
   DISCORD_WINNERS_CHANNEL_ID   — step-2
   DISCORD_GAMING_LIBRARY_CHANNEL_ID — step-3
   DISCORD_SCHEDULING_CHANNEL_ID — schedule channel
-  DISCORD_HEALTH_MONITOR_CHANNEL_ID — health monitor channel; falls back to webhook lookup
-  DISCORD_HEALTH_MONITOR_WEBHOOK_URL — used if DISCORD_HEALTH_MONITOR_CHANNEL_ID unset
+  DISCORD_HEALTH_MONITOR_CHANNEL_ID — health monitor channel (read via DISCORD_BOT_TOKEN)
+  DISCORD_HEALTH_MONITOR_WEBHOOK_URL — used to look up health monitor channel_id if
+                                        DISCORD_HEALTH_MONITOR_CHANNEL_ID unset
+
+Note on health monitor: the health monitor channel can only be posted to via webhook.
+Reading requires the main bot token (DISCORD_BOT_TOKEN) to have read access to the
+channel. If the bot lacks access, the health snapshot is skipped with a warning.
 
 Usage:
     # Fetch all 5 channels
-    PYTHONPATH=. DISCORD_BOT_TOKEN=<token> python scripts/read_discord_channel.py
+    PYTHONPATH=. DISCORD_BOT_TOKEN=<token> DISCORD_SCHEDULING_BOT_TOKEN=<token2> \\
+        python scripts/read_discord_channel.py
 
     # Fetch a specific channel by name
     PYTHONPATH=. DISCORD_BOT_TOKEN=<token> python scripts/read_discord_channel.py --channel step1
@@ -80,6 +91,30 @@ CHANNEL_NAMES = {
     "health": CHANNEL_HEALTH,
 }
 
+# Which bot token each channel key uses
+# step-1/step-2/step-3/health: DISCORD_BOT_TOKEN
+# schedule: DISCORD_SCHEDULING_BOT_TOKEN
+CHANNEL_TOKEN_ENV = {
+    "step1": "DISCORD_BOT_TOKEN",
+    "step2": "DISCORD_BOT_TOKEN",
+    "step3": "DISCORD_BOT_TOKEN",
+    "schedule": "DISCORD_SCHEDULING_BOT_TOKEN",
+    "health": "DISCORD_BOT_TOKEN",
+}
+
+
+# ---------------------------------------------------------------------------
+# Client factory
+# ---------------------------------------------------------------------------
+
+def _make_client(token: str) -> DiscordClient:
+    session = requests.Session()
+    session.headers.update({
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    })
+    return DiscordClient(session)
+
 
 # ---------------------------------------------------------------------------
 # Channel ID resolution
@@ -105,22 +140,30 @@ def _resolve_webhook_channel_id(webhook_url: str, client: DiscordClient) -> str 
     return None
 
 
-def resolve_channel_ids(client: DiscordClient) -> dict[str, str | None]:
-    """Return a dict mapping channel key → channel_id (or None if unresolvable)."""
+def resolve_channel_ids(clients: dict[str, DiscordClient]) -> dict[str, str | None]:
+    """Return a dict mapping channel key → channel_id (or None if unresolvable).
+
+    `clients` maps token env-var name → DiscordClient (may be empty for tokens
+    that weren't set).
+    """
     ids: dict[str, str | None] = {}
+    main_client = clients.get("DISCORD_BOT_TOKEN")
+    sched_client = clients.get("DISCORD_SCHEDULING_BOT_TOKEN")
 
     # Step 1 — prefer explicit env var; fall back to webhook lookup
     step1_channel = (os.getenv("DISCORD_STEP1_CHANNEL_ID") or "").strip() or None
-    if not step1_channel:
+    if not step1_channel and main_client:
         webhook_url = (os.getenv("DISCORD_WEBHOOK_URL") or "").strip()
         if webhook_url:
-            step1_channel = _resolve_webhook_channel_id(webhook_url, client)
+            step1_channel = _resolve_webhook_channel_id(webhook_url, main_client)
             if step1_channel:
                 print(f"INFO: resolved step-1 channel_id={step1_channel} from DISCORD_WEBHOOK_URL")
             else:
                 print("WARN: DISCORD_STEP1_CHANNEL_ID not set and webhook lookup failed — step-1 will be skipped")
         else:
             print("WARN: DISCORD_STEP1_CHANNEL_ID and DISCORD_WEBHOOK_URL not set — step-1 will be skipped")
+    elif not step1_channel:
+        print("WARN: DISCORD_BOT_TOKEN not set — step-1 will be skipped")
     ids["step1"] = step1_channel
 
     ids["step2"] = (os.getenv("DISCORD_WINNERS_CHANNEL_ID") or "").strip() or None
@@ -134,19 +177,24 @@ def resolve_channel_ids(client: DiscordClient) -> dict[str, str | None]:
     ids["schedule"] = (os.getenv("DISCORD_SCHEDULING_CHANNEL_ID") or "").strip() or None
     if not ids["schedule"]:
         print("WARN: DISCORD_SCHEDULING_CHANNEL_ID not set — schedule will be skipped")
+    elif not sched_client:
+        print("WARN: DISCORD_SCHEDULING_BOT_TOKEN not set — schedule will be skipped")
+        ids["schedule"] = None
 
     # Health monitor — prefer explicit channel ID; fall back to webhook lookup
     health_channel = (os.getenv("DISCORD_HEALTH_MONITOR_CHANNEL_ID") or "").strip() or None
-    if not health_channel:
+    if not health_channel and main_client:
         health_webhook_url = (os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL") or "").strip()
         if health_webhook_url:
-            health_channel = _resolve_webhook_channel_id(health_webhook_url, client)
+            health_channel = _resolve_webhook_channel_id(health_webhook_url, main_client)
             if health_channel:
                 print(f"INFO: resolved health-monitor channel_id={health_channel} from DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
             else:
                 print("WARN: DISCORD_HEALTH_MONITOR_CHANNEL_ID not set and webhook lookup failed — health will be skipped")
         else:
             print("WARN: DISCORD_HEALTH_MONITOR_CHANNEL_ID and DISCORD_HEALTH_MONITOR_WEBHOOK_URL not set — health will be skipped")
+    elif not health_channel:
+        print("WARN: DISCORD_BOT_TOKEN not set — health will be skipped")
     ids["health"] = health_channel
 
     return ids
@@ -242,17 +290,21 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def main() -> None:
     args = build_arg_parser().parse_args()
 
-    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
-    if not token:
+    main_token = (os.getenv("DISCORD_BOT_TOKEN") or "").strip()
+    if not main_token:
         print("ERROR: DISCORD_BOT_TOKEN is not set.")
         sys.exit(1)
 
-    session = requests.Session()
-    session.headers.update({
-        "Authorization": f"Bot {token}",
-        "Content-Type": "application/json",
-    })
-    client = DiscordClient(session)
+    sched_token = (os.getenv("DISCORD_SCHEDULING_BOT_TOKEN") or "").strip()
+    if not sched_token:
+        print("WARN: DISCORD_SCHEDULING_BOT_TOKEN not set — schedule channel will be skipped")
+
+    # Build one client per distinct token
+    clients: dict[str, DiscordClient] = {
+        "DISCORD_BOT_TOKEN": _make_client(main_token),
+    }
+    if sched_token:
+        clients["DISCORD_SCHEDULING_BOT_TOKEN"] = _make_client(sched_token)
 
     # Determine which channels to fetch
     if args.channel:
@@ -261,7 +313,7 @@ def main() -> None:
         channels_to_fetch = list(SNAPSHOT_FILES.keys())
 
     print("Resolving channel IDs...")
-    channel_ids = resolve_channel_ids(client)
+    channel_ids = resolve_channel_ids(clients)
 
     errors: list[str] = []
 
@@ -269,6 +321,12 @@ def main() -> None:
         channel_id = channel_ids.get(key)
         if not channel_id:
             print(f"SKIP: {key} — no channel_id available")
+            continue
+
+        token_env = CHANNEL_TOKEN_ENV[key]
+        client = clients.get(token_env)
+        if not client:
+            print(f"SKIP: {key} — token {token_env} not set")
             continue
 
         print(f"\nFetching {key}...")

--- a/tests/test_read_discord_channel.py
+++ b/tests/test_read_discord_channel.py
@@ -1,0 +1,311 @@
+"""Tests for scripts/read_discord_channel.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers to import the module under test
+# ---------------------------------------------------------------------------
+
+import sys
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.read_discord_channel import (
+    CHANNEL_NAMES,
+    SNAPSHOT_FILES,
+    _format_message,
+    _format_reaction,
+    fetch_channel_snapshot,
+    resolve_channel_ids,
+    write_snapshot,
+)
+from discord_api import DiscordApiError, DiscordClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_client(messages: list[dict[str, Any]] | None = None, raise_error: bool = False) -> DiscordClient:
+    """Return a mocked DiscordClient."""
+    client = MagicMock(spec=DiscordClient)
+    if raise_error:
+        client.get_channel_messages.side_effect = DiscordApiError("test error")
+    else:
+        client.get_channel_messages.return_value = messages or []
+    return client
+
+
+def _raw_message(
+    msg_id: str = "111",
+    username: str = "BotUser",
+    content: str = "hello",
+    timestamp: str = "2026-04-15T09:00:00.000000+00:00",
+    reactions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": msg_id,
+        "author": {"username": username, "global_name": username},
+        "content": content,
+        "timestamp": timestamp,
+        "reactions": reactions or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _format_reaction
+# ---------------------------------------------------------------------------
+
+class TestFormatReaction:
+    def test_basic_unicode_emoji(self) -> None:
+        raw = {"emoji": {"name": "👍", "id": None}, "count": 5}
+        result = _format_reaction(raw)
+        assert result["emoji"] == "👍"
+        assert result["count"] == 5
+        assert "emoji_id" not in result
+
+    def test_custom_emoji_includes_id(self) -> None:
+        raw = {"emoji": {"name": "pepe", "id": "999"}, "count": 2}
+        result = _format_reaction(raw)
+        assert result["emoji"] == "pepe"
+        assert result["count"] == 2
+        assert result["emoji_id"] == "999"
+
+    def test_missing_fields_handled(self) -> None:
+        result = _format_reaction({})
+        assert result["emoji"] == ""
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _format_message
+# ---------------------------------------------------------------------------
+
+class TestFormatMessage:
+    def test_basic_fields(self) -> None:
+        raw = _raw_message(msg_id="123", username="Bot", content="ping")
+        result = _format_message(raw)
+        assert result["id"] == "123"
+        assert result["author"] == "Bot"
+        assert result["content"] == "ping"
+        assert isinstance(result["reactions"], list)
+
+    def test_global_name_preferred_over_username(self) -> None:
+        raw = _raw_message()
+        raw["author"] = {"username": "bot_internal", "global_name": "XiannGPT Bot"}
+        result = _format_message(raw)
+        assert result["author"] == "XiannGPT Bot"
+
+    def test_reactions_formatted(self) -> None:
+        raw = _raw_message(reactions=[{"emoji": {"name": "👍", "id": None}, "count": 3}])
+        result = _format_message(raw)
+        assert len(result["reactions"]) == 1
+        assert result["reactions"][0]["emoji"] == "👍"
+        assert result["reactions"][0]["count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# fetch_channel_snapshot
+# ---------------------------------------------------------------------------
+
+class TestFetchChannelSnapshot:
+    def test_returns_correct_structure(self) -> None:
+        msgs = [_raw_message(msg_id=str(i)) for i in range(3)]
+        client = _make_client(messages=msgs)
+        snapshot = fetch_channel_snapshot(client, "step1", "12345", limit=50)
+        assert snapshot["channel_id"] == "12345"
+        assert snapshot["channel_name"] == CHANNEL_NAMES["step1"]
+        assert "fetched_at" in snapshot
+        assert len(snapshot["messages"]) == 3
+
+    def test_messages_have_required_fields(self) -> None:
+        msgs = [_raw_message(msg_id="42", username="Bot", content="test")]
+        client = _make_client(messages=msgs)
+        snapshot = fetch_channel_snapshot(client, "step2", "999", limit=10)
+        msg = snapshot["messages"][0]
+        assert "id" in msg
+        assert "author" in msg
+        assert "content" in msg
+        assert "timestamp" in msg
+        assert "reactions" in msg
+
+    def test_empty_channel_returns_empty_messages(self) -> None:
+        client = _make_client(messages=[])
+        snapshot = fetch_channel_snapshot(client, "step3", "111", limit=50)
+        assert snapshot["messages"] == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_channel_ids — missing env vars handled gracefully
+# ---------------------------------------------------------------------------
+
+class TestResolveChannelIds:
+    def test_all_env_vars_set(self) -> None:
+        env = {
+            "DISCORD_STEP1_CHANNEL_ID": "ch1",
+            "DISCORD_WINNERS_CHANNEL_ID": "ch2",
+            "DISCORD_GAMING_LIBRARY_CHANNEL_ID": "ch3",
+            "DISCORD_SCHEDULING_CHANNEL_ID": "ch4",
+            "DISCORD_HEALTH_MONITOR_CHANNEL_ID": "ch5",
+        }
+        client = MagicMock(spec=DiscordClient)
+        with patch.dict("os.environ", env, clear=False):
+            ids = resolve_channel_ids(client)
+        assert ids["step1"] == "ch1"
+        assert ids["step2"] == "ch2"
+        assert ids["step3"] == "ch3"
+        assert ids["schedule"] == "ch4"
+        assert ids["health"] == "ch5"
+
+    def test_missing_step2_returns_none(self) -> None:
+        env = {
+            "DISCORD_STEP1_CHANNEL_ID": "ch1",
+            "DISCORD_GAMING_LIBRARY_CHANNEL_ID": "ch3",
+            "DISCORD_SCHEDULING_CHANNEL_ID": "ch4",
+            "DISCORD_HEALTH_MONITOR_CHANNEL_ID": "ch5",
+        }
+        client = MagicMock(spec=DiscordClient)
+        with patch.dict("os.environ", env, clear=False):
+            # Remove DISCORD_WINNERS_CHANNEL_ID from environment
+            import os as _os
+            orig = _os.environ.pop("DISCORD_WINNERS_CHANNEL_ID", None)
+            try:
+                ids = resolve_channel_ids(client)
+            finally:
+                if orig is not None:
+                    _os.environ["DISCORD_WINNERS_CHANNEL_ID"] = orig
+        assert ids["step2"] is None
+
+    def test_all_env_vars_missing_returns_all_none(self) -> None:
+        """When no channel IDs are set and no webhooks given, all resolve to None."""
+        keys_to_clear = [
+            "DISCORD_STEP1_CHANNEL_ID",
+            "DISCORD_WINNERS_CHANNEL_ID",
+            "DISCORD_GAMING_LIBRARY_CHANNEL_ID",
+            "DISCORD_SCHEDULING_CHANNEL_ID",
+            "DISCORD_HEALTH_MONITOR_CHANNEL_ID",
+            "DISCORD_WEBHOOK_URL",
+            "DISCORD_HEALTH_MONITOR_WEBHOOK_URL",
+        ]
+        import os as _os
+        originals = {k: _os.environ.pop(k, None) for k in keys_to_clear}
+        client = MagicMock(spec=DiscordClient)
+        try:
+            ids = resolve_channel_ids(client)
+        finally:
+            for k, v in originals.items():
+                if v is not None:
+                    _os.environ[k] = v
+
+        for key in ("step1", "step2", "step3", "schedule", "health"):
+            assert ids[key] is None, f"Expected {key} to be None, got {ids[key]}"
+
+    def test_step1_falls_back_to_webhook_lookup(self) -> None:
+        """When DISCORD_STEP1_CHANNEL_ID absent, resolves via webhook URL."""
+        import os as _os
+        orig_step1 = _os.environ.pop("DISCORD_STEP1_CHANNEL_ID", None)
+        orig_webhook = _os.environ.get("DISCORD_WEBHOOK_URL")
+        _os.environ["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/123/abc"
+        client = MagicMock(spec=DiscordClient)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"channel_id": "from_webhook"}
+        client.request.return_value = mock_response
+        try:
+            ids = resolve_channel_ids(client)
+        finally:
+            if orig_step1 is not None:
+                _os.environ["DISCORD_STEP1_CHANNEL_ID"] = orig_step1
+            elif "DISCORD_STEP1_CHANNEL_ID" in _os.environ:
+                del _os.environ["DISCORD_STEP1_CHANNEL_ID"]
+            if orig_webhook is not None:
+                _os.environ["DISCORD_WEBHOOK_URL"] = orig_webhook
+            elif "DISCORD_WEBHOOK_URL" in _os.environ:
+                del _os.environ["DISCORD_WEBHOOK_URL"]
+
+        assert ids["step1"] == "from_webhook"
+
+    def test_webhook_lookup_failure_returns_none(self) -> None:
+        """If webhook API call fails, channel resolves to None gracefully."""
+        import os as _os
+        orig_step1 = _os.environ.pop("DISCORD_STEP1_CHANNEL_ID", None)
+        orig_webhook = _os.environ.get("DISCORD_WEBHOOK_URL")
+        _os.environ["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/bad/url"
+        client = MagicMock(spec=DiscordClient)
+        client.request.side_effect = DiscordApiError("bad webhook")
+        try:
+            ids = resolve_channel_ids(client)
+        finally:
+            if orig_step1 is not None:
+                _os.environ["DISCORD_STEP1_CHANNEL_ID"] = orig_step1
+            elif "DISCORD_STEP1_CHANNEL_ID" in _os.environ:
+                del _os.environ["DISCORD_STEP1_CHANNEL_ID"]
+            if orig_webhook is not None:
+                _os.environ["DISCORD_WEBHOOK_URL"] = orig_webhook
+            elif "DISCORD_WEBHOOK_URL" in _os.environ:
+                del _os.environ["DISCORD_WEBHOOK_URL"]
+
+        assert ids["step1"] is None
+
+
+# ---------------------------------------------------------------------------
+# write_snapshot — output JSON structure
+# ---------------------------------------------------------------------------
+
+class TestWriteSnapshot:
+    def test_writes_correct_json_structure(self, tmp_path: Path) -> None:
+        snapshot = {
+            "channel_id": "123",
+            "channel_name": "step-1-vote-on-games-to-test",
+            "fetched_at": "2026-04-15T09:00:00Z",
+            "messages": [
+                {
+                    "id": "999",
+                    "author": "XiannGPT Bot",
+                    "content": "hello",
+                    "timestamp": "2026-04-15T09:00:00.000000+00:00",
+                    "reactions": [{"emoji": "👍", "count": 3}],
+                }
+            ],
+        }
+        # Patch the SNAPSHOT_FILES dict to write to tmp_path
+        out_file = tmp_path / "snapshot_step1.json"
+        with patch("scripts.read_discord_channel.SNAPSHOT_FILES", {"step1": out_file}), \
+             patch("scripts.read_discord_channel.DATA_DIR", tmp_path):
+            write_snapshot("step1", snapshot)
+
+        assert out_file.exists()
+        written = json.loads(out_file.read_text(encoding="utf-8"))
+        assert written["channel_id"] == "123"
+        assert written["channel_name"] == "step-1-vote-on-games-to-test"
+        assert "fetched_at" in written
+        assert len(written["messages"]) == 1
+        msg = written["messages"][0]
+        assert msg["id"] == "999"
+        assert msg["author"] == "XiannGPT Bot"
+        assert msg["reactions"][0]["emoji"] == "👍"
+        assert msg["reactions"][0]["count"] == 3
+
+    def test_creates_data_dir_if_missing(self, tmp_path: Path) -> None:
+        nested = tmp_path / "nested" / "data"
+        snapshot = {
+            "channel_id": "1",
+            "channel_name": "test",
+            "fetched_at": "2026-04-15T09:00:00Z",
+            "messages": [],
+        }
+        out_file = nested / "snapshot_step2.json"
+        with patch("scripts.read_discord_channel.SNAPSHOT_FILES", {"step2": out_file}), \
+             patch("scripts.read_discord_channel.DATA_DIR", nested):
+            write_snapshot("step2", snapshot)
+        assert out_file.exists()

--- a/tests/test_read_discord_channel.py
+++ b/tests/test_read_discord_channel.py
@@ -23,6 +23,7 @@ if str(ROOT) not in sys.path:
 
 from scripts.read_discord_channel import (
     CHANNEL_NAMES,
+    CHANNEL_TOKEN_ENV,
     SNAPSHOT_FILES,
     _format_message,
     _format_reaction,
@@ -151,6 +152,21 @@ class TestFetchChannelSnapshot:
 # ---------------------------------------------------------------------------
 
 class TestResolveChannelIds:
+    """resolve_channel_ids now takes a dict of {token_env: DiscordClient}."""
+
+    def _make_clients(
+        self,
+        *,
+        main: bool = True,
+        sched: bool = True,
+    ) -> dict[str, MagicMock]:
+        clients: dict[str, MagicMock] = {}
+        if main:
+            clients["DISCORD_BOT_TOKEN"] = MagicMock(spec=DiscordClient)
+        if sched:
+            clients["DISCORD_SCHEDULING_BOT_TOKEN"] = MagicMock(spec=DiscordClient)
+        return clients
+
     def test_all_env_vars_set(self) -> None:
         env = {
             "DISCORD_STEP1_CHANNEL_ID": "ch1",
@@ -159,14 +175,26 @@ class TestResolveChannelIds:
             "DISCORD_SCHEDULING_CHANNEL_ID": "ch4",
             "DISCORD_HEALTH_MONITOR_CHANNEL_ID": "ch5",
         }
-        client = MagicMock(spec=DiscordClient)
+        clients = self._make_clients()
         with patch.dict("os.environ", env, clear=False):
-            ids = resolve_channel_ids(client)
+            ids = resolve_channel_ids(clients)
         assert ids["step1"] == "ch1"
         assert ids["step2"] == "ch2"
         assert ids["step3"] == "ch3"
         assert ids["schedule"] == "ch4"
         assert ids["health"] == "ch5"
+
+    def test_schedule_skipped_when_sched_token_missing(self) -> None:
+        """Schedule channel resolves to None when scheduling bot token absent."""
+        env = {
+            "DISCORD_STEP1_CHANNEL_ID": "ch1",
+            "DISCORD_SCHEDULING_CHANNEL_ID": "ch4",
+        }
+        # Only main client — no scheduling client
+        clients = self._make_clients(sched=False)
+        with patch.dict("os.environ", env, clear=False):
+            ids = resolve_channel_ids(clients)
+        assert ids["schedule"] is None
 
     def test_missing_step2_returns_none(self) -> None:
         env = {
@@ -175,16 +203,15 @@ class TestResolveChannelIds:
             "DISCORD_SCHEDULING_CHANNEL_ID": "ch4",
             "DISCORD_HEALTH_MONITOR_CHANNEL_ID": "ch5",
         }
-        client = MagicMock(spec=DiscordClient)
-        with patch.dict("os.environ", env, clear=False):
-            # Remove DISCORD_WINNERS_CHANNEL_ID from environment
-            import os as _os
-            orig = _os.environ.pop("DISCORD_WINNERS_CHANNEL_ID", None)
-            try:
-                ids = resolve_channel_ids(client)
-            finally:
-                if orig is not None:
-                    _os.environ["DISCORD_WINNERS_CHANNEL_ID"] = orig
+        clients = self._make_clients()
+        import os as _os
+        orig = _os.environ.pop("DISCORD_WINNERS_CHANNEL_ID", None)
+        try:
+            with patch.dict("os.environ", env, clear=False):
+                ids = resolve_channel_ids(clients)
+        finally:
+            if orig is not None:
+                _os.environ["DISCORD_WINNERS_CHANNEL_ID"] = orig
         assert ids["step2"] is None
 
     def test_all_env_vars_missing_returns_all_none(self) -> None:
@@ -200,9 +227,9 @@ class TestResolveChannelIds:
         ]
         import os as _os
         originals = {k: _os.environ.pop(k, None) for k in keys_to_clear}
-        client = MagicMock(spec=DiscordClient)
+        clients = self._make_clients()
         try:
-            ids = resolve_channel_ids(client)
+            ids = resolve_channel_ids(clients)
         finally:
             for k, v in originals.items():
                 if v is not None:
@@ -217,12 +244,13 @@ class TestResolveChannelIds:
         orig_step1 = _os.environ.pop("DISCORD_STEP1_CHANNEL_ID", None)
         orig_webhook = _os.environ.get("DISCORD_WEBHOOK_URL")
         _os.environ["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/123/abc"
-        client = MagicMock(spec=DiscordClient)
+        main_client = MagicMock(spec=DiscordClient)
         mock_response = MagicMock()
         mock_response.json.return_value = {"channel_id": "from_webhook"}
-        client.request.return_value = mock_response
+        main_client.request.return_value = mock_response
+        clients = {"DISCORD_BOT_TOKEN": main_client, "DISCORD_SCHEDULING_BOT_TOKEN": MagicMock(spec=DiscordClient)}
         try:
-            ids = resolve_channel_ids(client)
+            ids = resolve_channel_ids(clients)
         finally:
             if orig_step1 is not None:
                 _os.environ["DISCORD_STEP1_CHANNEL_ID"] = orig_step1
@@ -241,10 +269,11 @@ class TestResolveChannelIds:
         orig_step1 = _os.environ.pop("DISCORD_STEP1_CHANNEL_ID", None)
         orig_webhook = _os.environ.get("DISCORD_WEBHOOK_URL")
         _os.environ["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/bad/url"
-        client = MagicMock(spec=DiscordClient)
-        client.request.side_effect = DiscordApiError("bad webhook")
+        main_client = MagicMock(spec=DiscordClient)
+        main_client.request.side_effect = DiscordApiError("bad webhook")
+        clients = {"DISCORD_BOT_TOKEN": main_client}
         try:
-            ids = resolve_channel_ids(client)
+            ids = resolve_channel_ids(clients)
         finally:
             if orig_step1 is not None:
                 _os.environ["DISCORD_STEP1_CHANNEL_ID"] = orig_step1
@@ -256,6 +285,14 @@ class TestResolveChannelIds:
                 del _os.environ["DISCORD_WEBHOOK_URL"]
 
         assert ids["step1"] is None
+
+    def test_channel_token_env_mapping(self) -> None:
+        """Confirm step1/step2/step3/health use main token; schedule uses scheduling token."""
+        assert CHANNEL_TOKEN_ENV["step1"] == "DISCORD_BOT_TOKEN"
+        assert CHANNEL_TOKEN_ENV["step2"] == "DISCORD_BOT_TOKEN"
+        assert CHANNEL_TOKEN_ENV["step3"] == "DISCORD_BOT_TOKEN"
+        assert CHANNEL_TOKEN_ENV["health"] == "DISCORD_BOT_TOKEN"
+        assert CHANNEL_TOKEN_ENV["schedule"] == "DISCORD_SCHEDULING_BOT_TOKEN"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Creates `scripts/read_discord_channel.py` that fetches the last 50 messages from all 5 Discord channels in one pass
- Saves structured JSON snapshots to `data/snapshot_step1.json` through `data/snapshot_health.json`
- Channel IDs resolved from env vars (`DISCORD_STEP1_CHANNEL_ID`, `DISCORD_WINNERS_CHANNEL_ID`, etc.) with graceful fallback to webhook API lookup for Step 1 and health monitor
- Errors per channel are logged and non-fatal — script continues to remaining channels
- Supports `--channel <key>` to fetch a single channel and `--limit N` for custom message count

## Test plan
- [x] 16 new tests covering snapshot structure, reaction/message formatting, channel ID resolution (all env vars set, missing vars, webhook fallback, webhook failure), and file write correctness
- [x] Full test suite: 280 passed, 0 regressions

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)