### PR TITLE
fix: upload discord-verification artifact in evening-winners.yml

### DIFF
--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -95,6 +95,14 @@ jobs:
           WINNERS_DATE_UTC: ${{ inputs.winners_date_utc }}
         run: python scripts/verify_discord_output.py
 
+      - name: Upload Discord verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-verification-${{ github.run_id }}
+          path: discord_verification.json
+          if-no-files-found: ignore
+
       - name: Save updated winners state
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Added `Upload Discord verification artifact` step immediately after `Verify Discord output` in `evening-winners.yml`
- Uses `if: always()` so the artifact is uploaded even when verification reports failures
- Uses `if-no-files-found: ignore` so the step doesn't fail if `verify_discord_output.py` crashed before writing the file
- Artifact name matches the pattern `discord-verification-{run_id}` that auto-fix already downloads

## Test plan
- [ ] No new tests needed (workflow file only)
- [ ] Full suite: `pytest --tb=short -q` → 408 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)