### PR TITLE
feat: wire Discord snapshot steps into posting workflows and auto-fix

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -94,7 +94,22 @@ jobs:
           path: artifacts/
 
       # ------------------------------------------------------------------ #
-      # 6. Decide whether a fix is needed:
+      # 6. Download Discord snapshot artifacts so Claude Code can read
+      #    the actual Discord output when diagnosing failures.
+      # ------------------------------------------------------------------ #
+      - name: Download Discord snapshot artifact
+        id: download_snapshots
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: discord-snapshots-*
+          merge-multiple: true
+          path: artifacts/
+
+      # ------------------------------------------------------------------ #
+      # 7. Decide whether a fix is needed:
       #    - workflow concluded with failure, OR
       #    - any verification artifact reports pass: false
       # Sets should_fix and trigger_reason outputs.

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -76,6 +76,35 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python main.py
 
+      - name: Read Discord channel snapshots
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_CHANNEL_ID: ${{ secrets.DISCORD_HEALTH_MONITOR_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+        run: python scripts/read_discord_channel.py
+
+      - name: Upload Discord snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-snapshots-${{ github.run_id }}
+          path: |
+            data/snapshot_step1.json
+            data/snapshot_step2.json
+            data/snapshot_step3.json
+            data/snapshot_schedule.json
+            data/snapshot_health.json
+          if-no-files-found: ignore
+
       - name: Verify Discord output
         continue-on-error: true
         env:

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -48,6 +48,43 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python evening_winners.py
 
+      - name: Read Discord channel snapshots
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_CHANNEL_ID: ${{ secrets.DISCORD_HEALTH_MONITOR_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+        run: python scripts/read_discord_channel.py
+
+      - name: Upload Discord snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-snapshots-${{ github.run_id }}
+          path: |
+            data/snapshot_step1.json
+            data/snapshot_step2.json
+            data/snapshot_step3.json
+            data/snapshot_schedule.json
+            data/snapshot_health.json
+          if-no-files-found: ignore
+
+      - name: Verify Discord output
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
+        run: python scripts/verify_discord_output.py
+
       - name: Save updated winners state
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -51,6 +51,43 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/post_daily_gaming_library.py
 
+      - name: Read Discord channel snapshots
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_CHANNEL_ID: ${{ secrets.DISCORD_HEALTH_MONITOR_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+        run: python scripts/read_discord_channel.py
+
+      - name: Upload Discord snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-snapshots-${{ github.run_id }}
+          path: |
+            data/snapshot_step1.json
+            data/snapshot_step2.json
+            data/snapshot_step3.json
+            data/snapshot_schedule.json
+            data/snapshot_health.json
+          if-no-files-found: ignore
+
+      - name: Verify Discord output
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
+        run: python scripts/verify_discord_output.py
+
       - name: Verify gaming library output
         continue-on-error: true
         env:

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -56,6 +56,35 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/post_weekly_availability.py
 
+      - name: Read Discord channel snapshots
+        continue-on-error: true
+        env:
+          PYTHONPATH: .
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WINNERS_CHANNEL_ID: ${{ secrets.DISCORD_WINNERS_CHANNEL_ID }}
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
+          DISCORD_SCHEDULING_CHANNEL_ID: ${{ secrets.DISCORD_SCHEDULING_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_CHANNEL_ID: ${{ secrets.DISCORD_HEALTH_MONITOR_CHANNEL_ID }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+        run: python scripts/read_discord_channel.py
+
+      - name: Upload Discord snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-snapshots-${{ github.run_id }}
+          path: |
+            data/snapshot_step1.json
+            data/snapshot_step2.json
+            data/snapshot_step3.json
+            data/snapshot_schedule.json
+            data/snapshot_health.json
+          if-no-files-found: ignore
+
       - name: Verify weekly schedule output
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary

- **daily.yml**: Insert `Read Discord channel snapshots` + `Upload Discord snapshot artifact` steps between main script and verification
- **evening-winners.yml**: Same snapshot steps + add `python scripts/verify_discord_output.py` step (was missing)
- **gaming-library-daily.yml**: Same snapshot steps + add `python scripts/verify_discord_output.py` step (was missing)
- **weekly-scheduling-bot.yml**: Same snapshot steps inserted before verify_weekly_schedule.py
- **auto-fix.yml**: Add `Download Discord snapshot artifact` step after existing verification downloads so Claude Code can read actual Discord output when diagnosing failures

## Test plan

- [x] Full test suite: 356 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)