### PR TITLE
fix: check each state file individually before git add in state-backup.yml

### DIFF
--- a/.github/workflows/state-backup.yml
+++ b/.github/workflows/state-backup.yml
@@ -53,7 +53,7 @@ jobs:
             data/scheduling/weekly_schedule_bot_outputs.json \
             2>/dev/null || true
 
-          git add \
+          for f in \
             seen_ids.json \
             instagram_seen.json \
             page_state.json \
@@ -61,9 +61,21 @@ jobs:
             gaming_library.json \
             data/health_monitor_log.json \
             data/pinned_messages.json \
-            data/instagram_fetch_summary.json \
-            data/scheduling/ \
-            2>/dev/null || true
+            data/instagram_fetch_summary.json; do
+            if [ -f "$f" ]; then
+              git add "$f"
+              echo "Added: $f"
+            else
+              echo "SKIP: $f not found"
+            fi
+          done
+
+          if [ -d "data/scheduling" ]; then
+            git add data/scheduling/
+            echo "Added: data/scheduling/"
+          else
+            echo "SKIP: data/scheduling/ not found"
+          fi
 
           if ! git diff --cached --quiet; then
             git commit -m "backup: state files ${ET_TIMESTAMP}"


### PR DESCRIPTION
## Summary
- Replaced the single `git add ... 2>/dev/null || true` block with per-file existence checks using a `for` loop
- Each regular file is checked with `[ -f "$f" ]`; `data/scheduling/` is checked with `[ -d "data/scheduling" ]`
- Missing files print `SKIP: <path> not found` instead of being silently ignored

## Test plan
- [ ] No new tests needed (workflow file only)
- [ ] Full suite: `pytest --tb=short -q` → 408 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)