### PR TITLE
feat: add concurrency groups to daily and evening-winners workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,10 @@ on:
     # This runs at 13:00 UTC year-round: 9:00 AM in New York during EDT, 8:00 AM during EST.
     - cron: "0 13 * * *"
 
+concurrency:
+  group: daily-picks-state
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -12,6 +12,10 @@ on:
     # This runs at 23:00 UTC year-round: 7:00 PM in New York during EDT, 6:00 PM during EST.
     - cron: "0 23 * * *"
 
+concurrency:
+  group: evening-winners-state
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- Adds `concurrency: group: daily-picks-state` to `daily.yml`
- Adds `concurrency: group: evening-winners-state` to `evening-winners.yml`
- Both use `cancel-in-progress: false` so in-flight runs are never cancelled

Prevents concurrent scheduled or manual re-runs from racing on state file writes.

## Test plan
- [x] No Python code changed — workflow-only
- [x] Full suite: 393 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)