### PR TITLE
test: lock in format_daily_picks_footer_date full date format

### DIFF
--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -1,6 +1,19 @@
 import json
 
+import pytest
+
 import main
+
+
+def test_format_daily_picks_footer_date_full_format():
+    """format_daily_picks_footer_date returns full weekday+month+day+year format."""
+    assert main.format_daily_picks_footer_date("2026-04-15") == "Wednesday, April 15, 2026"
+
+
+def test_format_daily_picks_footer_date_single_digit_day():
+    """Single-digit day is not zero-padded in the output."""
+    result = main.format_daily_picks_footer_date("2026-04-01")
+    assert result == "Wednesday, April 1, 2026"
 
 
 class FakeDiscordClient:


### PR DESCRIPTION
## Summary

- `format_daily_picks_footer_date` already returns `"Wednesday, April 15, 2026"` (the correct full weekday + month + day + year format)
- Added 2 tests to `tests/test_main_daily_picks.py` to lock in this behaviour

## Test plan

- [x] Full test suite: 358 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)