### PR TITLE
feat: add watchdog.yml to health report monitoring

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -75,6 +75,7 @@ jobs:
               { file: "evening-winners.yml", name: "Evening Winners", staleHours: 12 },
               { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 20 },
               { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 4 },
+              { file: "watchdog.yml", name: "Missed-Run Watchdog", staleHours: 2 },
             ];
 
             const output = [];

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -76,6 +76,14 @@ SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
         "minute": 15,
         "window_before_minutes": 30,
     },
+    "Missed-Run Watchdog": {
+        "kind": "interval",
+        "cron": "0 * * * *",
+        "cadence": "every hour",
+        "interval_hours": 1,
+        "minute": 0,
+        "window_before_minutes": 90,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- `bot-health-report.yml`: added `{ file: "watchdog.yml", name: "Missed-Run Watchdog", staleHours: 2 }` to the workflows array so the health report flags watchdog as stale if it hasn't run in over 2 hours
- `scripts/build_daily_health_report.py`: added `"Missed-Run Watchdog"` to `SCHEDULE_EXPECTATIONS` with `kind: "interval"`, `cron: "0 * * * *"`, `interval_hours: 1`, `window_before_minutes: 90`

## Test plan
- [ ] No new tests needed for workflow changes
- [ ] Existing `build_daily_health_report.py` tests still pass
- [ ] Full suite: `pytest --tb=short -q` → 408 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)