### PR TITLE
fix: catch DiscordPermissionError when pinning messages

### DIFF
--- a/scripts/ensure_pinned_messages.py
+++ b/scripts/ensure_pinned_messages.py
@@ -14,7 +14,7 @@ import sys
 
 import requests
 
-from discord_api import DiscordClient, DiscordMessageNotFoundError
+from discord_api import DiscordClient, DiscordMessageNotFoundError, DiscordPermissionError
 from state_utils import load_json_object, save_json_object_atomic
 
 PINNED_MESSAGES_FILE = "data/pinned_messages.json"
@@ -175,7 +175,16 @@ def ensure_pinned_messages(
             if not new_id:
                 print(f"ERROR: Discord did not return message ID for {slug}", file=sys.stderr)
                 continue
-            active_client.pin_message(channel_id, new_id, context=f"pin {slug}")
+            try:
+                active_client.pin_message(channel_id, new_id, context=f"pin {slug}")
+            except DiscordPermissionError as e:
+                print(
+                    f"WARN: cannot pin message in {slug} — bot missing Manage Messages permission: {e}"
+                )
+                print(
+                    f"INFO: pinned message content was posted but could not be pinned. "
+                    f"Grant the bot Manage Messages permission to enable pinning."
+                )
             print(f"CREATE+PIN: pinned message for {slug} (message_id={new_id})")
             state[slug] = {"channel_id": channel_id, "message_id": new_id}
 

--- a/tests/test_ensure_pinned_messages.py
+++ b/tests/test_ensure_pinned_messages.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from scripts import ensure_pinned_messages as epm
-from discord_api import DiscordMessageNotFoundError
+from discord_api import DiscordMessageNotFoundError, DiscordPermissionError
 
 
 class FakeClient:
@@ -193,3 +193,44 @@ def test_step3_content_includes_commands_list(monkeypatch, tmp_path):
     assert "!rename" in content
     assert "!archive" in content
     assert "permanent gaming library" in content
+
+
+class FakeClientWithPermError(FakeClient):
+    """FakeClient whose pin_message raises DiscordPermissionError."""
+
+    def pin_message(self, channel_id, message_id, *, context):
+        raise DiscordPermissionError(f"403 Forbidden pinning {message_id}")
+
+
+def test_pin_permission_error_warns_and_continues(monkeypatch, tmp_path, capsys):
+    """When pin_message raises DiscordPermissionError, the script warns and does not crash."""
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        channel_envs={"DISCORD_STEP1_CHANNEL_ID": "chan-step1"},
+        fake_client=FakeClientWithPermError(),
+    )
+
+    # Message was still created despite the pin failure
+    assert len(fake.created_messages) == 1
+    assert "step-1" in saved
+
+    captured = capsys.readouterr()
+    assert "WARN" in captured.out
+    assert "Manage Messages" in captured.out
+
+
+def test_pin_permission_error_does_not_prevent_other_channels(monkeypatch, tmp_path, capsys):
+    """A permission error on one channel does not prevent other channels from being processed."""
+    saved, fake = _run(
+        monkeypatch, tmp_path,
+        channel_envs={
+            "DISCORD_STEP1_CHANNEL_ID": "chan-step1",
+            "DISCORD_WINNERS_CHANNEL_ID": "chan-step2",
+        },
+        fake_client=FakeClientWithPermError(),
+    )
+
+    # Both channels should have messages created
+    assert len(fake.created_messages) == 2
+    assert "step-1" in saved
+    assert "step-2" in saved


### PR DESCRIPTION
## Summary
- `scripts/ensure_pinned_messages.py` imported `DiscordMessageNotFoundError` but not `DiscordPermissionError`
- A 403 Forbidden response from `pin_message` raised an unhandled exception, crashing the script and blocking remaining channels
- Now wraps `pin_message` in `try/except DiscordPermissionError`, logs a `WARN` with guidance, and continues processing other channels

## Test plan
- [x] `test_pin_permission_error_warns_and_continues` — verifies warning is printed and message is still created
- [x] `test_pin_permission_error_does_not_prevent_other_channels` — verifies both channels are processed despite permission error on each
- [x] Full test suite: 417 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)