### PR TITLE
feat: add Discord bot token health check

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Install packages
         run: pip install -r requirements.txt
 
+      - name: Check Discord bot token health
+        continue-on-error: true
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_SCHEDULING_BOT_TOKEN: ${{ secrets.DISCORD_SCHEDULING_BOT_TOKEN }}
+          DISCORD_HEALTH_MONITOR_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_MONITOR_WEBHOOK_URL }}
+        run: python scripts/check_bot_token_health.py
+
       - name: Find latest daily.yml run ID
         id: find-daily-run
         continue-on-error: true

--- a/scripts/check_bot_token_health.py
+++ b/scripts/check_bot_token_health.py
@@ -1,0 +1,95 @@
+"""Check Discord bot token health by calling GET /users/@me for each token.
+
+Exits with code 0 even if tokens are invalid — warnings are posted to the
+health monitor webhook so the health report workflow continues regardless.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import requests
+
+DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL", "")
+
+
+def _post_health_monitor_warning(message: str) -> None:
+    """Post a warning to the Discord health monitor webhook (best-effort, never raises)."""
+    url = DISCORD_HEALTH_MONITOR_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json={"content": message}, timeout=10)
+    except Exception:
+        pass
+
+
+def check_token(token: str, label: str) -> bool:
+    """Return True if the token is valid, False otherwise.
+
+    On 401, prints a warning and posts to the health monitor webhook.
+    """
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        }
+    )
+    try:
+        response = session.get(
+            "https://discord.com/api/v10/users/@me",
+            timeout=10,
+        )
+    except requests.RequestException as exc:
+        print(f"WARN: {label} — request failed: {exc}", file=sys.stderr)
+        _post_health_monitor_warning(
+            f"⚠️ Discord bot token health check failed for {label}\n"
+            f"Request error: {exc}"
+        )
+        return False
+
+    if response.status_code == 401:
+        print(f"WARN: {label} — token is invalid (401 Unauthorized)", file=sys.stderr)
+        _post_health_monitor_warning(
+            f"🔴 Discord bot token is invalid for {label}\n"
+            "The token returned 401 Unauthorized. "
+            "Update the secret with a valid bot token."
+        )
+        return False
+
+    if not response.ok:
+        print(
+            f"WARN: {label} — unexpected status {response.status_code}",
+            file=sys.stderr,
+        )
+        return False
+
+    data = response.json()
+    username = data.get("username", "unknown")
+    print(f"Bot token OK: @{username} ({label})")
+    return True
+
+
+def main() -> None:
+    tokens: list[tuple[str, str]] = []
+
+    bot_token = os.getenv("DISCORD_BOT_TOKEN", "")
+    if bot_token:
+        tokens.append((bot_token, "DISCORD_BOT_TOKEN"))
+    else:
+        print("SKIP: DISCORD_BOT_TOKEN is not set")
+
+    scheduling_token = os.getenv("DISCORD_SCHEDULING_BOT_TOKEN", "")
+    if scheduling_token:
+        tokens.append((scheduling_token, "DISCORD_SCHEDULING_BOT_TOKEN"))
+    else:
+        print("SKIP: DISCORD_SCHEDULING_BOT_TOKEN is not set")
+
+    for token, label in tokens:
+        check_token(token, label)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_bot_token_health.py
+++ b/tests/test_check_bot_token_health.py
@@ -1,0 +1,69 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from scripts import check_bot_token_health as health
+
+
+def _make_response(status_code: int, json_data: dict | None = None) -> MagicMock:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.json.return_value = json_data or {}
+    return response
+
+
+class TestCheckToken:
+    def test_valid_token_prints_username(self, capsys):
+        response = _make_response(200, {"username": "CoolBot", "id": "123"})
+        with patch("scripts.check_bot_token_health.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            mock_session.get.return_value = response
+
+            result = health.check_token("valid-token", "DISCORD_BOT_TOKEN")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Bot token OK: @CoolBot" in captured.out
+        assert "DISCORD_BOT_TOKEN" in captured.out
+
+    def test_401_response_triggers_health_monitor_warning(self, capsys, monkeypatch):
+        posted_messages: list[str] = []
+
+        def fake_post_warning(message: str) -> None:
+            posted_messages.append(message)
+
+        monkeypatch.setattr(health, "_post_health_monitor_warning", fake_post_warning)
+
+        response = _make_response(401)
+        with patch("scripts.check_bot_token_health.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            mock_session.get.return_value = response
+
+            result = health.check_token("bad-token", "DISCORD_BOT_TOKEN")
+
+        assert result is False
+        assert len(posted_messages) == 1
+        assert "🔴" in posted_messages[0]
+        assert "DISCORD_BOT_TOKEN" in posted_messages[0]
+        assert "401" in posted_messages[0]
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+
+    def test_scheduling_token_valid_prints_username(self, capsys):
+        response = _make_response(200, {"username": "ScheduleBot", "id": "456"})
+        with patch("scripts.check_bot_token_health.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            mock_session.get.return_value = response
+
+            result = health.check_token("valid-sched-token", "DISCORD_SCHEDULING_BOT_TOKEN")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Bot token OK: @ScheduleBot" in captured.out
+        assert "DISCORD_SCHEDULING_BOT_TOKEN" in captured.out


### PR DESCRIPTION
## Summary
- Adds `scripts/check_bot_token_health.py` that calls `GET /users/@me` for `DISCORD_BOT_TOKEN` and `DISCORD_SCHEDULING_BOT_TOKEN`
- Posts a 🔴 warning to `DISCORD_HEALTH_MONITOR_WEBHOOK_URL` on 401 Unauthorized
- New step added to `bot-health-report.yml` after package install, with `continue-on-error: true` so the report still posts even if tokens fail

## Test plan
- [x] `test_valid_token_prints_username` — valid token prints `Bot token OK: @username`
- [x] `test_401_response_triggers_health_monitor_warning` — 401 posts 🔴 warning to health monitor
- [x] `test_scheduling_token_valid_prints_username` — scheduling token path covered
- [x] Full suite: 383 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)