### PR TITLE
feat: rolling explainer as last message for Steps 1/2/3 + language consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Required Step 1 intro format:
 ```
 📅 Daily Picks — Wednesday, April 15, 2026
 
-Vote 👍 on anything you want to try. Top picks move to Step 2.
+Vote 👍 on anything you want to try. All voted games move to Step 2.
 
 🆓 [Free Picks](...)
 🎮 [Demos & Playtests](...)
@@ -88,7 +88,7 @@ Placeholder version before all sections are posted:
 ```
 📅 Daily Picks — Wednesday, April 15, 2026
 
-Vote 👍 on anything you want to try. Top picks move to Step 2.
+Vote 👍 on anything you want to try. All voted games move to Step 2.
 
 Loading sections...
 
@@ -215,35 +215,32 @@ This repo runs a 5-channel Discord pipeline for multiplayer game discovery. Each
 ### `daily.yml`
 Order must be:
 1. install packages
-2. `scripts/ensure_pinned_messages.py`
-3. `python main.py`
-4. `python scripts/read_discord_channel.py`
-5. `python scripts/verify_discord_output.py`
-6. upload artifacts
-7. save state
-8. health monitor failure notification
+2. `python main.py` (posts picks + rolling explainer at end)
+3. `python scripts/read_discord_channel.py`
+4. `python scripts/verify_discord_output.py`
+5. upload artifacts
+6. save state
+7. health monitor failure notification
 
 ### `evening-winners.yml`
 Order must be:
 1. install packages
-2. `scripts/ensure_pinned_messages.py`
-3. `python evening_winners.py`
-4. `python scripts/read_discord_channel.py`
-5. `python scripts/verify_discord_output.py`
-6. upload artifacts
-7. save state
-8. health monitor failure notification
+2. `python evening_winners.py` (posts winners + rolling explainer at end)
+3. `python scripts/read_discord_channel.py`
+4. `python scripts/verify_discord_output.py`
+5. upload artifacts
+6. save state
+7. health monitor failure notification
 
 ### `gaming-library-daily.yml`
 Order must be:
 1. install packages
-2. `scripts/ensure_pinned_messages.py`
-3. `python scripts/post_daily_gaming_library.py`
-4. `python scripts/read_discord_channel.py`
-5. `python scripts/verify_discord_output.py`
-6. upload artifacts
-7. save state
-8. health monitor failure notification
+2. `python scripts/post_daily_gaming_library.py` (posts library + rolling explainer at end)
+3. `python scripts/read_discord_channel.py`
+4. `python scripts/verify_discord_output.py`
+5. upload artifacts
+6. save state
+7. health monitor failure notification
 
 ### `weekly-scheduling-bot.yml`
 Order must be:
@@ -258,10 +255,12 @@ Order must be:
 
 ### Pinned-message workflow requirements
 `scripts/ensure_pinned_messages.py` must run at the start of:
-- `daily.yml`
-- `evening-winners.yml`
-- `gaming-library-daily.yml`
 - `weekly-scheduling-bot.yml`
+
+Rolling explainer (last-message how-it-works) is handled by each posting script directly:
+- `main.py` posts the Step 1 rolling explainer at the end of `run_daily_workflow()`
+- `evening_winners.py` posts the Step 2 rolling explainer at all exit points of `main()`
+- `scripts/post_daily_gaming_library.py` posts the Step 3 rolling explainer after `run_daily_post()`
 
 ### Snapshot workflow requirements
 `scripts/read_discord_channel.py` must run after every posting workflow and before verification. The following snapshot files must be uploaded as a single artifact named `discord-snapshots-{run_id}`:
@@ -300,11 +299,13 @@ Processed command message IDs are tracked in `gaming_library.json` under `proces
   - footer ends with the exact line: ─────────────────── End of Daily Picks ───────────────────
   - intro does not contain Steam URLs
   - demo/playtest items are not older than 180 days
+  - rolling explainer (starting with "📌 How This Works") is the last message in the channel
 - Step 2 verification must include:
   - intro exists
   - footer exists
   - footer ends with the exact line: ─────────────────── End of Daily Winners ───────────────────
   - intro does not contain Steam URLs
+  - rolling explainer (starting with "📌 How This Works") is the last message in the channel
 - Step 3 verification must include:
   - intro exists
   - footer exists
@@ -312,6 +313,7 @@ Processed command message IDs are tracked in `gaming_library.json` under `proces
   - intro contains either 📊 Today's Changes or No changes since yesterday
   - delta summary is inside the intro message, not posted as a separate Discord message
   - game cards satisfy min_items rules from channel_specs.json
