### PR TITLE
feat: add pinned how-it-works messages to all 5 channels (#220)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -55,6 +55,15 @@ jobs:
           path: state_sanity.json
           if-no-files-found: ignore
 
+      - name: Ensure pinned how-it-works messages
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_CHANNEL_ID: ${{ secrets.DISCORD_HEALTH_MONITOR_CHANNEL_ID }}
+        run: python scripts/ensure_pinned_messages.py
+
       - name: Run Steam script
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -98,6 +107,7 @@ jobs:
 
           git add seen_ids.json page_state.json instagram_seen.json
           if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
+          if [ -f data/pinned_messages.json ]; then git add data/pinned_messages.json; fi
 
           if ! git diff --cached --quiet; then
             git commit -m "Update bot state"

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Install packages
         run: pip install -r requirements.txt
 
+      - name: Ensure pinned how-it-works messages
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+        run: python scripts/ensure_pinned_messages.py
+
       - name: Run evening winners script
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
@@ -46,6 +54,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
+          if [ -f data/pinned_messages.json ]; then git add data/pinned_messages.json; fi
 
           if ! git diff --cached --quiet; then
             git commit -m "Update winners state"

--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Install packages
         run: pip install -r requirements.txt
 
+      - name: Ensure pinned how-it-works messages
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+        run: python scripts/ensure_pinned_messages.py
+
       - name: Post daily gaming library reminder
         env:
           PYTHONPATH: .
@@ -65,6 +73,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           if [ -f gaming_library.json ]; then git add gaming_library.json; fi
+          if [ -f data/pinned_messages.json ]; then git add data/pinned_messages.json; fi
 
           if ! git diff --cached --quiet; then
             git commit -m "Update gaming library daily state"

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Ensure pinned how-it-works messages
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+        run: python scripts/ensure_pinned_messages.py
+
       - name: Post weekly availability
         env:
           PYTHONPATH: .
@@ -69,6 +77,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/scheduling/weekly_schedule_messages.json
+          if [ -f data/pinned_messages.json ]; then git add data/pinned_messages.json; fi
 
           if git diff --cached --quiet; then
             echo "No weekly schedule state changes to commit"

--- a/scripts/ensure_pinned_messages.py
+++ b/scripts/ensure_pinned_messages.py
@@ -1,0 +1,176 @@
+"""Ensure each Discord channel has a current pinned how-it-works message.
+
+For each channel ID that is configured via environment variables, the script:
+  - Checks if an existing pinned message ID is stored in data/pinned_messages.json
+  - If the message still exists on Discord → edits it in place with the latest content
+  - If the message is missing (deleted or never posted) → posts and pins a new one
+  - Saves the updated message ID back to data/pinned_messages.json
+
+State file: data/pinned_messages.json (keyed by channel slug, e.g. "step-1")
+"""
+
+import os
+import sys
+
+import requests
+
+from discord_api import DiscordClient, DiscordMessageNotFoundError
+from state_utils import load_json_object, save_json_object_atomic
+
+PINNED_MESSAGES_FILE = "data/pinned_messages.json"
+USER_AGENT = "steam-discord-free-games/ensure-pinned-messages"
+
+# ---------------------------------------------------------------------------
+# Pinned message content (one entry per channel slug)
+# ---------------------------------------------------------------------------
+
+PINNED_CONTENT: dict[str, str] = {
+    "step-1": """\
+📌 How This Works — #step-1-vote-on-games-to-test
+
+Every morning the bot posts fresh game picks for the group to vote on.
+
+👍 Vote on any game you want to try tonight
+Top voted games move to #step-2-test-then-vote-to-keep in the evening
+
+New picks are posted every morning""",
+
+    "step-2": """\
+📌 How This Works — #step-2-test-then-vote-to-keep
+
+Every evening the bot posts the day's winners from #step-1-vote-on-games-to-test.
+
+🔖 Bookmark any game you want to keep permanently
+Bookmarked games move to #step-3-review-existing-games
+
+Winners are posted every evening""",
+
+    "step-3": """\
+📌 How This Works — #step-3-review-existing-games
+
+This is your group's permanent gaming library.
+
+✅ Active — you want to play this
+⏸️ Paused — taking a break
+❌ Dropped — no longer interested
+
+Use commands below to manage the library:
+!addgame GameName SteamURL @user1 @user2
+!add @user GameName
+!remove @user GameName
+!unassign @user
+!rename GameName NewName
+!archive GameName
+
+Commands are processed periodically. Bot reacts ✅ when done.""",
+
+    "step-4": """\
+📌 How This Works — #update-weekly-schedule-here
+
+Every weekend the bot posts the week's availability schedule.
+
+Fill in when you're free to play each day
+The bot identifies overlapping availability and suggests session times
+
+Update your availability anytime — syncs automatically""",
+
+    "step-5": """\
+📌 About This Channel — #xiann-gpt-bot-health-monitor
+
+This channel is for bot diagnostics only.
+
+🟢 Green = all systems running normally
+🔴 Red = a workflow failed and needs attention
+🔧 Auto-fix attempts are logged here
+
+Daily health report posted each evening
+You only need to check this if something looks wrong in the other channels""",
+}
+
+# Map of (channel_slug → env_var_name_for_channel_id)
+CHANNEL_ENV_MAP: dict[str, str] = {
+    "step-1": "DISCORD_STEP1_CHANNEL_ID",
+    "step-2": "DISCORD_WINNERS_CHANNEL_ID",
+    "step-3": "DISCORD_GAMING_LIBRARY_CHANNEL_ID",
+    "step-4": "DISCORD_SCHEDULING_CHANNEL_ID",
+    "step-5": "DISCORD_HEALTH_MONITOR_CHANNEL_ID",
+}
+
+
+def _require_bot_token() -> str:
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if not token:
+        print("ERROR: DISCORD_BOT_TOKEN is not set", file=sys.stderr)
+        sys.exit(1)
+    return token
+
+
+def _try_get_message(client: DiscordClient, channel_id: str, message_id: str, slug: str) -> bool:
+    try:
+        client.get_message(channel_id, message_id, context=f"verify pinned {slug}")
+        return True
+    except DiscordMessageNotFoundError:
+        print(f"RECOVER: pinned message for {slug} is gone (message_id={message_id})")
+        return False
+    except Exception as error:
+        print(f"WARN: could not verify pinned message for {slug}: {error}")
+        return False
+
+
+def ensure_pinned_messages(client: DiscordClient, state: dict) -> dict:
+    """Process all configured channels. Returns updated state dict."""
+    for slug, env_var in CHANNEL_ENV_MAP.items():
+        channel_id = os.getenv(env_var, "").strip()
+        if not channel_id:
+            continue
+
+        content = PINNED_CONTENT[slug]
+        existing_id = state.get(slug, {}).get("message_id", "")
+
+        if existing_id and _try_get_message(client, channel_id, existing_id, slug):
+            client.edit_message(channel_id, existing_id, content, context=f"edit pinned {slug}")
+            print(f"EDIT: pinned message for {slug} (message_id={existing_id})")
+            # message_id unchanged — just update channel_id in case it changed
+            state[slug] = {"channel_id": channel_id, "message_id": existing_id}
+        else:
+            payload = client.post_message(channel_id, content, context=f"post pinned {slug}")
+            new_id = str(payload.get("id", ""))
+            if not new_id:
+                print(f"ERROR: Discord did not return message ID for {slug}", file=sys.stderr)
+                continue
+            client.pin_message(channel_id, new_id, context=f"pin {slug}")
+            print(f"CREATE+PIN: pinned message for {slug} (message_id={new_id})")
+            state[slug] = {"channel_id": channel_id, "message_id": new_id}
+
+    return state
+
+
+def main() -> None:
+    token = _require_bot_token()
+
+    configured = [slug for slug, ev in CHANNEL_ENV_MAP.items() if os.getenv(ev, "").strip()]
+    if not configured:
+        print("INFO: no channel IDs configured — nothing to pin")
+        return
+
+    print(f"ensure_pinned_messages: channels={configured}")
+
+    state = load_json_object(PINNED_MESSAGES_FILE, log=print)
+
+    with requests.Session() as session:
+        session.headers.update(
+            {
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+            }
+        )
+        client = DiscordClient(session)
+        state = ensure_pinned_messages(client, state)
+
+    save_json_object_atomic(PINNED_MESSAGES_FILE, state)
+    print(f"Saved pinned message state to {PINNED_MESSAGES_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ensure_pinned_messages.py
+++ b/tests/test_ensure_pinned_messages.py
@@ -1,0 +1,195 @@
+"""Tests for scripts/ensure_pinned_messages.py"""
+
+import json
+
+import pytest
+
+from scripts import ensure_pinned_messages as epm
+from discord_api import DiscordMessageNotFoundError
+
+
+class FakeClient:
+    def __init__(self, existing_message_ids=None, stale_ids=None):
+        self.existing = set(existing_message_ids or [])
+        self.stale = set(stale_ids or [])
+        self.created_messages = []  # list of (context, content, new_id)
+        self.edits = []             # list of (channel_id, message_id, content)
+        self.pin_calls = []         # list of message_id
+
+    def get_message(self, channel_id, message_id, *, context):
+        if message_id in self.stale:
+            raise DiscordMessageNotFoundError("gone")
+        if message_id in self.existing:
+            return {"id": message_id}
+        raise RuntimeError("not found")
+
+    def post_message(self, channel_id, content, *, context):
+        new_id = f"new-{len(self.created_messages) + 1}"
+        self.created_messages.append((context, content, new_id))
+        return {"id": new_id}
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        self.edits.append((channel_id, message_id, content))
+        return {"id": message_id}
+
+    def pin_message(self, channel_id, message_id, *, context):
+        self.pin_calls.append(message_id)
+
+
+def _run(monkeypatch, tmp_path, *, existing_state=None, channel_envs=None, fake_client=None):
+    """Helper: set up env and run ensure_pinned_messages with a FakeClient."""
+    path = tmp_path / "pinned_messages.json"
+    path.write_text(json.dumps(existing_state or {}), encoding="utf-8")
+    monkeypatch.setattr(epm, "PINNED_MESSAGES_FILE", str(path))
+
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+    # Clear all channel env vars first
+    for ev in epm.CHANNEL_ENV_MAP.values():
+        monkeypatch.delenv(ev, raising=False)
+    # Set only the ones requested
+    for key, val in (channel_envs or {}).items():
+        monkeypatch.setenv(key, val)
+
+    if fake_client is None:
+        fake_client = FakeClient()
+
+    import requests as requests_module
+    monkeypatch.setattr(requests_module, "Session", lambda: _FakeSession())
+    monkeypatch.setattr(epm, "DiscordClient", lambda session: fake_client)
+
+    epm.main()
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    return saved, fake_client
+
+
+class _FakeSession:
+    headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def update(self, *a, **kw):
+        pass
+
+
+def test_pinned_message_posted_and_pinned_when_not_exists(monkeypatch, tmp_path):
+    """When no existing message ID is stored, the script posts and pins a new message."""
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        channel_envs={"DISCORD_STEP1_CHANNEL_ID": "chan-step1"},
+    )
+
+    assert len(fake.created_messages) == 1
+    ctx, content, new_id = fake.created_messages[0]
+    assert "step-1" in ctx
+    assert content == epm.PINNED_CONTENT["step-1"]
+    assert new_id in fake.pin_calls
+    assert saved["step-1"]["message_id"] == new_id
+
+
+def test_pinned_message_edited_in_place_when_exists(monkeypatch, tmp_path):
+    """When an existing message ID is stored and still valid, it is edited in place."""
+    existing_id = "msg-step2-existing"
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        existing_state={"step-2": {"channel_id": "chan-step2", "message_id": existing_id}},
+        channel_envs={"DISCORD_WINNERS_CHANNEL_ID": "chan-step2"},
+        fake_client=FakeClient(existing_message_ids={existing_id}),
+    )
+
+    assert fake.created_messages == []   # no new post
+    assert fake.pin_calls == []          # no new pin
+    assert len(fake.edits) == 1
+    assert fake.edits[0][1] == existing_id
+    assert fake.edits[0][2] == epm.PINNED_CONTENT["step-2"]
+    assert saved["step-2"]["message_id"] == existing_id
+
+
+def test_no_duplicate_posted_when_already_exists(monkeypatch, tmp_path):
+    """Running the script twice with a valid message ID produces no duplicate posts."""
+    existing_id = "msg-step3-existing"
+    fake = FakeClient(existing_message_ids={existing_id})
+
+    # First run — sets up state
+    saved, _ = _run(
+        monkeypatch, tmp_path,
+        existing_state={"step-3": {"channel_id": "chan-step3", "message_id": existing_id}},
+        channel_envs={"DISCORD_GAMING_LIBRARY_CHANNEL_ID": "chan-step3"},
+        fake_client=fake,
+    )
+
+    # Second run — same state, same fake client
+    saved2, _ = _run(
+        monkeypatch, tmp_path,
+        existing_state=saved,
+        channel_envs={"DISCORD_GAMING_LIBRARY_CHANNEL_ID": "chan-step3"},
+        fake_client=fake,
+    )
+
+    assert len(fake.created_messages) == 0  # still zero posts after two runs
+    assert saved2["step-3"]["message_id"] == existing_id
+
+
+def test_stale_message_replaced_with_new_post_and_pin(monkeypatch, tmp_path):
+    """When the stored message ID is stale (deleted), a new message is posted and pinned."""
+    stale_id = "msg-stale-99"
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        existing_state={"step-4": {"channel_id": "chan-step4", "message_id": stale_id}},
+        channel_envs={"DISCORD_SCHEDULING_CHANNEL_ID": "chan-step4"},
+        fake_client=FakeClient(stale_ids={stale_id}),
+    )
+
+    assert len(fake.created_messages) == 1
+    new_id = fake.created_messages[0][2]
+    assert new_id in fake.pin_calls
+    assert saved["step-4"]["message_id"] == new_id
+    assert saved["step-4"]["message_id"] != stale_id
+
+
+def test_unconfigured_channels_skipped(monkeypatch, tmp_path):
+    """Channels whose env vars are not set are silently skipped."""
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        channel_envs={"DISCORD_STEP1_CHANNEL_ID": "chan-step1"},
+    )
+
+    # Only step-1 should be in state; others not set
+    assert "step-1" in saved
+    assert "step-2" not in saved
+    assert "step-3" not in saved
+
+
+def test_all_five_channels_processed_when_all_configured(monkeypatch, tmp_path):
+    """All 5 channels are posted when all channel IDs are configured."""
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        channel_envs={
+            "DISCORD_STEP1_CHANNEL_ID": "chan-1",
+            "DISCORD_WINNERS_CHANNEL_ID": "chan-2",
+            "DISCORD_GAMING_LIBRARY_CHANNEL_ID": "chan-3",
+            "DISCORD_SCHEDULING_CHANNEL_ID": "chan-4",
+            "DISCORD_HEALTH_MONITOR_CHANNEL_ID": "chan-5",
+        },
+    )
+
+    assert len(fake.created_messages) == 5
+    assert len(fake.pin_calls) == 5
+    for slug in ["step-1", "step-2", "step-3", "step-4", "step-5"]:
+        assert slug in saved
+        assert saved[slug]["message_id"].startswith("new-")
+
+
+def test_step3_content_includes_commands_list(monkeypatch, tmp_path):
+    """Step 3 pinned message includes both how-it-works and the commands list."""
+    content = epm.PINNED_CONTENT["step-3"]
+    assert "!addgame" in content
+    assert "!add" in content
+    assert "!remove" in content
+    assert "!unassign" in content
+    assert "!rename" in content
+    assert "!archive" in content
+    assert "permanent gaming library" in content


### PR DESCRIPTION
## Summary

- Adds `scripts/ensure_pinned_messages.py`: for each configured channel, posts a how-it-works message and pins it; edits it in place on subsequent runs; recovers from stale/deleted messages; never posts duplicates
- State tracked in `data/pinned_messages.json` keyed by channel slug (`step-1` … `step-5`)
- Step 3 pinned message is unified: includes both the how-it-works explanation AND the full commands list (`!addgame`, `!add`, `!remove`, `!unassign`, `!rename`, `!archive`)
- Script runs with `continue-on-error: true` at the start of `daily.yml`, `evening-winners.yml`, `gaming-library-daily.yml`, and `weekly-scheduling-bot.yml`
- `data/pinned_messages.json` saved in each workflow's state commit step

## Test plan

- [x] `tests/test_ensure_pinned_messages.py` — 7/7 pass (all new tests)
- [x] Full test suite — 346/346 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)