### PR TITLE
feat: add concurrency group to watchdog.yml

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+concurrency:
+  group: watchdog
+  cancel-in-progress: false
+
 permissions:
   actions: write
   contents: write


### PR DESCRIPTION
## Summary
- Added `concurrency: group: watchdog / cancel-in-progress: false` at the top level of `watchdog.yml` so a second hourly trigger queues rather than runs in parallel with an in-progress run

## Test plan
- [ ] No new tests needed (workflow file only)
- [ ] Full suite: `pytest --tb=short -q` → 415 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)