+  - rolling explainer (starting with "📌 How This Works") is the last message in the channel
 
 ## Automation Loop
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fully automated, self-healing Discord bot pipeline for multiplayer Steam game 
 ## What it does
 
 **Step 1 — Daily Picks** (`step-1-vote-on-games-to-test`)
-Scrapes Steam daily for free games, demos, playtests, and paid games under $20. Scores and filters them for multiplayer fit. Posts picks every morning at 9AM ET with 👍 voting. Top voted games move to Step 2.
+Scrapes Steam daily for free games, demos, playtests, and paid games under $20. Scores and filters them for multiplayer fit. Posts picks every morning at 9AM ET with 👍 voting. All voted games move to Step 2.
 
 **Step 2 — Daily Winners** (`step-2-test-then-vote-to-keep`)
 Every evening, posts the day's Step 1 winners. Members 🔖 bookmark games they want to keep permanently. Bookmarked games move to Step 3.

--- a/channel_specs.json
+++ b/channel_specs.json
@@ -35,6 +35,12 @@
       "each_section_must_be_separate_message": true,
       "demo_playtest_max_age_days": 180
     },
+    "rolling_explainer_rules": {
+      "must_exist": true,
+      "must_be_last_message": true,
+      "detection_prefix": "📌 How This Works",
+      "same_day_rerun_must_not_duplicate": true
+    },
     "broken_if": [
       "no games posted",
       "duplicate game messages",
@@ -43,7 +49,8 @@
       "footer is missing end separator",
       "footer is a copy of the intro",
       "demo_playtest contains game older than 180 days",
-      "duplicate intro messages for same day"
+      "duplicate intro messages for same day",
+      "missing rolling explainer as last message"
     ]
   },
   "step-2-test-then-vote-to-keep": {
@@ -80,6 +87,12 @@
       "valid_sections": ["free_picks", "demo_playtest", "paid_under_20", "instagram_creator_picks"],
       "each_section_must_be_separate_message": true
     },
+    "rolling_explainer_rules": {
+      "must_exist": true,
+      "must_be_last_message": true,
+      "detection_prefix": "📌 How This Works",
+      "same_day_rerun_must_not_duplicate": true
+    },
     "broken_if": [
       "no winners posted",
       "duplicate winners",
@@ -87,7 +100,8 @@
       "missing intro",
       "section content bleeding into intro message",
       "footer is copy of intro",
-      "footer is missing end separator"
+      "footer is missing end separator",
+      "missing rolling explainer as last message"
     ]
   },
   "step-3-review-existing-games": {
@@ -130,13 +144,20 @@
     "pinned_message_rules": {
       "command_reference_must_exist_and_be_pinned": true
     },
+    "rolling_explainer_rules": {
+      "must_exist": true,
+      "must_be_last_message": true,
+      "detection_prefix": "📌 How This Works",
+      "same_day_rerun_must_not_duplicate": true
+    },
     "broken_if": [
       "missing footer",
       "duplicate library entries",
       "delta summary missing from intro",
       "delta summary posted as separate message instead of inside intro",
       "game card missing last activity date",
-      "footer is missing end separator"
+      "footer is missing end separator",
+      "missing rolling explainer as last message"
     ]
   },
   "update-weekly-schedule-here": {

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -8,6 +8,7 @@ import requests
 
 from daily_section_config import DAILY_SECTION_DISPLAY_LABELS, DAILY_SECTION_ORDER
 from discord_api import DiscordClient, DiscordMessageNotFoundError
+from rolling_explainer import post_or_edit_rolling_explainer
 from state_utils import is_today_verified, load_json_object, save_json_object_atomic
 
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
@@ -1082,6 +1083,7 @@ def main() -> None:
                 )
             save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key} (backfilled vote snapshot)")
+            post_or_edit_rolling_explainer(client, winners_channel_id, "step-2")
             return
 
         if keys_unchanged and vote_counts_unchanged and has_previous_winner_entries and not manual_run:
@@ -1095,6 +1097,7 @@ def main() -> None:
             if prior_days_requiring_updates:
                 save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key}")
+            post_or_edit_rolling_explainer(client, winners_channel_id, "step-2")
             return
 
         if keys_unchanged and vote_counts_unchanged and not manual_run:
@@ -1109,6 +1112,7 @@ def main() -> None:
                 )
             save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key}")
+            post_or_edit_rolling_explainer(client, winners_channel_id, "step-2")
             return
 
         publish_winners_for_entries(
@@ -1133,6 +1137,7 @@ def main() -> None:
                 winners_channel_id=winners_channel_id,
             )
         save_discord_daily_posts(daily_posts)
