### PR TITLE
fix: add missing category notices to footers and update first-line format for Steps 1, 2, 3

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -216,18 +216,28 @@ def build_winners_navigation_footer(
             continue
         section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
         if not isinstance(section_state, dict):
-            return None
+            continue
         channel_id = str(section_state.get("channel_id") or "").strip()
         message_id = str(section_state.get("message_id") or "").strip()
         if not channel_id or not message_id:
-            return None
+            continue
         label = _WINNERS_FOOTER_SECTION_LABELS.get(section_key, section_key)
         link_parts.append(f"[{label}]({build_discord_message_link(guild_id, channel_id, message_id)})")
 
     top_link = build_discord_message_link(guild_id, intro_channel_id, intro_message_id)
     link_parts.append(f"[⬆️ Top]({top_link})")
 
-    first_line = f"📅 {date_str} · Jump to: {' · '.join(link_parts)}"
+    all_section_keys = list(SECTION_ORDER)
+    missing_sections = [k for k in all_section_keys if k not in posted_section_keys]
+    missing_lines = []
+    for key in missing_sections:
+        label = _WINNERS_MISSING_SECTION_LABELS.get(key, key)
+        missing_lines.append(f"_(No {label} today)_")
+
+    first_line = f"📅 End of Daily Winners — {date_str} · Jump to: {' · '.join(link_parts)}"
+    if missing_lines:
+        missing_block = "\n".join(missing_lines)
+        return f"{first_line}\n{missing_block}\n{WINNERS_FOOTER_SEPARATOR}"
     return f"{first_line}\n{WINNERS_FOOTER_SEPARATOR}"
 
 

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -90,6 +90,12 @@ _LIBRARY_FOOTER_SECTION_LABELS = {
     CATEGORY_CREATOR_PICKS: "📸 Creator",
     CATEGORY_OTHER: "🎮 Other",
 }
+_LIBRARY_FOOTER_MISSING_LABELS = {
+    CATEGORY_DEMO_PLAYTEST: "Demo & Playtest",
+    CATEGORY_FREE_PICKS: "Free Picks",
+    CATEGORY_PAID_PICKS: "Paid Picks",
+    CATEGORY_CREATOR_PICKS: "Creator Picks",
+}
 
 COMMAND_REFERENCE_MESSAGE = """\
 📋 Bot Commands — step-3-review-existing-games
@@ -451,7 +457,7 @@ def build_library_footer(
     """Build the Step 3 footer: date+jump line followed by End separator."""
     date_str = format_library_date(day_key)
     if not isinstance(guild_id, str) or not guild_id.strip() or not header_message_id:
-        return f"📅 {date_str}\n{LIBRARY_FOOTER_SEPARATOR}"
+        return f"📅 End of Gaming Library — {date_str}\n{LIBRARY_FOOTER_SEPARATOR}"
 
     link_parts: List[str] = []
     if posted_section_keys and channel_id:
@@ -466,7 +472,25 @@ def build_library_footer(
     top_link = _discord_message_link(guild_id, header_channel_id, header_message_id)
     link_parts.append(f"[⬆️ Top]({top_link})")
 
-    first_line = f"📅 {date_str} · Jump to: {' · '.join(link_parts)}"
+    active_categories = set()
+    if posted_section_keys:
+        for category in CATEGORY_ORDER:
+            section_key = f"section:{category}"
+            if posted_section_keys.get(section_key):
+                active_categories.add(category)
+
+    missing_lines = []
+    for category in CATEGORY_ORDER:
+        if category == CATEGORY_OTHER:
+            continue
+        if category not in active_categories:
+            label = _LIBRARY_FOOTER_MISSING_LABELS.get(category, category)
+            missing_lines.append(f"_(No {label} in library)_")
+
+    first_line = f"📅 End of Gaming Library — {date_str} · Jump to: {' · '.join(link_parts)}"
+    if missing_lines:
+        missing_block = "\n".join(missing_lines)
+        return f"{first_line}\n{missing_block}\n{LIBRARY_FOOTER_SEPARATOR}"
     return f"{first_line}\n{LIBRARY_FOOTER_SEPARATOR}"
 
 

--- a/main.py
+++ b/main.py
@@ -2220,7 +2220,17 @@ def build_daily_picks_footer_content(
     top_link = build_discord_message_link(guild_id, intro_channel_id, intro_message_id)
     link_parts.append(f"[⬆️ Top]({top_link})")
 
-    first_line = f"📅 {date_str} · Jump to: {' · '.join(link_parts)}"
+    all_section_keys = list(DAILY_SECTION_ORDER)
+    missing_sections = [k for k in all_section_keys if k not in posted_section_keys]
+    missing_lines = []
+    for key in missing_sections:
+        label = _DAILY_MISSING_SECTION_LABELS.get(key, key)
+        missing_lines.append(f"_(No {label} today)_")
+
+    first_line = f"📅 End of Daily Picks — {date_str} · Jump to: {' · '.join(link_parts)}"
+    if missing_lines:
+        missing_block = "\n".join(missing_lines)
+        return f"{first_line}\n{missing_block}\n{DAILY_FOOTER_SEPARATOR}"
     return f"{first_line}\n{DAILY_FOOTER_SEPARATOR}"
 
 

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -141,9 +141,13 @@ def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
     winners.main()
     footer = fake.posts[-1][1]
     assert "Free" in footer
-    assert "Paid" not in footer
-    assert "Creator" not in footer
     assert "⬆️ Top" in footer
+    # Jump links only include posted sections (no [Paid] or [Creator] links)
+    assert "[💰 Paid]" not in footer
+    assert "[📸 Creator]" not in footer
+    # Missing section notices ARE present
+    assert "_(No Paid Winners today)_" in footer
+    assert "_(No Creator Winners today)_" in footer
 
 
 def test_winners_header_shows_date_and_subtitle(monkeypatch, tmp_path):
@@ -623,8 +627,12 @@ class TestStep2IntroFooterFormatting:
         )
         assert footer is not None
         assert "Free" in footer
-        assert "Paid" not in footer
-        assert "Demo & Playtest" not in footer
+        # Jump links only include posted sections
+        assert "[💰 Paid]" not in footer
+        assert "[🎮 Demo & Playtest]" not in footer
+        # Missing section notices ARE present
+        assert "_(No Paid Winners today)_" in footer
+        assert "_(No Demo & Playtest Winners today)_" in footer
 
 
 class TestStep2MissingSectionNotices:
@@ -652,3 +660,40 @@ class TestStep2MissingSectionNotices:
     def test_present_winner_section_does_not_show_missing_notice(self):
         header = self._build_header(["free"])
         assert "_(No Free Winners today)_" not in header
+
+
+# ---------------------------------------------------------------------------
+# FIX: Step 2 footer first-line format and missing section notices
+# ---------------------------------------------------------------------------
+
+class TestStep2FooterFormat:
+    def _build_footer(self, posted_section_keys):
+        winners_state = {
+            "intro": {"channel_id": "wchan", "message_id": "intro-1"},
+            "section_headers": {
+                key: {"channel_id": "wchan", "message_id": f"hdr-{key}"}
+                for key in posted_section_keys
+            },
+        }
+        return winners.build_winners_navigation_footer(
+            winners_state,
+            guild_id="guild-1",
+            target_day_key="2026-04-15",
+            posted_section_keys=posted_section_keys,
+        )
+
+    def test_step2_footer_first_line_starts_with_end_of_daily_winners(self):
+        """Step 2 footer first line must start with '📅 End of Daily Winners —'."""
+        footer = self._build_footer(["free"])
+        assert footer is not None
+        first_line = footer.split("\n")[0]
+        assert first_line.startswith("📅 End of Daily Winners — Wednesday, April 15, 2026")
+
+    def test_step2_footer_shows_missing_winner_notices(self):
+        """Footer includes _(No X Winners today)_ for each section not posted."""
+        footer = self._build_footer(["free"])
+        assert footer is not None
+        assert "_(No Demo & Playtest Winners today)_" in footer
+        assert "_(No Paid Winners today)_" in footer
+        assert "_(No Creator Winners today)_" in footer
+        assert "_(No Free Winners today)_" not in footer

--- a/tests/test_gaming_library.py
+++ b/tests/test_gaming_library.py
@@ -897,3 +897,37 @@ def test_gaming_library_header_placeholder_not_re_edited_on_rerun(capsys):
     assert "📊 Today's Changes" in final_content, (
         "nav_header edit on rerun must still include delta"
     )
+
+
+# ---------------------------------------------------------------------------
+# FIX: Step 3 footer first-line format and missing category notices
+# ---------------------------------------------------------------------------
+
+def test_step3_footer_first_line_starts_with_end_of_gaming_library():
+    """Step 3 footer first line must start with '📅 End of Gaming Library —'."""
+    footer = lib.build_library_footer(
+        day_key="2026-04-15",
+        header_channel_id="hchan",
+        header_message_id="hdr-1",
+        guild_id="guild-1",
+        channel_id="lchan",
+        posted_section_keys={f"section:{lib.CATEGORY_FREE_PICKS}": "m-free"},
+    )
+    first_line = footer.split("\n")[0]
+    assert first_line.startswith("📅 End of Gaming Library — Wednesday, April 15, 2026")
+
+
+def test_step3_footer_shows_missing_category_notices():
+    """Footer includes _(No X in library)_ for each category not in posted_section_keys."""
+    footer = lib.build_library_footer(
+        day_key="2026-04-15",
+        header_channel_id="hchan",
+        header_message_id="hdr-1",
+        guild_id="guild-1",
+        channel_id="lchan",
+        posted_section_keys={f"section:{lib.CATEGORY_FREE_PICKS}": "m-free"},
+    )
+    assert "_(No Demo & Playtest in library)_" in footer
+    assert "_(No Paid Picks in library)_" in footer
+    assert "_(No Creator Picks in library)_" in footer
+    assert "_(No Free Picks in library)_" not in footer

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -375,7 +375,7 @@ def test_daily_picks_header_and_footer_are_posted_with_expected_links(monkeypatc
 
     # Footer posted last — new format: single date+links line + End separator
     footer = posted[-1]
-    assert footer.startswith("📅 Wednesday, April 8, 2026 · Jump to:")
+    assert footer.startswith("📅 End of Daily Picks — Wednesday, April 8, 2026 · Jump to:")
     assert "⬆️ Top" in footer
     assert footer.endswith(main.DAILY_FOOTER_SEPARATOR)
     # Footer must not be a copy of intro
@@ -559,7 +559,7 @@ def test_daily_picks_footer_uses_target_day_override_for_display(monkeypatch, tm
 
     main.post_daily_pick_messages([], [{"title": "Free", "url": "https://store.steampowered.com/app/12", "score": 10}], [], [])
 
-    assert posted[-1].startswith("📅 Friday, April 10, 2026 · Jump to:")
+    assert posted[-1].startswith("📅 End of Daily Picks — Friday, April 10, 2026 · Jump to:")
 
 
 def test_daily_picks_footer_skips_safely_when_guild_id_missing(monkeypatch, tmp_path):
@@ -1952,3 +1952,63 @@ class TestStaleSectionHeaderPruning:
         assert "free" in saved_run_state.get("section_headers", {}), (
             "Active free section header must not be pruned"
         )
+
+
+# ---------------------------------------------------------------------------
+# FIX: Step 1 footer first-line format and missing section notices
+# ---------------------------------------------------------------------------
+
+def _make_step1_run_state(posted_keys):
+    """Build a minimal run_state for build_daily_picks_footer_content."""
+    section_headers = {
+        key: {"channel_id": "chan-1", "message_id": f"hdr-{key}"}
+        for key in posted_keys
+    }
+    return {
+        "intro": {"channel_id": "chan-1", "message_id": "intro-1"},
+        "section_headers": section_headers,
+    }
+
+
+def test_step1_footer_first_line_starts_with_end_of_daily_picks():
+    """Step 1 footer first line must start with '📅 End of Daily Picks —'."""
+    run_state = _make_step1_run_state(["free"])
+    footer = main.build_daily_picks_footer_content(
+        run_state,
+        guild_id="guild-1",
+        target_day_key="2026-04-15",
+        posted_section_keys=["free"],
+    )
+    assert footer is not None
+    first_line = footer.split("\n")[0]
+    assert first_line.startswith("📅 End of Daily Picks — Wednesday, April 15, 2026")
+
+
+def test_step1_footer_shows_missing_section_notices():
+    """Footer includes _(No X today)_ for each section not in posted_section_keys."""
+    run_state = _make_step1_run_state(["free"])
+    footer = main.build_daily_picks_footer_content(
+        run_state,
+        guild_id="guild-1",
+        target_day_key="2026-04-15",
+        posted_section_keys=["free"],
+    )
+    assert footer is not None
+    assert "_(No Demos & Playtests today)_" in footer
+    assert "_(No Paid Under $20 today)_" in footer
+    assert "_(No Instagram Picks today)_" in footer
+    assert "_(No Free Picks today)_" not in footer
+
+
+def test_step1_footer_no_missing_notices_when_all_sections_present():
+    """Footer has no missing notices when all sections are in posted_section_keys."""
+    all_keys = ["demo_playtest", "free", "paid", "instagram"]
+    run_state = _make_step1_run_state(all_keys)
+    footer = main.build_daily_picks_footer_content(
+        run_state,
+        guild_id="guild-1",
+        target_day_key="2026-04-15",
+        posted_section_keys=all_keys,
+    )
+    assert footer is not None
+    assert "_(No " not in footer


### PR DESCRIPTION
## Summary
- Footer first lines for Steps 1, 2, 3 now read `📅 End of X — {date} · Jump to: ...` instead of `📅 {date} · Jump to: ...`
- Footers now include `_(No X today)_` / `_(No X in library)_` notices for each section that had no content that day
- Added `_LIBRARY_FOOTER_MISSING_LABELS` constant to `gaming_library.py`
- Fixed `build_winners_navigation_footer` loop in `evening_winners.py` to use `continue` instead of `return None` for missing section states (prevents premature early-exit before footer is built)

## Files changed
- `main.py` — `build_daily_picks_footer_content()`: new first-line format, missing section notices
- `evening_winners.py` — `build_winners_navigation_footer()`: new first-line format, missing section notices, loop `return None` → `continue` fix
- `gaming_library.py` — `build_library_footer()`: new first-line format, missing category notices, new `_LIBRARY_FOOTER_MISSING_LABELS` constant

## Tests
- 7 new tests added across all 3 test files
- 2 existing tests updated to match new first-line format
- 2 existing tests updated to distinguish between jump-link absence and missing-notice presence
- **434 total tests pass, 0 failures**

## Test plan
- [ ] Run `python -m pytest tests/` — expect 434 passed
- [ ] Confirm Step 1 footer in Discord shows `📅 End of Daily Picks — {date}` on next daily run
- [ ] Confirm Step 2 footer shows `_(No X today)_` for any sections with no winners
- [ ] Confirm Step 3 footer shows `_(No X in library)_` for any categories with no games

🤖 Generated with [Claude Code](https://claude.com/claude-code)