### PR TITLE
feat: vertical Step 1 intro jump links and emoji footer labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -2119,10 +2119,10 @@ _DAILY_INTRO_SECTION_LABELS = {
     "instagram": ("📸", "Instagram Picks"),
 }
 _DAILY_FOOTER_SECTION_LABELS = {
-    "demo_playtest": "Demos",
-    "free": "Free Picks",
-    "paid": "Paid",
-    "instagram": "Instagram",
+    "demo_playtest": "🎮 Demos",
+    "free": "🆓 Free",
+    "paid": "💰 Paid",
+    "instagram": "📸 Instagram",
 }
 
 
@@ -2158,7 +2158,8 @@ def build_daily_picks_intro_content(
             parts.append(f"{emoji} [{label}]({link})")
         if parts:
             lines.append("")
-            lines.append(" · ".join(parts))
+            for part in parts:
+                lines.append(part)
 
     lines.append("")
     lines.append(DAILY_INTRO_DIVIDER)

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -1583,6 +1583,39 @@ class TestStep1IntroFooterFormatting:
         footer = posted[-1]
         assert "⬆️ Top" in footer
 
+    def test_intro_jump_links_are_vertical_not_horizontal(self, monkeypatch, tmp_path):
+        items = {
+            "demo_playtest": [{"title": "D", "url": "https://store.steampowered.com/app/1", "score": 9}],
+            "free": [{"title": "G", "url": "https://store.steampowered.com/app/2", "score": 9}],
+        }
+        posted, fake_client = self._run_post(monkeypatch, tmp_path, items)
+        edited_intro = fake_client.edits[0][2]
+        assert " · " not in edited_intro, "Jump links must be vertical, not joined with ' · '"
+
+    def test_intro_each_section_link_on_own_line(self, monkeypatch, tmp_path):
+        items = {
+            "demo_playtest": [{"title": "D", "url": "https://store.steampowered.com/app/1", "score": 9}],
+            "free": [{"title": "G", "url": "https://store.steampowered.com/app/2", "score": 9}],
+            "paid": [{"title": "P", "url": "https://store.steampowered.com/app/3", "score": 8, "price": "$9.99"}],
+        }
+        posted, fake_client = self._run_post(monkeypatch, tmp_path, items)
+        edited_intro = fake_client.edits[0][2]
+        intro_lines = edited_intro.split("\n")
+        link_lines = [line for line in intro_lines if "](https://discord.com/" in line]
+        assert len(link_lines) == 3, f"Expected 3 link lines, got {len(link_lines)}: {link_lines}"
+
+    def test_footer_section_labels_include_emojis(self, monkeypatch, tmp_path):
+        items = {
+            "demo_playtest": [{"title": "D", "url": "https://store.steampowered.com/app/1", "score": 9}],
+            "free": [{"title": "G", "url": "https://store.steampowered.com/app/2", "score": 9}],
+            "paid": [{"title": "P", "url": "https://store.steampowered.com/app/3", "score": 8, "price": "$9.99"}],
+        }
+        posted, _ = self._run_post(monkeypatch, tmp_path, items)
+        footer = posted[-1]
+        assert "🎮 Demos" in footer
+        assert "🆓 Free" in footer
+        assert "💰 Paid" in footer
+
 
 class TestScrapingHealthCheck:
     def test_all_pages_fail_yields_broken_status(self):


### PR DESCRIPTION
## Summary
- `build_daily_picks_intro_content()`: jump links now render one per line instead of `·`-joined
- `_DAILY_FOOTER_SECTION_LABELS`: each label now has an emoji prefix (🎮 Demos, 🆓 Free, 💰 Paid, 📸 Instagram)

## Test plan
- [x] `test_intro_jump_links_are_vertical_not_horizontal` — asserts `" · "` not in edited intro
- [x] `test_intro_each_section_link_on_own_line` — 3 sections → 3 separate link lines
- [x] `test_footer_section_labels_include_emojis` — all three emoji labels present in footer
- [x] Full suite: 396 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)