### PR TITLE
feat: warn health monitor when bot token env vars are missing

### DIFF
--- a/scripts/check_bot_token_health.py
+++ b/scripts/check_bot_token_health.py
@@ -79,13 +79,23 @@ def main() -> None:
     if bot_token:
         tokens.append((bot_token, "DISCORD_BOT_TOKEN"))
     else:
-        print("SKIP: DISCORD_BOT_TOKEN is not set")
+        print("WARN: DISCORD_BOT_TOKEN is not set", file=sys.stderr)
+        _post_health_monitor_warning(
+            "⚠️ DISCORD_BOT_TOKEN is not set\n"
+            "The bot token secret is missing from this environment. "
+            "Daily picks and library posts will fail without it."
+        )
 
     scheduling_token = os.getenv("DISCORD_SCHEDULING_BOT_TOKEN", "")
     if scheduling_token:
         tokens.append((scheduling_token, "DISCORD_SCHEDULING_BOT_TOKEN"))
     else:
-        print("SKIP: DISCORD_SCHEDULING_BOT_TOKEN is not set")
+        print("WARN: DISCORD_SCHEDULING_BOT_TOKEN is not set", file=sys.stderr)
+        _post_health_monitor_warning(
+            "⚠️ DISCORD_SCHEDULING_BOT_TOKEN is not set\n"
+            "The scheduling bot token secret is missing from this environment. "
+            "Weekly scheduling posts will fail without it."
+        )
 
     for token, label in tokens:
         check_token(token, label)

--- a/tests/test_check_bot_token_health.py
+++ b/tests/test_check_bot_token_health.py
@@ -67,3 +67,43 @@ class TestCheckToken:
         captured = capsys.readouterr()
         assert "Bot token OK: @ScheduleBot" in captured.out
         assert "DISCORD_SCHEDULING_BOT_TOKEN" in captured.out
+
+
+class TestMissingTokenWarnings:
+    def test_missing_bot_token_posts_health_monitor_warning(self, monkeypatch, capsys):
+        posted_messages: list[str] = []
+
+        def fake_post_warning(message: str) -> None:
+            posted_messages.append(message)
+
+        monkeypatch.setattr(health, "_post_health_monitor_warning", fake_post_warning)
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("DISCORD_SCHEDULING_BOT_TOKEN", raising=False)
+
+        health.main()
+
+        assert any("DISCORD_BOT_TOKEN" in m for m in posted_messages), "Expected warning for missing DISCORD_BOT_TOKEN"
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+        assert "DISCORD_BOT_TOKEN" in captured.err
+
+    def test_missing_scheduling_token_posts_health_monitor_warning(self, monkeypatch, capsys):
+        posted_messages: list[str] = []
+
+        def fake_post_warning(message: str) -> None:
+            posted_messages.append(message)
+
+        monkeypatch.setattr(health, "_post_health_monitor_warning", fake_post_warning)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "some-token")
+        monkeypatch.delenv("DISCORD_SCHEDULING_BOT_TOKEN", raising=False)
+
+        with patch("scripts.check_bot_token_health.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            mock_session.get.return_value = _make_response(200, {"username": "Bot", "id": "1"})
+            health.main()
+
+        assert any("DISCORD_SCHEDULING_BOT_TOKEN" in m for m in posted_messages), \
+            "Expected warning for missing DISCORD_SCHEDULING_BOT_TOKEN"
+        captured = capsys.readouterr()
+        assert "DISCORD_SCHEDULING_BOT_TOKEN" in captured.err


### PR DESCRIPTION
## Summary
- `scripts/check_bot_token_health.py`: when `DISCORD_BOT_TOKEN` or `DISCORD_SCHEDULING_BOT_TOKEN` is absent (empty string), replace the silent `SKIP` print with a `WARN` to stderr and a webhook post to the health monitor channel
- Each missing-token warning message names the specific secret and explains which workflows will break

## Test plan
- [ ] `pytest tests/test_check_bot_token_health.py::TestMissingTokenWarnings` — both new tests pass
- [ ] Full suite: `pytest --tb=short -q` → 395 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)