### PR TITLE
feat: add Instagram fetch summary to health report and track per-creator stats (#222)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -108,6 +108,7 @@ jobs:
           git add seen_ids.json page_state.json instagram_seen.json
           if [ -f discord_daily_posts.json ]; then git add discord_daily_posts.json; fi
           if [ -f data/pinned_messages.json ]; then git add data/pinned_messages.json; fi
+          if [ -f instagram_fetch_summary.json ]; then git add instagram_fetch_summary.json; fi
 
           if ! git diff --cached --quiet; then
             git commit -m "Update bot state"

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_U
 STATE_FILE = "seen_ids.json"
 PAGE_STATE_FILE = "page_state.json"
 INSTAGRAM_STATE_FILE = "instagram_seen.json"
+INSTAGRAM_FETCH_SUMMARY_FILE = "instagram_fetch_summary.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 DISCORD_DAILY_POSTS_RETENTION_DAYS = 30
 DAILY_DATE_OVERRIDE_ENV = "DAILY_DATE_UTC"
@@ -2663,7 +2664,10 @@ def fetch_instagram_posts():
 
     cutoff_utc = datetime.now(timezone.utc) - timedelta(days=INSTAGRAM_MAX_POST_AGE_DAYS)
 
+    creator_stats: Dict[str, Dict] = {}
+
     for username in INSTAGRAM_CREATORS:
+        creator_stats[username] = {"collected": 0, "skipped_seen": 0, "skipped_age": 0, "failed": False, "failure_reason": None}
         try:
             if username not in seen:
                 seen[username] = []
@@ -2711,6 +2715,10 @@ def fetch_instagram_posts():
 
             seen[username] = seen[username][-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
 
+            creator_stats[username]["collected"] = count
+            creator_stats[username]["skipped_seen"] = skipped_seen
+            creator_stats[username]["skipped_age"] = skipped_age
+
             if count == 0:
                 print(
                     f"INSTAGRAM ZERO POSTS: @{username} returned 0 new posts "
@@ -2721,10 +2729,31 @@ def fetch_instagram_posts():
 
         except Exception as e:
             print(f"Instagram scrape failed for {username}: {e}")
+            creator_stats[username]["failed"] = True
+            creator_stats[username]["failure_reason"] = str(e)
             continue
 
     save_instagram_seen(seen)
-    print(f"Instagram posts found this run: {len(all_new_posts)}")
+    total_posts = len(all_new_posts)
+    total_skipped_seen = sum(s["skipped_seen"] for s in creator_stats.values())
+    creators_with_posts = sum(1 for s in creator_stats.values() if s["collected"] > 0)
+    failed_creators = [u for u, s in creator_stats.items() if s["failed"]]
+    print(f"Instagram posts found this run: {total_posts}")
+
+    fetch_summary = {
+        "run_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "total_creators": len(INSTAGRAM_CREATORS),
+        "creators_with_posts": creators_with_posts,
+        "total_posts_collected": total_posts,
+        "total_skipped_seen": total_skipped_seen,
+        "failed_creators": failed_creators,
+        "creators": creator_stats,
+    }
+    try:
+        save_json_object_atomic(INSTAGRAM_FETCH_SUMMARY_FILE, fetch_summary)
+    except Exception as e:
+        print(f"WARN: could not save instagram_fetch_summary.json: {e}")
+
     return all_new_posts
     
 def load_daily_verification_artifact(path: str = DAILY_VERIFICATION_FILE) -> dict:

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -22,6 +22,8 @@ WEEKLY_PATHS = {
     "roster": ROOT / "data/scheduling/expected_schedule_roster.json",
 }
 DAILY_POSTS_PATH = ROOT / "discord_daily_posts.json"
+INSTAGRAM_FETCH_SUMMARY_PATH = ROOT / "instagram_fetch_summary.json"
+INSTAGRAM_TOTAL_CREATORS = 8
 
 NEW_YORK_TZ = ZoneInfo("America/New_York")
 SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
@@ -764,6 +766,7 @@ def render_report(
                 state_lines.append("")
 
     lines.extend(_render_section("State / Artifact Health", state_lines))
+    lines.extend(_render_section("Instagram Fetch", build_instagram_summary_lines()))
 
     return "\n".join(lines).strip()
 
@@ -883,6 +886,30 @@ def build_workflow_status_lines(
             lines.append(f"Next step: {next_step}")
         lines.append("")
     return lines, diagnostics_payload
+
+
+def build_instagram_summary_lines() -> list[str]:
+    """Return lines for the Instagram Fetch section of the daily health report."""
+    data = _load_json(INSTAGRAM_FETCH_SUMMARY_PATH)
+    if not isinstance(data, dict):
+        return ["_No Instagram fetch summary available for today_"]
+
+    total = data.get("total_creators", INSTAGRAM_TOTAL_CREATORS)
+    with_posts = data.get("creators_with_posts", 0)
+    collected = data.get("total_posts_collected", 0)
+    skipped_seen = data.get("total_skipped_seen", 0)
+    failed = data.get("failed_creators", [])
+    run_at = data.get("run_at", "")
+
+    lines: list[str] = []
+    icon = "🟢" if not failed else "🔴"
+    lines.append(f"{icon} {with_posts} of {total} creators fetched new posts")
+    lines.append(f"Posts collected: {collected}  |  Skipped (already seen): {skipped_seen}")
+    if failed:
+        lines.append(f"⚠️ Failed creators: {', '.join('@' + u for u in failed)}")
+    if run_at:
+        lines.append(f"Last fetch: {run_at}")
+    return lines
 
 
 def _report_date_new_york(now_utc: datetime) -> str:

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -709,3 +709,46 @@ def test_scheduled_run_succeeded_renders_green():
         now_utc=now_utc,
     )
     assert lines[0].startswith("🟢"), f"Expected green for successful scheduled run: {lines[0]!r}"
+
+
+def test_instagram_summary_included_in_report(monkeypatch, tmp_path):
+    """Instagram Fetch section appears in the daily health report."""
+    fake_summary = tmp_path / "instagram_fetch_summary.json"
+    fake_summary.write_text(
+        '{"total_creators": 8, "creators_with_posts": 1, "total_posts_collected": 1, '
+        '"total_skipped_seen": 13, "failed_creators": [], "run_at": "2026-04-16T06:37:00Z"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(report, "INSTAGRAM_FETCH_SUMMARY_PATH", fake_summary)
+
+    lines = report.build_instagram_summary_lines()
+    rendered = "\n".join(lines)
+    assert "1 of 8 creators" in rendered
+    assert "Posts collected: 1" in rendered
+    assert "Skipped (already seen): 13" in rendered
+
+
+def test_instagram_summary_shows_failed_creators(monkeypatch, tmp_path):
+    """Failed creators are listed by name in the Instagram section."""
+    fake_summary = tmp_path / "instagram_fetch_summary.json"
+    fake_summary.write_text(
+        '{"total_creators": 8, "creators_with_posts": 0, "total_posts_collected": 0, '
+        '"total_skipped_seen": 0, "failed_creators": ["gemgamingnetwork", "cloudual"], '
+        '"run_at": "2026-04-16T06:37:00Z"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(report, "INSTAGRAM_FETCH_SUMMARY_PATH", fake_summary)
+
+    lines = report.build_instagram_summary_lines()
+    rendered = "\n".join(lines)
+    assert "@gemgamingnetwork" in rendered
+    assert "@cloudual" in rendered
+    assert "🔴" in rendered
+
+
+def test_instagram_summary_missing_file_shows_placeholder(monkeypatch, tmp_path):
+    """If the summary file does not exist, a placeholder is shown."""
+    monkeypatch.setattr(report, "INSTAGRAM_FETCH_SUMMARY_PATH", tmp_path / "nonexistent.json")
+
+    lines = report.build_instagram_summary_lines()
+    assert any("No Instagram" in line for line in lines)


### PR DESCRIPTION
## Investigation Findings

- **Session is healthy** — loads and authenticates successfully (no session failures)
- **4 inactive creators**: `gemgamingnetwork` (last post 22d ago), `cloudual` (63d), `mildsoss_official` (257d), `indiegamespotlights` (569d) — genuinely not posting within the 7-day window, not a session issue
- **3 active creators with all recent posts already seen**: `wilfratgaming`, `biffmatictv`, `itzjaysasa` — posts exist within 7 days but were already displayed in prior runs
- **1 creator producing new content**: `sharedxp_official` — 1 post per run
- **Root cause**: low Instagram pick count is working as designed; inactive creators aren't posting; active creators have been featured recently

## Changes

- Track per-creator stats (`collected`, `skipped_seen`, `skipped_age`, `failed`, `failure_reason`) in `fetch_instagram_posts()` in `main.py`
- Save fetch results to `instagram_fetch_summary.json` after each daily run
- Add **Instagram Fetch** section to `build_daily_health_report.py`: "X of 8 creators fetched new posts | Posts collected: Y | Skipped (already seen): Z", with 🔴 alert and creator names when scrape failures occur
- Save `instagram_fetch_summary.json` in `daily.yml` state commit step

## Test plan

- [x] `tests/test_build_daily_health_report.py` — 31/31 pass (3 new tests)
- [x] Full test suite — 356/356 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)