### PR TITLE
feat: fix Step 1 and Step 2 intro, footer, and divider formatting (#216)

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -26,6 +26,22 @@ MAX_VOTERS_SHOWN_PER_GAME = 6
 DISCORD_MESSAGE_CHAR_LIMIT = 2000
 WINNERS_MESSAGE_TARGET_MAX = 1900
 
+WINNERS_INTRO_DIVIDER = "─────────────────────────────────────────"
+WINNERS_FOOTER_SEPARATOR = "─────────────────── End of Daily Winners ───────────────────"
+
+_WINNERS_INTRO_SECTION_LABELS = {
+    "demo_playtest": ("🎮", "Demo & Playtest Winners"),
+    "free": ("🆓", "Free Winners"),
+    "paid": ("💰", "Paid Winners"),
+    "instagram": ("📸", "Creator Winners"),
+}
+_WINNERS_FOOTER_SECTION_LABELS = {
+    "demo_playtest": "Demo & Playtest",
+    "free": "Free",
+    "paid": "Paid",
+    "instagram": "Creator",
+}
+
 # Winners intentionally mirror daily section ordering as product behavior,
 # not an incidental implementation detail.
 SECTION_CONFIG = DAILY_SECTION_DISPLAY_LABELS
@@ -87,8 +103,11 @@ def build_winners_header_placeholder(target_day_key: str) -> str:
     date_str = format_winners_footer_date(target_day_key)
     return "\n".join(
         [
-            f"🏆 Daily Winners - {date_str}",
-            "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
+            f"🏆 Daily Winners — {date_str}",
+            "",
+            "These games won the Step 1 vote. Play them and 🔖 bookmark to keep permanently.",
+            "",
+            WINNERS_INTRO_DIVIDER,
         ]
     )
 
@@ -102,41 +121,33 @@ def build_winners_navigation_header(
 ) -> str:
     date_str = format_winners_footer_date(target_day_key)
     lines = [
-        f"🏆 Daily Winners - {date_str}",
-        "Games that won the vote in Step 1. Play them and 🔖 bookmark to keep permanently.",
+        f"🏆 Daily Winners — {date_str}",
+        "",
+        "These games won the Step 1 vote. Play them and 🔖 bookmark to keep permanently.",
     ]
 
-    if not isinstance(guild_id, str) or not guild_id.strip() or not posted_section_keys:
-        return "\n".join(lines)
+    if isinstance(guild_id, str) and guild_id.strip() and posted_section_keys:
+        section_headers = winners_state.get("section_headers", {})
+        parts = []
+        for section_key in SECTION_ORDER:
+            if section_key not in posted_section_keys:
+                continue
+            section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+            if not isinstance(section_state, dict):
+                continue
+            channel_id = str(section_state.get("channel_id") or "").strip()
+            message_id = str(section_state.get("message_id") or "").strip()
+            if not channel_id or not message_id:
+                continue
+            emoji, label = _WINNERS_INTRO_SECTION_LABELS.get(section_key, ("", section_key))
+            link = build_discord_message_link(guild_id, channel_id, message_id)
+            parts.append(f"{emoji} [{label}]({link})")
+        if parts:
+            lines.append("")
+            lines.append(" · ".join(parts))
 
-    section_labels = {
-        "demo_playtest": "🧪 Demo & Playtest Winners",
-        "free": "🎮 Free Winners",
-        "paid": "💸 Paid Winners",
-        "instagram": "📸 Creator Winners",
-    }
-    section_headers = winners_state.get("section_headers", {})
-    jump_lines = []
-    for section_key in SECTION_ORDER:
-        if section_key not in posted_section_keys:
-            continue
-        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
-        if not isinstance(section_state, dict):
-            continue
-        channel_id = str(section_state.get("channel_id") or "").strip()
-        message_id = str(section_state.get("message_id") or "").strip()
-        if not channel_id or not message_id:
-            continue
-        section_label = section_labels.get(section_key)
-        if section_label:
-            jump_lines.append(
-                f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})"
-            )
-
-    if jump_lines:
-        lines.append("")
-        lines.extend(jump_lines)
-
+    lines.append("")
+    lines.append(WINNERS_INTRO_DIVIDER)
     return "\n".join(lines)
 
 
