### PR TITLE
fix: make Step 2 intro jump links vertical (one per line)

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -144,7 +144,8 @@ def build_winners_navigation_header(
             parts.append(f"{emoji} [{label}]({link})")
         if parts:
             lines.append("")
-            lines.append(" · ".join(parts))
+            for part in parts:
+                lines.append(part)
 
     lines.append("")
     lines.append(WINNERS_INTRO_DIVIDER)

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -574,6 +574,40 @@ class TestStep2IntroFooterFormatting:
         assert winners._WINNERS_FOOTER_SECTION_LABELS["paid"] == "💰 Paid"
         assert winners._WINNERS_FOOTER_SECTION_LABELS["instagram"] == "📸 Creator"
 
+    def test_intro_jump_links_are_vertical_not_horizontal(self):
+        winners_state = {
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-free"},
+                "paid": {"channel_id": "wchan", "message_id": "hdr-paid"},
+            }
+        }
+        header = winners.build_winners_navigation_header(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["free", "paid"],
+        )
+        # Links must NOT be joined with " · " on one line
+        assert " · " not in header
+
+    def test_intro_each_section_link_on_own_line(self):
+        winners_state = {
+            "section_headers": {
+                "free": {"channel_id": "wchan", "message_id": "hdr-free"},
+                "demo_playtest": {"channel_id": "wchan", "message_id": "hdr-demo"},
+                "paid": {"channel_id": "wchan", "message_id": "hdr-paid"},
+            }
+        }
+        header = winners.build_winners_navigation_header(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=["demo_playtest", "free", "paid"],
+        )
+        lines = header.split("\n")
+        link_lines = [ln for ln in lines if "](https://" in ln]
+        assert len(link_lines) == 3
+
     def test_footer_jump_links_only_include_posted_sections(self):
         winners_state = {
             "intro": {"channel_id": "wchan", "message_id": "intro-1"},


### PR DESCRIPTION
## Summary
- `build_winners_navigation_header()` was joining section jump links with `' · '` on a single horizontal line
- Changed to append each link on its own line to match the Step 1 intro format spec from CLAUDE.md

## Tests added
- `test_intro_jump_links_are_vertical_not_horizontal` — asserts `' · '` is absent from the header
- `test_intro_each_section_link_on_own_line` — asserts each section link appears on its own line

## Test plan
- [x] `pytest tests/test_evening_winners.py` — 28/28 passed
- [x] `pytest tests/` — 382/382 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)