### PR TITLE
fix: add 'Negative' to HARD_EXCLUDE_REVIEW_SENTIMENTS and Instagram caption filter

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,6 +376,7 @@ HARD_EXCLUDE_REVIEW_SENTIMENTS = {
     "Mostly Negative",
     "Very Negative",
     "Overwhelmingly Negative",
+    "Negative",
 }
 
 REVIEW_SENTIMENT_PATTERNS = [
@@ -1576,10 +1577,16 @@ def inspect_game(source: str, app_id: str) -> Optional[dict]:
             print(f"EXCLUDE: {title} — demo/playtest older than 180 days (or no release date)")
             return None
 
+    review_sentiment = extract_review_sentiment(soup)
+
+    if item_type in {"demo", "playtest"}:
+        if review_sentiment in HARD_EXCLUDE_REVIEW_SENTIMENTS:
+            print(f"EXCLUDE: {title} — blocked review: {review_sentiment}")
+            return None
+
     multiplayer_score, multiplayer_hits = score_multiplayer(page_text)
     player_score, player_hits, rejected = score_player_count(page_text)
     flavor_score, flavor_hits = score_genres_and_description(title, description, page_text)
-    review_sentiment = extract_review_sentiment(soup)
     review_count = extract_review_count(page_text)
     review_score = REVIEW_SENTIMENT_SCORES.get(review_sentiment, UNKNOWN_REVIEW_SCORE_BY_TYPE.get(item_type, 0))
 
@@ -2700,6 +2707,23 @@ def fetch_instagram_posts():
                 caption = (post.caption or "").replace("\n", " ").strip()
                 if len(caption) > 120:
                     caption = caption[:117] + "..."
+
+                blocked_caption_phrases = [
+                    "coming soon",
+                    "not yet available",
+                    "wishlist now",
+                ]
+                blocked_caption_patterns = [
+                    r"coming\s+202[5-9]",
+                    r"coming\s+203[0-9]",
+                ]
+                caption_lower = caption.lower()
+                if any(phrase in caption_lower for phrase in blocked_caption_phrases):
+                    print(f"INSTAGRAM SKIP: @{username} — unavailable caption")
+                    continue
+                if any(re.search(p, caption_lower) for p in blocked_caption_patterns):
+                    print(f"INSTAGRAM SKIP: @{username} — future release caption")
+                    continue
 
                 all_new_posts.append({
                     "username": username,

--- a/tests/test_main_scoring_model.py
+++ b/tests/test_main_scoring_model.py
@@ -1009,3 +1009,61 @@ def test_non_demo_not_affected_by_coming_soon_check(monkeypatch):
     # free_game items should NOT be filtered by the demo availability check
     assert item is not None
     assert item["type"] == "free_game"
+
+
+# --- FIX 11: HARD_EXCLUDE_REVIEW_SENTIMENTS "Negative" and Instagram caption filter ---
+
+def test_negative_review_sentiment_excludes_demo(monkeypatch):
+    shared = "Release Date: Dec 01, 2025 Multiplayer Online Co-Op up to 6 players Download Demo"
+    html = build_html("Bad Demo", "bad game", shared, "Negative")
+    stub_app_pages(monkeypatch, {"9100": html})
+
+    item = main.inspect_game("steam_demo", "9100")
+    assert item is None
+
+
+def test_instagram_coming_2026_caption_skipped(monkeypatch, tmp_path):
+    from datetime import datetime, timezone, timedelta
+    from tests.test_main_daily_picks import (
+        FakePost, FakeProfile, _patched_fetch_instagram_direct
+    )
+
+    now = datetime(2026, 4, 13, 12, 0, 0, tzinfo=timezone.utc)
+    blocked = FakePost("block1", now - timedelta(days=1), "Coming 2026 to all platforms")
+    allowed = FakePost("allow1", now - timedelta(days=1), "Play now on Steam")
+
+    fake_profiles = {"gemgamingnetwork": FakeProfile([blocked, allowed])}
+    monkeypatch.setattr(main, "INSTAGRAM_CREATORS", ["gemgamingnetwork"])
+
+    results = _patched_fetch_instagram_direct(monkeypatch, fake_profiles, now)
+    # _patched_fetch_instagram_direct doesn't apply caption filter — test the real function
+    monkeypatch.setattr(main, "INSTAGRAM_STATE_FILE", str(tmp_path / "seen.json"))
+    monkeypatch.setenv("INSTAGRAM_USERNAME", "testuser")
+
+    import sys
+    sys.path.insert(0, ".")
+    from tests.test_main_daily_picks import _setup_instagram_env
+    _setup_instagram_env(monkeypatch, tmp_path, fake_profiles)
+
+    posts = main.fetch_instagram_posts()
+    urls = [p["url"] for p in posts]
+    assert "https://www.instagram.com/p/block1/" not in urls
+    assert "https://www.instagram.com/p/allow1/" in urls
+
+
+def test_instagram_wishlist_now_caption_skipped(monkeypatch, tmp_path):
+    from datetime import datetime, timezone, timedelta
+    from tests.test_main_daily_picks import FakeProfile, FakePost, _setup_instagram_env
+
+    now = datetime(2026, 4, 13, 12, 0, 0, tzinfo=timezone.utc)
+    blocked = FakePost("wl1", now - timedelta(days=1), "Wishlist now on Steam!")
+    allowed = FakePost("ok1", now - timedelta(days=1), "Available now - grab it!")
+
+    fake_profiles = {"gemgamingnetwork": FakeProfile([blocked, allowed])}
+    monkeypatch.setattr(main, "INSTAGRAM_CREATORS", ["gemgamingnetwork"])
+    _setup_instagram_env(monkeypatch, tmp_path, fake_profiles)
+
+    posts = main.fetch_instagram_posts()
+    urls = [p["url"] for p in posts]
+    assert "https://www.instagram.com/p/wl1/" not in urls
+    assert "https://www.instagram.com/p/ok1/" in urls


### PR DESCRIPTION
## Summary

### BUG 1 — Missing "Negative" from HARD_EXCLUDE_REVIEW_SENTIMENTS
- Added `"Negative"` to `HARD_EXCLUDE_REVIEW_SENTIMENTS` in `main.py`
- Moved `review_sentiment = extract_review_sentiment(soup)` above the new demo/playtest review block
- Added early return for demo/playtest items with a blocked review sentiment (after the 180-day cutoff check)

### BUG 2 — Instagram posts not filtered by unavailable captions
- Added phrase filter (`"coming soon"`, `"not yet available"`, `"wishlist now"`) after caption extraction in `fetch_instagram_posts()`
- Added regex pattern filter (`coming 202[5-9]`, `coming 203[0-9]`) for future release captions

## Tests added
- `test_negative_review_sentiment_excludes_demo` — demo with "Negative" sentiment returns None
- `test_instagram_coming_2026_caption_skipped` — post with "Coming 2026" is excluded
- `test_instagram_wishlist_now_caption_skipped` — post with "Wishlist now" is excluded

## Test plan
- [x] `pytest tests/test_main_scoring_model.py` — 73/73 passed
- [x] `pytest tests/` — 374/374 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)