@@ -180,19 +191,9 @@ def build_winners_navigation_footer(
     if not intro_channel_id or not intro_message_id:
         return None
 
-    section_labels = {
-        "demo_playtest": "🧪 Demo & Playtest Winners",
-        "free": "🎮 Free Winners",
-        "paid": "💸 Paid Winners",
-        "instagram": "📸 Creator Winners",
-    }
     section_headers = winners_state.get("section_headers", {})
     date_str = format_winners_footer_date(target_day_key)
-    lines = [
-        f"🏆 Daily Winners - {date_str}",
-        "",
-        f"🏆 Top of Post ⟹ [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
-    ]
+    link_parts: List[str] = []
     for section_key in SECTION_ORDER:
         if section_key not in posted_section_keys:
             continue
@@ -203,10 +204,14 @@ def build_winners_navigation_footer(
         message_id = str(section_state.get("message_id") or "").strip()
         if not channel_id or not message_id:
             return None
-        section_label = section_labels.get(section_key)
-        if section_label:
-            lines.append(f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
-    return "\n".join(lines)
+        label = _WINNERS_FOOTER_SECTION_LABELS.get(section_key, section_key)
+        link_parts.append(f"[{label}]({build_discord_message_link(guild_id, channel_id, message_id)})")
+
+    top_link = build_discord_message_link(guild_id, intro_channel_id, intro_message_id)
+    link_parts.append(f"[⬆️ Top]({top_link})")
+
+    first_line = f"📅 {date_str} · Jump to: {' · '.join(link_parts)}"
+    return f"{first_line}\n{WINNERS_FOOTER_SEPARATOR}"
 
 
 def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:

--- a/main.py
+++ b/main.py
@@ -2070,6 +2070,103 @@ def build_daily_picks_navigation_content(
     return "\n".join(lines)
 
 
+DAILY_INTRO_DIVIDER = "─────────────────────────────────────────"
+DAILY_FOOTER_SEPARATOR = "─────────────────── End of Daily Picks ───────────────────"
+
+_DAILY_INTRO_SECTION_LABELS = {
+    "demo_playtest": ("🎮", "Demos & Playtests"),
+    "free": ("🆓", "Free Picks"),
+    "paid": ("💰", "Paid Under $20"),
+    "instagram": ("📸", "Instagram Picks"),
+}
+_DAILY_FOOTER_SECTION_LABELS = {
+    "demo_playtest": "Demos",
+    "free": "Free Picks",
+    "paid": "Paid",
+    "instagram": "Instagram",
+}
+
+
+def build_daily_picks_intro_content(
+    run_state: dict,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> str:
+    """Build the Step 1 intro message with optional jump links and trailing divider."""
+    date_str = format_daily_picks_footer_date(target_day_key)
+    lines = [
+        f"📅 Daily Picks — {date_str}",
+        "",
+        "Vote 👍 on anything you want to try. Top picks move to Step 2.",
+    ]
+
+    if isinstance(guild_id, str) and guild_id.strip() and posted_section_keys:
+        section_headers = run_state.get("section_headers", {})
+        parts = []
+        for section_key in DAILY_SECTION_ORDER:
+            if section_key not in posted_section_keys:
+                continue
+            section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+            if not isinstance(section_state, dict):
+                continue
+            channel_id = section_state.get("channel_id")
+            message_id = section_state.get("message_id")
+            if not (isinstance(channel_id, str) and isinstance(message_id, str)):
+                continue
+            emoji, label = _DAILY_INTRO_SECTION_LABELS.get(section_key, ("", section_key))
+            link = build_discord_message_link(guild_id, channel_id, message_id)
+            parts.append(f"{emoji} [{label}]({link})")
+        if parts:
+            lines.append("")
+            lines.append(" · ".join(parts))
+
+    lines.append("")
+    lines.append(DAILY_INTRO_DIVIDER)
+    return "\n".join(lines)
+
+
+def build_daily_picks_footer_content(
+    run_state: dict,
+    guild_id: Optional[str],
+    target_day_key: str,
+    posted_section_keys: List[str],
+) -> Optional[str]:
+    """Build the Step 1 footer: single date+jump line followed by End separator."""
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        return None
+
+    intro_state = run_state.get("intro")
+    if not isinstance(intro_state, dict):
+        return None
+    intro_channel_id = str(intro_state.get("channel_id") or "").strip()
+    intro_message_id = str(intro_state.get("message_id") or "").strip()
+    if not intro_channel_id or not intro_message_id:
+        return None
+
+    date_str = format_daily_picks_footer_date(target_day_key)
+    section_headers = run_state.get("section_headers", {})
+    link_parts: List[str] = []
+    for section_key in DAILY_SECTION_ORDER:
+        if section_key not in posted_section_keys:
+            continue
+        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
+        if not isinstance(section_state, dict):
+            continue
+        channel_id = section_state.get("channel_id")
+        message_id = section_state.get("message_id")
+        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
+            continue
+        label = _DAILY_FOOTER_SECTION_LABELS.get(section_key, section_key)
+        link_parts.append(f"[{label}]({build_discord_message_link(guild_id, channel_id, message_id)})")
+
+    top_link = build_discord_message_link(guild_id, intro_channel_id, intro_message_id)
+    link_parts.append(f"[⬆️ Top]({top_link})")
+
+    first_line = f"📅 {date_str} · Jump to: {' · '.join(link_parts)}"
+    return f"{first_line}\n{DAILY_FOOTER_SEPARATOR}"
+
+
 def post_daily_pick_messages(
     demo_playtest_items: List[dict],
     free_items: List[dict],
@@ -2186,13 +2283,15 @@ def post_daily_pick_messages(
             run_counts["skipped"] += 1
         save_discord_daily_posts(daily_posts)
 
-    header_state = run_state.setdefault("header", {})
-    placeholder_content = f"📅 Daily Picks - {format_daily_picks_footer_date(day_key)}\nVote 👍 on any game you want to try. Every vote advances to Step 2."
-    post_or_reconcile_simple(placeholder_content, "header", header_state)
-    sleep_briefly()
-
     intro_state = run_state.setdefault("intro", {})
-    post_or_reconcile_simple("🎯 Daily Picks — vote with 👍 on your favorites", "intro", intro_state)
+    intro_placeholder = "\n".join([
+        f"📅 Daily Picks — {format_daily_picks_footer_date(day_key)}",
+        "",
+        "Vote 👍 on anything you want to try. Top picks move to Step 2.",
+        "",
+        DAILY_INTRO_DIVIDER,
+    ])
+    post_or_reconcile_simple(intro_placeholder, "intro", intro_state)
     sleep_briefly()
 
     section_items_by_key = {
@@ -2316,21 +2415,21 @@ def post_daily_pick_messages(
                 run_counts["skipped"] += 1
             sleep_briefly()
 
-    # Edit header with jump links now that sections are posted
+    # Edit intro with jump links now that sections are posted
     if token_available and discord_client:
-        header_content = build_daily_picks_navigation_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
-        existing_message_id = header_state.get("message_id")
-        existing_channel_id = header_state.get("channel_id")
+        intro_content = build_daily_picks_intro_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
+        existing_message_id = intro_state.get("message_id")
+        existing_channel_id = intro_state.get("channel_id")
         if existing_message_id and existing_channel_id:
             try:
-                discord_client.edit_message(existing_channel_id, existing_message_id, header_content, context=f"edit header for {day_key}")
-                header_state["posted_at_utc"] = utc_now_iso()
-                print(f"EDIT: updated header for {day_key}")
+                discord_client.edit_message(existing_channel_id, existing_message_id, intro_content, context=f"edit intro for {day_key}")
+                intro_state["posted_at_utc"] = utc_now_iso()
+                print(f"EDIT: updated intro for {day_key}")
             except Exception as e:
-                print(f"WARN: failed to edit header for {day_key}: {e}")
+                print(f"WARN: failed to edit intro for {day_key}: {e}")
 
     footer_state = run_state.setdefault("footer", {})
-    footer_content = build_daily_picks_navigation_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
+    footer_content = build_daily_picks_footer_content(run_state, DISCORD_GUILD_ID, day_key, posted_section_keys)
     if footer_content:
         post_or_reconcile_simple(footer_content, "footer", footer_state)
         sleep_briefly()

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -101,28 +101,31 @@ def test_winners_channel_posts_intro_sections_games_and_footer_in_order(monkeypa
     winners.main()
 
     posted = [content for _, content, _, _ in fake.posts]
-    # Header placeholder posted first (date + subtitle, no jump links yet)
-    assert posted[0].startswith("🏆 Daily Winners - ")
+    # Header placeholder posted first (new format with em-dash and divider)
+    assert posted[0].startswith("🏆 Daily Winners — ")
     assert "bookmark to keep permanently" in posted[0]
+    assert posted[0].endswith(winners.WINNERS_INTRO_DIVIDER)
     assert posted[1] == "🧪 Demo & Playtest Winners"
     assert "Demo Winner" in posted[2]
     assert posted[3] == "🎮 Free Winners"
     assert "Late Voted Earlier Day" in posted[4]
     assert posted[5] == "💸 Paid Winners"
     assert "Current Paid Winner" in posted[6]
-    # Footer uses new format
-    assert posted[-1].startswith("🏆 Daily Winners - ")
-    assert "Top of Post ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-1)" in posted[-1]
-    assert "Demo & Playtest Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-2)" in posted[-1]
-    assert "Free Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-4)" in posted[-1]
-    assert "Paid Winners ⟹ [Jump](https://discord.com/channels/guild-1/wchan/w-6)" in posted[-1]
+    # Footer uses new format: single date+links line + End separator
+    footer = posted[-1]
+    assert footer.startswith("📅 ")
+    assert "⬆️ Top" in footer
+    assert footer.endswith(winners.WINNERS_FOOTER_SEPARATOR)
+    # Footer must not be a copy of intro
+    assert footer != posted[0]
     # Header edited with jump links after sections posted
     header_edits = [(mid, content) for _, mid, content, _ in fake.edits if mid == "w-1"]
     assert header_edits, "Header message should be edited with jump links"
     _, header_final = header_edits[-1]
-    assert "Demo & Playtest Winners ⟹ [Jump]" in header_final
-    assert "Free Winners ⟹ [Jump]" in header_final
-    assert "Paid Winners ⟹ [Jump]" in header_final
+    assert "Demo & Playtest Winners" in header_final
+    assert "Free Winners" in header_final
+    assert "Paid Winners" in header_final
+    assert header_final.endswith(winners.WINNERS_INTRO_DIVIDER)
 
 
 def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
@@ -137,9 +140,10 @@ def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
     _patch_common(monkeypatch, path, fake, day_key)
     winners.main()
     footer = fake.posts[-1][1]
-    assert "Free Winners" in footer
-    assert "Paid Winners" not in footer
-    assert "Creator Winners" not in footer
+    assert "Free" in footer
+    assert "Paid" not in footer
+    assert "Creator" not in footer
+    assert "⬆️ Top" in footer
 
 
 def test_winners_header_shows_date_and_subtitle(monkeypatch, tmp_path):
@@ -154,14 +158,15 @@ def test_winners_header_shows_date_and_subtitle(monkeypatch, tmp_path):
     _patch_common(monkeypatch, path, fake, day_key)
     winners.main()
 
-    # First posted message is header placeholder
+    # First posted message is header placeholder (new format)
     first_post = fake.posts[0][1]
-    assert "🏆 Daily Winners - Monday, April 13, 2026" in first_post
+    assert "🏆 Daily Winners — Monday, April 13, 2026" in first_post
     assert "bookmark to keep permanently" in first_post
+    assert first_post.endswith(winners.WINNERS_INTRO_DIVIDER)
 
-    # Header is subsequently edited with jump links
+    # Header is subsequently edited with jump links and divider
     header_edits = [(mid, content) for _, mid, content, _ in fake.edits]
-    assert any("Free Winners ⟹ [Jump]" in content for _, content in header_edits)
+    assert any("Free Winners" in content and content.endswith(winners.WINNERS_INTRO_DIVIDER) for _, content in header_edits)
 
 
 def test_winners_header_no_jump_links_when_guild_id_missing(monkeypatch, tmp_path):
@@ -185,10 +190,11 @@ def test_winners_header_no_jump_links_when_guild_id_missing(monkeypatch, tmp_pat
 
     # No footer when guild ID missing
     all_content = "\n".join(p[1] for p in fake.posts)
-    assert "Top of Post" not in all_content
-    # Header still posted with date
+    assert "⬆️ Top" not in all_content
+    # Header still posted with date (new format)
     first_post = fake.posts[0][1]
-    assert "🏆 Daily Winners -" in first_post
+    assert "🏆 Daily Winners —" in first_post
+    assert first_post.endswith(winners.WINNERS_INTRO_DIVIDER)
 
 
 def test_winners_header_footer_reused_on_same_day_rerun(monkeypatch, tmp_path):
@@ -446,3 +452,120 @@ def test_instagram_fallback_description_is_preserved():
     )
     assert "Instagram post from @creator" in msg
     assert "caption unavailable in legacy state" in msg
+
+
+# ---------------------------------------------------------------------------
+# Issue #216 — Step 2 intro/footer formatting contract tests
+# ---------------------------------------------------------------------------
+
+class TestStep2IntroFooterFormatting:
+    """Contract tests for the new Step 2 intro/footer spec from Issue #216."""
+
+    def test_intro_placeholder_uses_em_dash(self):
+        placeholder = winners.build_winners_header_placeholder("2026-04-15")
+        assert "🏆 Daily Winners — Wednesday, April 15, 2026" in placeholder
+
+    def test_intro_placeholder_has_divider_as_last_line(self):
+        placeholder = winners.build_winners_header_placeholder("2026-04-15")
+        assert placeholder.endswith(winners.WINNERS_INTRO_DIVIDER)
+
+    def test_intro_placeholder_has_correct_subtitle(self):
+        placeholder = winners.build_winners_header_placeholder("2026-04-15")
+        assert "These games won the Step 1 vote" in placeholder
+        assert "🔖 bookmark to keep permanently" in placeholder
+
+    def test_navigation_header_with_links_has_divider_as_last_line(self):
+        winners_state = {
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-1"},
+            }
+        }
+        header = winners.build_winners_navigation_header(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        assert header.endswith(winners.WINNERS_INTRO_DIVIDER)
+        assert "Free Winners" in header
+
+    def test_navigation_header_without_guild_id_has_divider(self):
+        winners_state = {"section_headers": {}}
+        header = winners.build_winners_navigation_header(
+            winners_state,
+            guild_id=None,
+            target_day_key="2026-04-15",
+            posted_section_keys=[],
+        )
+        assert header.endswith(winners.WINNERS_INTRO_DIVIDER)
+
+    def test_footer_is_not_a_copy_of_intro(self):
+        winners_state = {
+            "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-1"},
+            },
+        }
+        intro = winners.build_winners_navigation_header(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        footer = winners.build_winners_navigation_footer(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        assert intro != footer
+
+    def test_footer_has_end_separator_as_last_line(self):
+        winners_state = {
+            "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-1"},
+            },
+        }
+        footer = winners.build_winners_navigation_footer(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        assert footer is not None
+        assert footer.endswith(winners.WINNERS_FOOTER_SEPARATOR)
+
+    def test_footer_contains_top_link(self):
+        winners_state = {
+            "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-1"},
+            },
+        }
+        footer = winners.build_winners_navigation_footer(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        assert footer is not None
+        assert "⬆️ Top" in footer
+
+    def test_footer_jump_links_only_include_posted_sections(self):
+        winners_state = {
+            "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-free"},
+            },
+        }
+        footer = winners.build_winners_navigation_footer(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free"],
+        )
+        assert footer is not None
+        assert "Free" in footer
+        assert "Paid" not in footer
+        assert "Demo & Playtest" not in footer

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -299,20 +299,18 @@ def test_daily_sections_post_in_new_order(monkeypatch, tmp_path):
         [{"username": "creator", "caption": "caption", "url": "https://www.instagram.com/p/a/"}],
     )
 
-    headers = [
+    # Intro is the single first message; sections follow in order
+    assert posted[0].startswith("📅 Daily Picks — ")
+    assert "Vote 👍 on anything you want to try" in posted[0]
+    section_headers = [
         message for message in posted
-        if message in {
-            "🎯 Daily Picks — vote with 👍 on your favorites",
-            "🧪 New Demos & Playtests",
-            "🎮 Free Picks",
-            "💸 Paid Under $20",
-        }
+        if message in {"🧪 New Demos & Playtests", "🎮 Free Picks", "💸 Paid Under $20", "📸 Instagram Creator Picks"}
     ]
-    assert headers[:4] == [
-        "🎯 Daily Picks — vote with 👍 on your favorites",
+    assert section_headers == [
         "🧪 New Demos & Playtests",
         "🎮 Free Picks",
         "💸 Paid Under $20",
+        "📸 Instagram Creator Picks",
     ]
 
 
@@ -345,22 +343,30 @@ def test_daily_picks_header_and_footer_are_posted_with_expected_links(monkeypatc
         [],
     )
 
-    # Check header placeholder posted first
-    expected_placeholder = "📅 Daily Picks - Wednesday, April 8, 2026\nVote 👍 on any game you want to try. Every vote advances to Step 2."
-    assert posted[0] == expected_placeholder
+    # Intro placeholder posted first (single message — no separate "header" + "intro")
+    assert posted[0].startswith("📅 Daily Picks — Wednesday, April 8, 2026")
+    assert "Vote 👍 on anything you want to try" in posted[0]
+    assert posted[0].endswith(main.DAILY_INTRO_DIVIDER)
+    # No second simple "intro" message before sections
+    assert not any(msg == "🎯 Daily Picks — vote with 👍 on your favorites" for msg in posted)
 
-    # Check header was edited with full content
-    expected_full = "\n".join([
-        "📅 Daily Picks - Wednesday, April 8, 2026",
-        "Vote 👍 on any game you want to try. Every vote advances to Step 2.",
-        "🧪 Demo & Playtest Picks ⟹ [Jump](https://discord.com/channels/guild-1/chan-1/m-3)",
-        "🎮 Free Picks ⟹ [Jump](https://discord.com/channels/guild-1/chan-1/m-5)",
-    ])
+    # Intro edited with jump links after sections posted
+    # posted[0] gets message id "m-1"; sections get m-2,m-3,m-4,m-5 → demo_header=m-2, paid_item=m-3, free_header=m-4, free_item=m-5
     assert len(fake_client.edits) == 1
-    assert fake_client.edits[0][2] == expected_full  # content
+    edited_content = fake_client.edits[0][2]
+    assert "📅 Daily Picks — Wednesday, April 8, 2026" in edited_content
+    assert "Vote 👍 on anything you want to try" in edited_content
+    assert "Demos & Playtests" in edited_content
+    assert "Free Picks" in edited_content
+    assert edited_content.endswith(main.DAILY_INTRO_DIVIDER)
 
-    # Check footer posted last with full content
-    assert posted[-1] == expected_full
+    # Footer posted last — new format: single date+links line + End separator
+    footer = posted[-1]
+    assert footer.startswith("📅 Wednesday, April 8, 2026 · Jump to:")
+    assert "⬆️ Top" in footer
+    assert footer.endswith(main.DAILY_FOOTER_SEPARATOR)
+    # Footer must not be a copy of intro
+    assert footer != edited_content
 
     # Check other messages are present
     assert any("Demo Pick #1" in message for message in posted[1:-1])
@@ -373,7 +379,6 @@ def test_daily_picks_header_and_footer_rerun_reuse_existing_messages(monkeypatch
     initial = {
         day_key: {
             "run_state": {
-                "header": {"message_id": "header-1", "channel_id": "chan-1"},
                 "intro": {"message_id": "intro-1", "channel_id": "chan-1"},
                 "section_headers": {"free": {"message_id": "header-free-1", "channel_id": "chan-1"}},
                 "footer": {"message_id": "footer-1", "channel_id": "chan-1"},
@@ -441,7 +446,6 @@ def test_daily_force_refresh_reconciles_same_day_without_duplicates(monkeypatch,
     initial = {
         day_key: {
             "run_state": {
-                "header": {"message_id": "header-1", "channel_id": "chan-1"},
                 "intro": {"message_id": "intro-1", "channel_id": "chan-1"},
                 "section_headers": {"free": {"message_id": "header-free-1", "channel_id": "chan-1"}},
                 "footer": {"message_id": "footer-1", "channel_id": "chan-1"},
@@ -471,7 +475,7 @@ def test_daily_force_refresh_reconciles_same_day_without_duplicates(monkeypatch,
         counter["i"] += 1
         return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
 
-    fake_client = FakeDiscordClient(existing_ids={"header-1", "intro-1", "header-free-1", "footer-1", "item-1"})
+    fake_client = FakeDiscordClient(existing_ids={"intro-1", "header-free-1", "footer-1", "item-1"})
 
     monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
     monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
@@ -498,7 +502,7 @@ def test_daily_force_refresh_reconciles_same_day_without_duplicates(monkeypatch,
     main.post_daily_pick_messages([], free_items, [], [], force_refresh_same_day=True)
 
     assert len(posted) == 1
-    assert len(fake_client.edits) == 6  # header (refresh) + intro + free header + item + header (manual edit) + footer
+    assert len(fake_client.edits) == 5  # intro (refresh) + free header + item + intro (jump-links edit) + footer
     assert len(fake_client.reactions) == 1  # only brand-new item gets 👍
 
     saved = json.loads(daily_path.read_text(encoding="utf-8"))
@@ -512,7 +516,7 @@ def test_daily_force_refresh_reconciles_same_day_without_duplicates(monkeypatch,
     main.post_daily_pick_messages([], free_items, [], [], force_refresh_same_day=True)
 
     assert len(posted) == 1
-    assert len(fake_client.edits) == edits_after_first + 7  # header + intro + free header + two items + header (manual edit) + footer
+    assert len(fake_client.edits) == edits_after_first + 6  # intro + free header + two items + intro (jump-links edit) + footer
     assert len(fake_client.reactions) == reactions_after_first
     saved_after_second = json.loads(daily_path.read_text(encoding="utf-8"))
     assert len(saved_after_second[day_key]["items"]) == 2
@@ -542,7 +546,7 @@ def test_daily_picks_footer_uses_target_day_override_for_display(monkeypatch, tm
 
     main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
 
-    assert posted[-1].splitlines()[0] == "📅 Daily Picks - Friday, April 10, 2026"
+    assert posted[-1].startswith("📅 Friday, April 10, 2026 · Jump to:")
 
 
 def test_daily_picks_footer_skips_safely_when_guild_id_missing(monkeypatch, tmp_path):
@@ -572,8 +576,8 @@ def test_daily_picks_footer_skips_safely_when_guild_id_missing(monkeypatch, tmp_
     main.post_daily_pick_messages([{"title": "Demo", "url": "https://store.steampowered.com/app/11", "score": 10}], [], [], [])
 
     assert any("Demo Pick #1" in message for message in posted)
-    assert len(posted) == 4  # header, intro, demo_header, demo_item; no footer since no guild_id
-    assert "Vote 👍 on any game you want to try" in posted[0]  # header placeholder
+    assert len(posted) == 3  # intro, demo_header, demo_item; no footer since no guild_id
+    assert "Vote 👍 on anything you want to try" in posted[0]  # intro placeholder
     saved = json.loads(daily_path.read_text(encoding="utf-8"))
     assert saved[day_key]["run_state"]["completed"] is True
 
@@ -1279,8 +1283,8 @@ def test_post_daily_pick_messages_returns_counts(monkeypatch, tmp_path):
     run_counts, rerun_protection_active, _ = main.post_daily_pick_messages([], free_items, [], [])
 
     assert rerun_protection_active is False
-    # header + intro + free_header + 1 item = 4 created
-    assert run_counts["created"] == 4
+    # intro + free_header + 1 item = 3 created (single intro message, no separate header)
+    assert run_counts["created"] == 3
     assert run_counts["updated"] == 0
     assert run_counts["reused"] == 0
 
@@ -1467,3 +1471,101 @@ def test_instagram_age_filter_boundary_exactly_7_days_excluded(monkeypatch, tmp_
 
     results = _patched_fetch_instagram_direct(monkeypatch, fake_profiles, now)
     assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #216 — Step 1 intro/footer formatting contract tests
+# ---------------------------------------------------------------------------
+
+class TestStep1IntroFooterFormatting:
+    """Contract tests for the new intro/footer spec from Issue #216."""
+
+    def _run_post(self, monkeypatch, tmp_path, items_by_section, guild_id="guild-1"):
+        daily_path = tmp_path / "daily.json"
+        daily_path.write_text("{}", encoding="utf-8")
+        day_key = "2026-04-15"
+        posted = []
+        counter = {"i": 0}
+
+        def fake_post(message, capture_metadata=False):
+            posted.append(message)
+            counter["i"] += 1
+            return {"message_id": f"m-{counter['i']}", "channel_id": "chan-1"}
+
+        fake_client = FakeDiscordClient()
+
+        monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+        monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+        monkeypatch.setattr(main, "DISCORD_GUILD_ID", guild_id)
+        monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+        monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+        monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+        monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+        main.post_daily_pick_messages(
+            items_by_section.get("demo_playtest", []),
+            items_by_section.get("free", []),
+            items_by_section.get("paid", []),
+            items_by_section.get("instagram", []),
+        )
+        return posted, fake_client
+
+    def test_intro_contains_exactly_one_voting_instruction(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        intro = posted[0]
+        vote_occurrences = intro.count("Vote 👍")
+        assert vote_occurrences == 1, f"Expected 1 voting instruction, found {vote_occurrences}"
+
+    def test_footer_is_not_a_copy_of_intro(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        intro = posted[0]
+        footer = posted[-1]
+        assert intro != footer, "Footer must not be a copy of the intro"
+
+    def test_intro_has_divider_as_last_line(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        intro = posted[0]
+        assert intro.endswith(main.DAILY_INTRO_DIVIDER), "Divider must be last line of intro"
+
+    def test_footer_has_end_separator_as_last_line(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        footer = posted[-1]
+        assert footer.endswith(main.DAILY_FOOTER_SEPARATOR), "End separator must be last line of footer"
+
+    def test_jump_links_only_include_sections_with_content(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, fake_client = self._run_post(monkeypatch, tmp_path, items)
+        # Intro edited with jump links — check only free section is present
+        assert fake_client.edits, "Intro should be edited with jump links"
+        edited_intro = fake_client.edits[0][2]
+        assert "Free Picks" in edited_intro
+        assert "Demos & Playtests" not in edited_intro
+        assert "Paid Under $20" not in edited_intro
+        assert "Instagram Picks" not in edited_intro
+
+    def test_jump_links_include_all_present_sections(self, monkeypatch, tmp_path):
+        items = {
+            "demo_playtest": [{"title": "D", "url": "https://store.steampowered.com/app/1", "score": 9}],
+            "free": [{"title": "G", "url": "https://store.steampowered.com/app/2", "score": 9}],
+        }
+        posted, fake_client = self._run_post(monkeypatch, tmp_path, items)
+        edited_intro = fake_client.edits[0][2]
+        assert "Demos & Playtests" in edited_intro
+        assert "Free Picks" in edited_intro
+
+    def test_footer_skipped_when_guild_id_missing(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items, guild_id="")
+        # Without guild_id, footer should not be posted
+        for msg in posted:
+            assert "End of Daily Picks" not in msg
+
+    def test_footer_contains_top_link(self, monkeypatch, tmp_path):
+        items = {"free": [{"title": "G", "url": "https://store.steampowered.com/app/1", "score": 9}]}
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        footer = posted[-1]
+        assert "⬆️ Top" in footer


### PR DESCRIPTION
## Summary

- Replaces the Step 1 two-message header+intro pattern with a single clean intro containing: date, voting instruction, jump links (only present sections), and trailing divider `─────────────────────────────────────────`
- New Step 1 footer: `📅 {date} · Jump to: [sections] · [⬆️ Top](url)` followed by `─────────────────── End of Daily Picks ───────────────────`
- Updates Step 2 header placeholder and navigation header to use em-dash, new subtitle, inline section badge jump links, and trailing divider
- New Step 2 footer: same single-line + End separator pattern
- Adds 17 new formatting contract tests (voting instruction count, divider presence, footer ≠ intro, jump link filtering)

Closes #216

## Test plan

- [x] 333 tests pass, 0 regressions (was 316)
- [x] `test_intro_contains_exactly_one_voting_instruction` — passes
- [x] `test_footer_is_not_a_copy_of_intro` — passes
- [x] `test_intro_has_divider_as_last_line` — passes
- [x] `test_jump_links_only_include_sections_with_content` — passes
- [x] Step 2 formatting contract tests — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)