### PR TITLE
fix: graceful handling of unpin_message 403 errors in weekly-scheduling-bot

### DIFF
--- a/scripts/post_weekly_availability.py
+++ b/scripts/post_weekly_availability.py
@@ -8,12 +8,13 @@ from typing import Any
 
 import requests
 
-from discord_api import DiscordClient, DiscordMessageNotFoundError
+from discord_api import DiscordClient, DiscordMessageNotFoundError, DiscordPermissionError
 from scripts.scheduling_labels import DAY_MESSAGE_TEMPLATES, format_day_label
 from state_utils import load_json_object, prune_latest_keys, save_json_object_atomic
 
 USER_AGENT = "steam-discord-free-games/weekly-scheduling-bot"
 WEEKLY_SCHEDULE_MESSAGES_FILE = "data/scheduling/weekly_schedule_messages.json"
+DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL", "")
 
 INTRO_MESSAGE_TEMPLATE = """🗓️ Weekly Availability — react below for next week
 Week of {date_range}
@@ -36,6 +37,17 @@ Wed after 6
 Sat 1–4 PM"""
 
 AVAILABILITY_REACTIONS: list[str] = ["✅", "🌅", "☀️", "🌙", "❌", "📝"]
+
+
+def _notify_health_monitor(message: str) -> None:
+    """Post a warning to the Discord health monitor webhook (best-effort, never raises)."""
+    url = DISCORD_HEALTH_MONITOR_WEBHOOK_URL
+    if not url:
+        return
+    try:
+        requests.post(url, json={"content": message}, timeout=10)
+    except Exception:
+        pass
 
 
 def fail(message: str) -> None:
@@ -160,8 +172,16 @@ def main() -> None:
             pinned_id = str(pinned.get("id") or "")
             pinned_content = str(pinned.get("content") or "")
             if pinned_id and pinned_id != intro_message_id and pinned_content.startswith("🗓️ Weekly Availability"):
-                client.unpin_message(channel_id, pinned_id, context=f"unpin old weekly availability {pinned_id}")
-                print(f"UNPIN: old weekly availability message {pinned_id}")
+                try:
+                    client.unpin_message(channel_id, pinned_id, context=f"unpin old weekly availability {pinned_id}")
+                    print(f"UNPIN: old weekly availability message {pinned_id}")
+                except DiscordPermissionError as e:
+                    warning = (
+                        f"WARN: cannot unpin message {pinned_id} in scheduling channel "
+                        f"— bot missing Manage Messages permission: {e}"
+                    )
+                    print(warning)
+                    _notify_health_monitor(warning)
         if intro_message_id not in already_pinned_ids:
             client.pin_message(channel_id, intro_message_id, context=f"pin intro for {week_key}")
             print(f"PIN: intro message for {week_key} (message_id={intro_message_id})")

--- a/tests/test_weekly_post_availability.py
+++ b/tests/test_weekly_post_availability.py
@@ -1,5 +1,6 @@
 import json
 
+from discord_api import DiscordPermissionError
 from scripts import post_weekly_availability as weekly
 from scripts import scheduling_labels
 
@@ -195,3 +196,45 @@ def test_legacy_state_shape_loads_and_upgrades(monkeypatch, tmp_path, load_fixtu
     assert saved[week_key]["channel_id"] == "chan-1"
     assert "updated_at_utc" in saved[week_key]
     assert saved[week_key]["post_completed"] is True
+
+
+class FakeClientWithUnpinPermError(FakeClient):
+    """FakeClient whose unpin_message raises DiscordPermissionError."""
+
+    def unpin_message(self, channel_id, message_id, *, context):
+        raise DiscordPermissionError(f"403 Forbidden unpinning {message_id}")
+
+
+def test_unpin_permission_error_warns_and_continues(monkeypatch, tmp_path, capsys):
+    """When unpin_message raises DiscordPermissionError the script warns and does not crash."""
+    old_pinned_id = "old-intro-99"
+    pinned = [{"id": old_pinned_id, "content": "🗓️ Weekly Availability — react below for next week\nWeek of Apr 6–12, 2026"}]
+    webhook_calls = []
+
+    def fake_post(url, *, json=None, timeout=None):
+        webhook_calls.append(json)
+        return type("R", (), {"status_code": 204})()
+
+    monkeypatch.setattr(weekly.requests, "post", fake_post)
+    monkeypatch.setenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL", "https://discord.com/api/webhooks/fake")
+    monkeypatch.setattr(weekly, "DISCORD_HEALTH_MONITOR_WEBHOOK_URL", "https://discord.com/api/webhooks/fake")
+
+    fake = FakeClientWithUnpinPermError(pinned_messages=pinned)
+    saved = _run_main(monkeypatch, tmp_path, existing_state={}, fake_client=fake)
+
+    # Script must complete and save state normally
+    week_key = "2026-04-13_to_2026-04-19"
+    assert week_key in saved
+
+    # Old pin was NOT unpinned (permission denied), new intro was still pinned
+    assert old_pinned_id not in fake.unpin_calls
+    assert len(fake.pin_calls) == 1
+
+    # Warning was printed
+    captured = capsys.readouterr()
+    assert "WARN" in captured.out
+    assert "Manage Messages" in captured.out
+
+    # Health monitor webhook was called
+    assert len(webhook_calls) == 1
+    assert "Manage Messages" in webhook_calls[0]["content"]


### PR DESCRIPTION
Fixes #284

Clause Code implementation: wraps unpin_message() in try/except DiscordPermissionError in post_weekly_availability.py, matching the pattern from ensure_pinned_messages.py. 435 tests pass.