### PR TITLE
feat: add @mentions for missing users in availability summary

### DIFF
--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -607,6 +607,7 @@ def format_summary_message(
     responded_count: int,
     active_user_count: int,
     synced_at_utc: datetime,
+    missing_user_ids: list[str] | None = None,
 ) -> str:
     """Build a richer deterministic summary message from weekly summary data."""
     summary = week_summary.get("summary")
@@ -708,10 +709,16 @@ def format_summary_message(
         f"{missing_count} still missing*"
     )
     last_updated_line = format_summary_last_updated_line(synced_at_utc)
+    missing_mentions_line = ""
+    if missing_user_ids:
+        missing_mentions_line = "Missing: " + " ".join(
+            f"<@{uid}>" for uid in missing_user_ids
+        )
     lines = [
         f"📊 Availability Summary — {date_range}",
         "",
         response_status_line,
+        *([ missing_mentions_line ] if missing_mentions_line else []),
         last_updated_line,
         "",
         *chronological_day_lines,
@@ -1043,6 +1050,7 @@ def main() -> None:
                 responded_count=responded_active_user_count,
                 active_user_count=active_user_count,
                 synced_at_utc=effective_summary_synced_at_utc,
+                missing_user_ids=missing_user_ids,
             )
 
         week_outputs["summary_data_signature"] = current_summary_data_signature

--- a/tests/test_weekly_sync_summary.py
+++ b/tests/test_weekly_sync_summary.py
@@ -700,3 +700,50 @@ def test_main_reminder_uses_multi_message_ids_when_content_is_long(monkeypatch, 
     reminder_ids = outputs[week_key].get("reminder_message_ids")
     assert isinstance(reminder_ids, list) and len(reminder_ids) >= 2
     assert outputs[week_key]["reminder_message_id"] == reminder_ids[0]
+
+
+# --- FIX 8: missing @mentions in availability summary ---
+
+def _make_week_summary():
+    return {
+        "week_key": "2026-04-13_to_2026-04-19",
+        "date_range": "Apr 13\u201319, 2026",
+        "summary": {
+            "day_counts": {d: 0 for d in sync.DAY_NAMES},
+            "slot_counts": {d: {slot: 0 for slot in sync.SUMMARY_DISPLAY_ORDER} for d in sync.DAY_NAMES},
+            "slot_voters": {},
+        },
+    }
+
+
+def test_missing_user_ids_shows_at_mentions_in_summary():
+    from datetime import datetime, timezone
+
+    week_summary = _make_week_summary()
+    message = sync.format_summary_message(
+        "Apr 13\u201319, 2026",
+        week_summary,
+        responded_count=1,
+        active_user_count=3,
+        synced_at_utc=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
+        missing_user_ids=["111", "222"],
+    )
+    assert "Missing:" in message
+    assert "<@111>" in message
+    assert "<@222>" in message
+
+
+def test_empty_missing_user_ids_shows_no_mention_line_in_summary():
+    from datetime import datetime, timezone
+
+    week_summary = _make_week_summary()
+    message = sync.format_summary_message(
+        "Apr 13\u201319, 2026",
+        week_summary,
+        responded_count=2,
+        active_user_count=2,
+        synced_at_utc=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
+        missing_user_ids=[],
+    )
+    assert "Missing:" not in message
+    assert "<@" not in message


### PR DESCRIPTION
## Summary
- `format_summary_message` now accepts an optional `missing_user_ids` parameter
- When non-empty, inserts a `Missing: <@uid> <@uid>...` line immediately after the response status line
- Updated the call site in `sync_weekly_schedule_responses.py` to pass `missing_user_ids`

## Tests added
- `test_missing_user_ids_shows_at_mentions_in_summary` — verifies `<@uid>` mentions appear
- `test_empty_missing_user_ids_shows_no_mention_line_in_summary` — verifies no mention line when everyone responded

## Test plan
- [x] `pytest tests/test_weekly_sync_summary.py` — 17/17 passed
- [x] `pytest tests/` — 373/373 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)