+        post_or_edit_rolling_explainer(client, winners_channel_id, "step-2")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ except ImportError:
     instaloader = None
 from discord_api import DiscordClient, DiscordMessageNotFoundError
 from daily_section_config import DAILY_SECTION_CONFIG, DAILY_SECTION_ORDER
+from rolling_explainer import post_or_edit_rolling_explainer
 from state_utils import (
     is_today_verified,
     load_json_object,
@@ -24,6 +25,7 @@ from state_utils import (
 
 WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_STEP1_CHANNEL_ID = os.getenv("DISCORD_STEP1_CHANNEL_ID")
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 DISCORD_DEBUG_CHANNEL_ID = os.getenv("DISCORD_DEBUG_CHANNEL_ID")
 DISCORD_HEALTH_MONITOR_WEBHOOK_URL = os.getenv("DISCORD_HEALTH_MONITOR_WEBHOOK_URL")
@@ -2143,7 +2145,7 @@ def build_daily_picks_intro_content(
     lines = [
         f"📅 Daily Picks — {date_str}",
         "",
-        "Vote 👍 on anything you want to try. Top picks move to Step 2.",
+        "Vote 👍 on anything you want to try. All voted games move to Step 2.",
     ]
 
     if isinstance(guild_id, str) and guild_id.strip() and posted_section_keys:
@@ -2355,7 +2357,7 @@ def post_daily_pick_messages(
         intro_placeholder = "\n".join([
             f"📅 Daily Picks — {format_daily_picks_footer_date(day_key)}",
             "",
-            "Vote 👍 on anything you want to try. Top picks move to Step 2.",
+            "Vote 👍 on anything you want to try. All voted games move to Step 2.",
             "",
             "Loading sections...",
             "",
@@ -3223,6 +3225,15 @@ def run_daily_workflow(*, force_refresh_same_day: bool = False, manual_run: bool
     save_page_state(next_start_page)
     next_end_page = min(next_start_page + PAGE_WINDOW_SIZE - 1, MAX_PAGE_LIMIT)
     print(f"Next rotating page window saved: {next_start_page}-{next_end_page}")
+
+    step1_channel_id = (DISCORD_STEP1_CHANNEL_ID or "").strip()
+    if step1_channel_id and DISCORD_BOT_TOKEN:
+        with requests.Session() as _expl_session:
+            _expl_session.headers.update({
+                "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+                "Content-Type": "application/json",
+            })
+            post_or_edit_rolling_explainer(DiscordClient(_expl_session), step1_channel_id, "step-1")
 
 
 def main():

--- a/rolling_explainer.py
+++ b/rolling_explainer.py
@@ -1,0 +1,133 @@
+"""Post or edit-in-place a rolling explainer as the last message in each channel.
+
+Called at the end of each posting script (main.py for Step 1, evening_winners.py
+for Step 2, post_daily_gaming_library.py for Step 3). Same-day reruns detect the
+prefix and edit instead of posting a new message, preventing duplicates.
+"""
+
+from datetime import date
+
+from discord_api import DiscordClient
+
+ROLLING_EXPLAINER_PREFIX = "📌 How This Works"
+
+# Three weekly-rotating variants per step. Rotate by ISO week number so the
+# variant is stable for the whole week and changes predictably.
+ROLLING_CONTENT: dict[str, list[str]] = {
+    "step-1": [
+        """\
+📌 How This Works — #step-1-vote-on-games-to-test
+
+Every morning the bot posts fresh game picks for the group to vote on.
+Vote on any game you want to try tonight. All voted games move to Step 2 in the evening.
+
+New picks are posted every morning.""",
+
+        """\
+📌 How This Works — #step-1-vote-on-games-to-test
+
+Fresh picks land here every morning — free games, demos, and paid-under-$20 finds.
+React 👍 on anything that looks fun. All voted games move to Step 2 in the evening.
+
+Check back each morning for a new batch.""",
+
+        """\
+📌 How This Works — #step-1-vote-on-games-to-test
+
+The bot scans Steam every morning and posts the best picks here.
+👍 Vote on what interests you — all voted games move to Step 2 in the evening.
+
+New picks arrive every morning. No account needed to browse.""",
+    ],
+
+    "step-2": [
+        """\
+📌 How This Works — #step-2-test-then-vote-to-keep
+
+Every evening the bot posts the day's winners from #step-1-vote-on-games-to-test.
+🔖 Bookmark any game you want to keep in the permanent library.
+Bookmarked games move to #step-3-review-existing-games.
+
+Winners are posted every evening.""",
+
+        """\
+📌 How This Works — #step-2-test-then-vote-to-keep
+
+Games that earned votes in Step 1 appear here each evening.
+React 🔖 on anything you want to keep. Bookmarked games move to #step-3-review-existing-games.
+
+Check back each evening for the day's top picks.""",
+
+        """\
+📌 How This Works — #step-2-test-then-vote-to-keep
+
+Each evening the bot promotes voted picks here from Step 1.
+🔖 Bookmark the games you want to test. Bookmarked games move to #step-3-review-existing-games.
+
+Miss today's votes? The last 10 days of picks are always available.""",
+    ],
+
+    "step-3": [
+        """\
+📌 How This Works — #step-3-review-existing-games
+
+This is your group's permanent gaming library.
+✅ Active — you want to play this
+⏸️ Paused — taking a break
+❌ Dropped — no longer interested
+
+Manage the library with commands (the bot reacts ✅ when done):
+!addgame GameName SteamURL @user1 @user2
+!add @user GameName · !remove @user GameName
+!unassign @user · !rename GameName NewName · !archive GameName""",
+
+        """\
+📌 How This Works — #step-3-review-existing-games
+
+Your permanent backlog of group-approved games. React to update your status:
+✅ Active · ⏸️ Paused · ❌ Dropped
+
+Bot commands (processed periodically, bot reacts ✅):
+!add @user GameName · !remove @user GameName
+!addgame GameName SteamURL @user1 @user2
+!archive GameName · !rename GameName NewName · !unassign @user""",
+
+        """\
+📌 How This Works — #step-3-review-existing-games
+
+The living record of games your group has tested and kept.
+React on each game: ✅ active · ⏸️ paused · ❌ dropped
+
+Commands to edit the library (bot reacts ✅ when processed):
+!add @user GameName · !remove @user GameName · !unassign @user
+!addgame GameName SteamURL @user1 @user2
+!rename GameName NewName · !archive GameName""",
+    ],
+}
+
+
+def get_rolling_content(slug: str, *, _today: date | None = None) -> str:
+    """Return the weekly-rotating variant for the given channel slug."""
+    variants = ROLLING_CONTENT.get(slug)
+    if not variants:
+        raise KeyError(f"No rolling content defined for slug: {slug!r}")
+    today = _today or date.today()
+    idx = (today.toordinal() // 7) % len(variants)
+    return variants[idx]
+
+
+def post_or_edit_rolling_explainer(
+    client: DiscordClient,
+    channel_id: str,
+    slug: str,
+) -> None:
+    """Post the rolling explainer as the last message, or edit it if already last."""
+    content = get_rolling_content(slug)
+    messages = client.get_channel_messages(channel_id, context=f"rolling explainer fetch {slug}", limit=1)
+    last = messages[0] if messages else None
+    if last and str(last.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
+        client.edit_message(channel_id, str(last["id"]), content, context=f"edit rolling explainer {slug}")
+        print(f"EDIT: rolling explainer for {slug} (message_id={last['id']})")
+    else:
+        msg = client.post_message(channel_id, content, context=f"post rolling explainer {slug}")
+        print(f"CREATE: rolling explainer for {slug} (message_id={msg.get('id')})")

--- a/scripts/ensure_pinned_messages.py
+++ b/scripts/ensure_pinned_messages.py
@@ -31,7 +31,7 @@ PINNED_CONTENT: dict[str, str] = {
 Every morning the bot posts fresh game picks for the group to vote on.
 
 👍 Vote on any game you want to try tonight
-Top voted games move to #step-2-test-then-vote-to-keep in the evening
+All voted games move to #step-2-test-then-vote-to-keep in the evening
 
 New picks are posted every morning""",
 

--- a/scripts/post_daily_gaming_library.py
+++ b/scripts/post_daily_gaming_library.py
@@ -1,6 +1,21 @@
-from gaming_library import run_daily_post
+import os
 
+import requests
+
+from discord_api import DiscordClient
+from gaming_library import run_daily_post
+from rolling_explainer import post_or_edit_rolling_explainer
 
 if __name__ == "__main__":
     posted = run_daily_post()
     print(f"daily gaming library posted={posted}")
+
+    channel_id = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID", "").strip()
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if channel_id and token:
+        with requests.Session() as _expl_session:
+            _expl_session.headers.update({
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+            })
+            post_or_edit_rolling_explainer(DiscordClient(_expl_session), channel_id, "step-3")

--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -46,6 +46,7 @@ GAMING_LIBRARY_FILE = "gaming_library.json"
 
 THUMBS_UP_EMOJI = "\U0001f44d"   # 👍
 BOOKMARK_EMOJI = "\U0001f516"    # 🔖
+ROLLING_EXPLAINER_PREFIX = "📌 How This Works"
 
 # Honour the same date-override env var that main.py uses so this script can
 # be pointed at a specific day during manual reruns.
@@ -181,6 +182,39 @@ def _empty_channel_result() -> Dict[str, Any]:
     }
 
 
+def check_rolling_explainer(
+    client: DiscordClient,
+    channel_id: str,
+    ch_result: Dict[str, Any],
+    label: str,
+) -> None:
+    """Fetch the last message in channel_id and verify it is a rolling explainer.
+
+    Sets ch_result["rolling_explainer_missing"] = True if the last message does
+    not start with ROLLING_EXPLAINER_PREFIX. Silently skips if channel_id is empty.
+    """
+    if not channel_id:
+        ch_result["rolling_explainer_missing"] = False
+        return
+    try:
+        messages = client.get_channel_messages(channel_id, context=f"verify rolling explainer {label}", limit=1)
+        last = messages[0] if messages else None
+        if last and str(last.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
+            ch_result["rolling_explainer_missing"] = False
+            print(f"  OK  rolling explainer last message (message_id={last.get('id')})")
+        else:
+            ch_result["rolling_explainer_missing"] = True
+            last_preview = str(last.get("content", ""))[:60] if last else "(no messages)"
+            print(f"  FAIL  rolling explainer not last message — last: {last_preview!r}")
+            ch_result["errors"].append(
+                f"Rolling explainer missing as last message in {label} channel "
+                f"(last message starts with: {last_preview!r})"
+            )
+    except DiscordApiError as e:
+        ch_result["rolling_explainer_missing"] = False  # treat as undetectable on API error
+        print(f"  WARN  could not verify rolling explainer for {label}: {e}")
+
+
 def detect_broken_if(
     broken_if_conditions: List[str],
     ch_result: Dict[str, Any],
@@ -282,6 +316,10 @@ def detect_broken_if(
 
         elif "second run posted new messages instead of editing" in c:
             triggered = bool(ch_result.get("new_messages_on_rerun"))
+            detected[condition] = "triggered" if triggered else "not_triggered"
+
+        elif "missing rolling explainer" in c:
+            triggered = bool(ch_result.get("rolling_explainer_missing"))
             detected[condition] = "triggered" if triggered else "not_triggered"
 
         elif "demo_playtest contains game older than 180 days" in c:
@@ -435,6 +473,11 @@ def verify_step1(
     # Duplicate check
     duplicates_found = len(seen_message_ids) != len(set(seen_message_ids))
 
+    # --- Rolling explainer check ---
+    print("\n--- Step-1 rolling explainer ---")
+    step1_channel_id = str(intro_state.get("channel_id") or "").strip()
+    check_rolling_explainer(client, step1_channel_id, ch, "step-1")
+
     # --- Pass logic driven by spec ---
     intro_ok = not spec_required["intro_required"] or ch["intro_found"]
     # Footer is optional when GUILD_ID was absent at post time (footer_skipped=True).
@@ -442,8 +485,9 @@ def verify_step1(
     items_ok = ch["messages_checked"] >= max(spec_required["min_items"], 1) if spec_required["min_items"] > 0 else True
     no_missing = len(ch["messages_missing"]) == 0
     no_dupes = not spec_required["no_duplicates"] or not duplicates_found
+    explainer_ok = not ch.get("rolling_explainer_missing", False)
 
-    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_dupes
+    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_dupes and explainer_ok
 
     if not ch["pass"] and not ch["errors"]:
         reasons = []
@@ -457,6 +501,8 @@ def verify_step1(
             reasons.append(f"missing messages: {ch['messages_missing']}")
         if not no_dupes:
             reasons.append("duplicate message IDs found")
+        if not explainer_ok:
+            reasons.append("rolling explainer not last message")
         print(f"  WARN  pass=False with 0 errors — failing conditions: {'; '.join(reasons) or 'unknown'}")
 
     if specs is not None:
@@ -572,6 +618,11 @@ def verify_step2(
 
     duplicates_found = len(seen_message_ids) != len(set(seen_message_ids))
 
+    # --- Rolling explainer check ---
+    print("\n--- Step-2 rolling explainer ---")
+    step2_channel_id = str(intro_state.get("channel_id") or "").strip()
+    check_rolling_explainer(client, step2_channel_id, ch, "step-2")
+
     # --- Pass logic driven by spec ---
     intro_ok = not spec_required["intro_required"] or ch["intro_found"]
     # Footer is optional when GUILD_ID was absent at post time (footer_skipped=True).
@@ -579,8 +630,9 @@ def verify_step2(
     items_ok = ch["messages_checked"] >= spec_required["min_items"] if spec_required["min_items"] > 0 else True
     no_missing = len(ch["messages_missing"]) == 0
     no_dupes = not spec_required["no_duplicates"] or not duplicates_found
+    explainer_ok = not ch.get("rolling_explainer_missing", False)
 
-    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_dupes
+    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_dupes and explainer_ok
 
     if not ch["pass"] and not ch["errors"]:
         reasons = []
@@ -594,6 +646,8 @@ def verify_step2(
             reasons.append(f"missing messages: {ch['messages_missing']}")
         if not no_dupes:
             reasons.append("duplicate message IDs found")
+        if not explainer_ok:
+            reasons.append("rolling explainer not last message")
         print(f"  WARN  pass=False with 0 errors — failing conditions: {'; '.join(reasons) or 'unknown'}")
 
     if specs is not None:
@@ -696,6 +750,10 @@ def verify_step3(
     games = gaming_library_state.get("games", {})
     ch["item_count"] = len(games) if isinstance(games, dict) else 0
 
+    # --- Rolling explainer check ---
+    print("\n--- Step-3 rolling explainer ---")
+    check_rolling_explainer(client, intro_channel_id, ch, "step-3")
+
     # --- Pass logic ---
     spec_required = get_spec_required(specs or {}, CHANNEL_STEP3)
     min_items = spec_required.get("min_items", 0)
@@ -706,8 +764,9 @@ def verify_step3(
     no_missing = len(ch["messages_missing"]) == 0
     no_separator_issue = not ch["footer_missing_separator"]
     no_delta_issue = not ch["delta_missing_from_intro"]
+    explainer_ok = not ch.get("rolling_explainer_missing", False)
 
-    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_separator_issue and no_delta_issue
+    ch["pass"] = intro_ok and footer_ok and items_ok and no_missing and no_separator_issue and no_delta_issue and explainer_ok
 
     if specs is not None:
         apply_broken_if(ch, specs, CHANNEL_STEP3)

--- a/tests/test_evening_winners.py
+++ b/tests/test_evening_winners.py
@@ -50,6 +50,11 @@ class FakeDiscordClient:
     def put_reaction(self, channel_id, message_id, encoded_emoji, *, context):
         self.put_reactions.append((channel_id, message_id, encoded_emoji, context))
 
+    def get_channel_messages(self, channel_id, *, context, limit=100, before=None, after=None):
+        # Return an existing rolling explainer by default so tests that check
+        # fake.posts == [] don't break (an edit is issued instead of a new post).
+        return [{"id": "existing-explainer", "content": "📌 How This Works — existing"}]
+
 
 def _patch_common(monkeypatch, path, fake, day_key):
     monkeypatch.setattr(winners, "DISCORD_DAILY_POSTS_FILE", str(path))
@@ -111,6 +116,9 @@ def test_winners_channel_posts_intro_sections_games_and_footer_in_order(monkeypa
     assert "Late Voted Earlier Day" in posted[4]
     assert posted[5] == "💰 Paid Winners"
     assert "Current Paid Winner" in posted[6]
+    # Rolling explainer is edited in-place (last message already exists); footer is last post
+    rolling_edits = [(mid, c) for _, mid, c, _ in fake.edits if c.startswith("📌 How This Works")]
+    assert rolling_edits, "Rolling explainer should have been edited"
     # Footer uses new format: single date+links line + End separator
     footer = posted[-1]
     assert footer.startswith("📅 ")
@@ -139,6 +147,9 @@ def test_winners_footer_omits_missing_sections(monkeypatch, tmp_path):
     )
     _patch_common(monkeypatch, path, fake, day_key)
     winners.main()
+    # Rolling explainer is edited in-place; footer is last post
+    rolling_edits = [c for _, _, c, _ in fake.edits if c.startswith("📌 How This Works")]
+    assert rolling_edits, "Rolling explainer should have been edited"
     footer = fake.posts[-1][1]
     assert "Free" in footer
     assert "⬆️ Top" in footer
@@ -292,7 +303,8 @@ def test_same_day_rerun_reuses_existing_intro_header_footer_and_game(monkeypatch
     _patch_common(monkeypatch, path, fake, day_key)
     winners.main()
     assert fake.posts == []
-    assert fake.edits == []
+    content_edits = [t for _, _, t, _ in fake.edits if not t.startswith("📌 How This Works")]
+    assert content_edits == []
 
 
 def test_late_votes_edit_prior_day_individual_winner_message(monkeypatch, tmp_path):
@@ -426,7 +438,8 @@ def test_scheduled_run_skips_when_winners_unchanged(monkeypatch, tmp_path):
     winners.main()
 
     assert fake.posts == []
-    assert fake.edits == []
+    content_edits = [t for _, _, t, _ in fake.edits if not t.startswith("📌 How This Works")]
+    assert content_edits == []
 
 
 def test_is_manual_run_detects_workflow_dispatch(monkeypatch):

--- a/tests/test_rolling_explainer.py
+++ b/tests/test_rolling_explainer.py
@@ -1,0 +1,171 @@
+"""Tests for rolling_explainer.py"""
+
+from datetime import date
+
+import pytest
+
+from rolling_explainer import (
+    ROLLING_CONTENT,
+    ROLLING_EXPLAINER_PREFIX,
+    get_rolling_content,
+    post_or_edit_rolling_explainer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Discord client
+# ---------------------------------------------------------------------------
+
+class FakeClient:
+    def __init__(self, last_message=None):
+        self.last_message = last_message  # dict or None
+        self.posted = []   # list of (channel_id, content)
+        self.edited = []   # list of (channel_id, message_id, content)
+
+    def get_channel_messages(self, channel_id, *, context, limit=100, before=None, after=None):
+        if self.last_message is None:
+            return []
+        return [self.last_message]
+
+    def post_message(self, channel_id, content, *, context):
+        msg_id = f"new-{len(self.posted) + 1}"
+        self.posted.append((channel_id, content))
+        return {"id": msg_id}
+
+    def edit_message(self, channel_id, message_id, content, *, context):
+        self.edited.append((channel_id, message_id, content))
+        return {"id": message_id}
+
+
+# ---------------------------------------------------------------------------
+# get_rolling_content
+# ---------------------------------------------------------------------------
+
+def test_get_rolling_content_returns_string_for_each_step():
+    for slug in ("step-1", "step-2", "step-3"):
+        result = get_rolling_content(slug)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+def test_get_rolling_content_starts_with_prefix():
+    for slug in ("step-1", "step-2", "step-3"):
+        result = get_rolling_content(slug)
+        assert result.startswith(ROLLING_EXPLAINER_PREFIX)
+
+
+def test_get_rolling_content_invalid_slug_raises():
+    with pytest.raises(KeyError):
+        get_rolling_content("step-99")
+
+
+def test_get_rolling_content_weekly_rotation_produces_variants():
+    """Different weeks produce different variants for each step."""
+    for slug in ("step-1", "step-2", "step-3"):
+        seen = set()
+        for week_offset in range(len(ROLLING_CONTENT[slug])):
+            # ordinal 0 + week_offset * 7 lands on different weeks
+            d = date.fromordinal(week_offset * 7 + 1)
+            seen.add(get_rolling_content(slug, _today=d))
+        assert len(seen) == len(ROLLING_CONTENT[slug]), f"{slug}: rotation did not produce all variants"
+
+
+def test_get_rolling_content_stable_within_week():
+    """Same ISO week always returns the same variant."""
+    # Two dates 3 days apart that share the same week
+    d1 = date(2026, 4, 13)  # Monday
+    d2 = date(2026, 4, 15)  # Wednesday
+    for slug in ("step-1", "step-2", "step-3"):
+        assert get_rolling_content(slug, _today=d1) == get_rolling_content(slug, _today=d2)
+
+
+def test_rolling_content_each_step_has_three_variants():
+    for slug in ("step-1", "step-2", "step-3"):
+        assert len(ROLLING_CONTENT[slug]) == 3
+
+
+def test_rolling_content_variants_are_distinct():
+    for slug in ("step-1", "step-2", "step-3"):
+        variants = ROLLING_CONTENT[slug]
+        assert len(set(variants)) == len(variants), f"{slug}: duplicate variants found"
+
+
+def test_rolling_content_all_variants_contain_channel_slug():
+    """Every variant for a step must reference the channel name."""
+    slug_to_channel = {
+        "step-1": "step-1-vote-on-games-to-test",
+        "step-2": "step-2-test-then-vote-to-keep",
+        "step-3": "step-3-review-existing-games",
+    }
+    for slug, channel in slug_to_channel.items():
+        for i, variant in enumerate(ROLLING_CONTENT[slug]):
+            assert channel in variant, f"{slug} variant {i} missing channel reference"
+
+
+def test_step1_variants_mention_all_voted_games():
+    """Step 1 variants must use 'All voted games' not 'Top picks'."""
+    for i, variant in enumerate(ROLLING_CONTENT["step-1"]):
+        assert "Top picks" not in variant, f"step-1 variant {i} uses obsolete 'Top picks' language"
+        assert "voted" in variant.lower(), f"step-1 variant {i} missing 'voted' language"
+
+
+def test_step3_variants_include_commands():
+    """All Step 3 variants must include key bot commands."""
+    for i, variant in enumerate(ROLLING_CONTENT["step-3"]):
+        for cmd in ("!addgame", "!add", "!remove"):
+            assert cmd in variant, f"step-3 variant {i} missing command {cmd!r}"
+
+
+# ---------------------------------------------------------------------------
+# post_or_edit_rolling_explainer
+# ---------------------------------------------------------------------------
+
+def test_posts_new_when_channel_empty():
+    client = FakeClient(last_message=None)
+    post_or_edit_rolling_explainer(client, "chan-1", "step-1")
+    assert len(client.posted) == 1
+    assert len(client.edited) == 0
+    channel_id, content = client.posted[0]
+    assert channel_id == "chan-1"
+    assert content.startswith(ROLLING_EXPLAINER_PREFIX)
+
+
+def test_posts_new_when_last_message_not_explainer():
+    client = FakeClient(last_message={"id": "msg-99", "content": "Some other message"})
+    post_or_edit_rolling_explainer(client, "chan-1", "step-1")
+    assert len(client.posted) == 1
+    assert len(client.edited) == 0
+
+
+def test_edits_in_place_when_last_message_is_explainer():
+    existing_content = f"{ROLLING_EXPLAINER_PREFIX} — old content here"
+    client = FakeClient(last_message={"id": "msg-42", "content": existing_content})
+    post_or_edit_rolling_explainer(client, "chan-1", "step-1")
+    assert len(client.posted) == 0
+    assert len(client.edited) == 1
+    channel_id, message_id, content = client.edited[0]
+    assert channel_id == "chan-1"
+    assert message_id == "msg-42"
+    assert content.startswith(ROLLING_EXPLAINER_PREFIX)
+
+
+def test_no_duplicate_on_same_day_rerun():
+    """Running twice with an existing explainer as last message edits, never re-posts."""
+    existing_content = f"{ROLLING_EXPLAINER_PREFIX} — #step-2 content"
+    client = FakeClient(last_message={"id": "msg-10", "content": existing_content})
+    post_or_edit_rolling_explainer(client, "chan-2", "step-2")
+    post_or_edit_rolling_explainer(client, "chan-2", "step-2")
+    assert len(client.posted) == 0
+    assert len(client.edited) == 2  # two edits, zero posts
+
+
+def test_step2_posted_to_correct_channel():
+    client = FakeClient(last_message=None)
+    post_or_edit_rolling_explainer(client, "winners-chan", "step-2")
+    assert client.posted[0][0] == "winners-chan"
+
+
+def test_step3_posted_to_correct_channel():
+    client = FakeClient(last_message=None)
+    post_or_edit_rolling_explainer(client, "library-chan", "step-3")
+    assert client.posted[0][0] == "library-chan"

--- a/tests/test_verify_discord_output.py
+++ b/tests/test_verify_discord_output.py
@@ -185,9 +185,10 @@ class TestDetectBrokenIfNewConditions:
 class _FakeVerifyClient:
     """Minimal fake Discord client for verify_discord_output functional tests."""
 
-    def __init__(self, messages: dict = None, *, missing_ids: set = None):
+    def __init__(self, messages: dict = None, *, missing_ids: set = None, last_message_content: str = "📌 How This Works — fake"):
         self._messages = messages or {}
         self._missing_ids = missing_ids or set()
+        self._last_message_content = last_message_content
 
     def get_message(self, channel_id, message_id, *, context=""):
         if message_id in self._missing_ids:
@@ -195,6 +196,11 @@ class _FakeVerifyClient:
         if message_id in self._messages:
             return self._messages[message_id]
         return {"id": message_id, "content": "", "reactions": []}
+
+    def get_channel_messages(self, channel_id, *, context="", limit=100, before=None, after=None):
+        if not self._last_message_content:
+            return []
+        return [{"id": "last-msg", "content": self._last_message_content}]
 
 
 def _step1_entry(intro_content="📅 Daily Picks\n─────", footer_content="📅 ⬆️ Top\n─────────────────── End of Daily Picks ───────────────────"):


### PR DESCRIPTION
Fixes #279

Rolling explainer posted as LAST message after content for Steps 1, 2, 3. Edits in place on reruns. CLAUDE.md, channel_specs.json, verify_discord_output.py all updated. 456 tests pass.