### PR TITLE
fix: prevent duplicate daily posts and missing intro on reruns (Issue…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1929,8 +1929,9 @@ def get_force_refresh_same_day() -> bool:
 def is_manual_run() -> bool:
     """Return True when triggered by workflow_dispatch (manual/test run).
 
-    Manual runs post to Discord but do NOT mark the day as completed so that
-    the subsequent scheduled run always executes cleanly.
+    Manual runs post to Discord and mark the day as completed unless
+    force_refresh_same_day is also set, which signals an explicit test rerun
+    that should keep the day open for the next scheduled run.
     """
     event = (os.getenv(GITHUB_EVENT_NAME_ENV, "") or "").strip().lower()
     return event == "workflow_dispatch"
@@ -2247,9 +2248,10 @@ def post_daily_pick_messages(
 ) -> Tuple[Dict[str, int], bool]:
     """Post (or reconcile) daily pick messages. Returns (run_counts, rerun_protection_active, verification_state).
 
-    When manual_run is True (workflow_dispatch trigger), the run completes normally
-    but does NOT mark the day as completed in state. This ensures the next scheduled
-    run always executes cleanly regardless of prior manual runs.
+    When manual_run is True AND force_refresh_same_day is True, the run completes
+    but does NOT mark the day as completed, keeping the day open for the next
+    scheduled run. For all other cases (including plain manual runs triggered by
+    workflow_dispatch without force_refresh), completed=True is set normally.
     """
     run_counts: Dict[str, int] = {"created": 0, "updated": 0, "reused": 0, "skipped": 0}
     if not (demo_playtest_items or free_items or paid_items or instagram_posts):
@@ -2506,6 +2508,11 @@ def post_daily_pick_messages(
                 discord_client.edit_message(existing_channel_id, existing_message_id, intro_content, context=f"edit intro for {day_key}")
                 intro_state["posted_at_utc"] = utc_now_iso()
                 print(f"EDIT: updated intro for {day_key}")
+            except DiscordMessageNotFoundError:
+                print(f"REPOST: original intro for {day_key} missing, posting fresh")
+                intro_state.pop("message_id", None)
+                intro_state.pop("channel_id", None)
+                post_or_reconcile_simple(intro_content, "intro", intro_state)
             except Exception as e:
                 print(f"WARN: failed to edit intro for {day_key}: {e}")
 
@@ -2515,8 +2522,8 @@ def post_daily_pick_messages(
         post_or_reconcile_simple(footer_content, "footer", footer_state)
         sleep_briefly()
 
-    if manual_run:
-        print(f"MANUAL RUN: daily picks done for {day_key}; skipping completed=True to preserve scheduled run eligibility")
+    if manual_run and force_refresh_same_day:
+        print(f"Manual rerun with force_refresh — not marking {day_key} completed")
     else:
         run_state["completed"] = True
         run_state["completed_at_utc"] = utc_now_iso()

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -646,8 +646,13 @@ def test_daily_picks_footer_skips_safely_when_guild_id_missing(monkeypatch, tmp_
     assert saved[day_key]["run_state"]["completed"] is True
 
 
-def test_manual_run_does_not_set_completed_flag(monkeypatch, tmp_path):
-    """workflow_dispatch runs post normally but do not mark the day as completed."""
+def test_manual_run_without_force_refresh_sets_completed_flag(monkeypatch, tmp_path):
+    """workflow_dispatch without force_refresh posts normally AND marks the day completed.
+
+    Fix 1 (Issue #292): only workflow_dispatch + force_refresh_same_day=True should keep
+    the day open. A plain workflow_dispatch (e.g. from auto-fix bot) must set completed=True
+    so that the next scheduled cron run is correctly suppressed.
+    """
     daily_path = tmp_path / "daily.json"
     daily_path.write_text("{}", encoding="utf-8")
     day_key = "2026-04-09"
@@ -662,13 +667,14 @@ def test_manual_run_does_not_set_completed_flag(monkeypatch, tmp_path):
     main.post_daily_pick_messages(
         [], [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}], [], [],
         manual_run=True,
+        force_refresh_same_day=False,
     )
 
     # Posts happened (manual run still posts to Discord)
     assert len(posted) > 0
-    # But completed flag is NOT set
+    # completed IS set — plain manual runs must not leave the day open
     saved = json.loads(daily_path.read_text(encoding="utf-8"))
-    assert saved[day_key]["run_state"].get("completed") is not True
+    assert saved[day_key]["run_state"].get("completed") is True
 
 
 def test_scheduled_run_sets_completed_flag(monkeypatch, tmp_path):
@@ -693,8 +699,14 @@ def test_scheduled_run_sets_completed_flag(monkeypatch, tmp_path):
     assert saved[day_key]["run_state"]["completed"] is True
 
 
-def test_manual_run_followed_by_scheduled_run_executes_normally(monkeypatch, tmp_path):
-    """After a manual run, the scheduled run still runs (not blocked by completed flag)."""
+def test_manual_run_without_force_refresh_blocks_subsequent_scheduled_run(monkeypatch, tmp_path):
+    """After a plain manual run, the subsequent scheduled run is blocked (Fix 1, Issue #292).
+
+    workflow_dispatch without force_refresh_same_day sets completed=True, so the next
+    scheduled cron run sees completed=True and correctly suppresses itself.
+    Use force_refresh_same_day=True if the intent is to keep the day open for a follow-up
+    scheduled run.
+    """
     daily_path = tmp_path / "daily.json"
     daily_path.write_text("{}", encoding="utf-8")
     day_key = "2026-04-09"
@@ -706,11 +718,46 @@ def test_manual_run_followed_by_scheduled_run_executes_normally(monkeypatch, tmp
 
     free_items = [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}]
 
-    # Manual run first
+    # Manual run first (no force_refresh)
     manual_posts = []
     monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda msg, capture_metadata=False: manual_posts.append(msg))
-    main.post_daily_pick_messages([], free_items, [], [], manual_run=True)
+    main.post_daily_pick_messages([], free_items, [], [], manual_run=True, force_refresh_same_day=False)
     assert manual_posts  # posts happened
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"]["completed"] is True  # completed set after manual run
+
+    # Scheduled run after — must be blocked because completed=True
+    scheduled_posts = []
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda msg, capture_metadata=False: scheduled_posts.append(msg))
+    _, rerun_protection_active, _ = main.post_daily_pick_messages([], free_items, [], [], manual_run=False)
+    assert rerun_protection_active  # suppressed by completed flag
+    assert not scheduled_posts  # no duplicate posts
+
+
+def test_manual_run_with_force_refresh_followed_by_scheduled_run_executes_normally(monkeypatch, tmp_path):
+    """After manual run + force_refresh=True, the scheduled run proceeds normally.
+
+    This is the explicit test-rerun flow: force_refresh_same_day=True keeps the day open
+    so the next scheduled run executes from scratch.
+    """
+    daily_path = tmp_path / "daily.json"
+    daily_path.write_text("{}", encoding="utf-8")
+    day_key = "2026-04-09"
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    free_items = [{"title": "Free", "url": "https://store.steampowered.com/app/99", "score": 10}]
+
+    # Manual run with force_refresh — must NOT set completed
+    manual_posts = []
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", lambda msg, capture_metadata=False: manual_posts.append(msg))
+    main.post_daily_pick_messages([], free_items, [], [], manual_run=True, force_refresh_same_day=True)
+    assert manual_posts
+    saved = json.loads(daily_path.read_text(encoding="utf-8"))
+    assert saved[day_key]["run_state"].get("completed") is not True  # day left open
 
     # Scheduled run after — must NOT be blocked
     scheduled_posts = []
@@ -2063,3 +2110,57 @@ def test_step1_footer_no_missing_notices_when_all_sections_present():
     )
     assert footer is not None
     assert "_(No " not in footer
+
+
+def test_intro_reposts_on_404_when_stale_message_id(monkeypatch, tmp_path):
+    """If the stored intro message_id no longer exists (404), a fresh intro must be posted.
+
+    Without Fix 2, the edit_message call catches generic Exception and prints a WARN,
+    leaving the channel without an intro. With Fix 2, the DiscordMessageNotFoundError
+    triggers a re-post via post_or_reconcile_simple.
+    """
+    daily_path = tmp_path / "daily.json"
+    day_key = "2026-04-18"
+
+    # State with a stale intro message_id that no longer exists on Discord
+    initial = {
+        day_key: {
+            "run_state": {
+                "completed": False,
+                "section_headers": {},
+                "intro": {"message_id": "stale-intro-id", "channel_id": "chan-1"},
+            }
+        }
+    }
+    daily_path.write_text(json.dumps(initial), encoding="utf-8")
+
+    posted = []
+    counter = {"i": 0}
+
+    def fake_post(message, capture_metadata=False):
+        counter["i"] += 1
+        posted.append(message)
+        return {"message_id": f"new-{counter['i']}", "channel_id": "chan-1"}
+
+    # FakeDiscordClient raises DiscordMessageNotFoundError for the stale intro id
+    fake_client = FakeDiscordClient(stale_ids={"stale-intro-id"})
+
+    monkeypatch.setattr(main, "DISCORD_DAILY_POSTS_FILE", str(daily_path))
+    monkeypatch.setattr(main, "DISCORD_BOT_TOKEN", "token")
+    monkeypatch.setattr(main, "DiscordClient", lambda session: fake_client)
+    monkeypatch.setattr(main, "post_to_discord_with_metadata", fake_post)
+    monkeypatch.setattr(main, "sleep_briefly", lambda: None)
+    monkeypatch.setenv(main.DAILY_DATE_OVERRIDE_ENV, day_key)
+
+    main.post_daily_pick_messages(
+        demo_playtest_items=[],
+        free_items=[{"title": "Game A", "url": "https://store.steampowered.com/app/1", "price": "Free", "score": 9}],
+        paid_items=[],
+        instagram_posts=[],
+    )
+
+    # A fresh intro must have been posted (not silently skipped)
+    assert any("Daily Picks" in msg for msg in posted), (
+        "Expected a fresh intro to be posted after 404 on stale intro message_id, "
+        f"but posted messages were: {posted!r}"
+    )

--- a/tests/test_retrigger_suppression.py
+++ b/tests/test_retrigger_suppression.py
@@ -144,6 +144,99 @@ class TestStep1RetriggerSuppression:
 
         assert skipped is False
 
+    def test_manual_run_without_force_refresh_sets_completed_so_next_run_skips(self) -> None:
+        """workflow_dispatch without force_refresh must set completed=True (Issue #292).
+
+        A plain workflow_dispatch (e.g. triggered by auto-fix bot) must NOT keep
+        the day open. Only workflow_dispatch + force_refresh_same_day=True should
+        leave completed=False so the next scheduled run re-runs from scratch.
+
+        After Fix 1, this verifies that:
+        - Run 1: manual_run=True, force_refresh=False → completed=True is set
+        - Run 2: manual_run=False, force_refresh=False → skipped (idempotency gate fires)
+        """
+        from main import post_daily_pick_messages
+
+        day_key = "2026-04-18"
+        daily_posts = self._make_daily_posts(day_key, completed=False)
+        mock_meta = {"message_id": "msg1", "channel_id": "ch1"}
+
+        # Run 1: workflow_dispatch (manual), no force_refresh.
+        # DISCORD_BOT_TOKEN must be truthy so load_discord_daily_posts() is called and
+        # returns our mutable daily_posts dict, allowing us to inspect the in-memory state.
+        with patch("main.is_today_verified", return_value=False), \
+             patch("main.load_discord_daily_posts", return_value=daily_posts), \
+             patch("main.get_target_day_key", return_value=day_key), \
+             patch("main.DISCORD_BOT_TOKEN", "fake_token"), \
+             patch("main.DiscordClient"), \
+             patch("main.post_to_discord_with_metadata", return_value=mock_meta), \
+             patch("main.sleep_briefly"), \
+             patch("main.save_discord_daily_posts"):
+            _, skipped1, _ = post_daily_pick_messages(
+                demo_playtest_items=[{"title": "Demo A", "url": "u", "score": 1, "section": "demo_playtest"}],
+                free_items=[],
+                paid_items=[],
+                instagram_posts=[],
+                force_refresh_same_day=False,
+                manual_run=True,
+            )
+
+        assert skipped1 is False
+        assert daily_posts[day_key]["run_state"].get("completed") is True, (
+            "manual_run without force_refresh must set completed=True"
+        )
+
+        # Run 2: scheduled cron — must be suppressed because completed=True
+        with patch("main.is_today_verified", return_value=False), \
+             patch("main.load_discord_daily_posts", return_value=daily_posts), \
+             patch("main.get_target_day_key", return_value=day_key), \
+             patch("main.DISCORD_BOT_TOKEN", "fake_token"), \
+             patch("main.save_discord_daily_posts"):
+            _, skipped2, _ = post_daily_pick_messages(
+                demo_playtest_items=[{"title": "Demo A", "url": "u", "score": 1, "section": "demo_playtest"}],
+                free_items=[],
+                paid_items=[],
+                instagram_posts=[],
+                force_refresh_same_day=False,
+                manual_run=False,
+            )
+
+        assert skipped2 is True, "Scheduled run after completed manual run must be suppressed"
+
+    def test_manual_run_with_force_refresh_does_not_set_completed(self) -> None:
+        """workflow_dispatch + force_refresh_same_day=True must NOT set completed=True.
+
+        This allows the next scheduled run to re-execute, which is the intended
+        behaviour for explicit test reruns.
+        """
+        from main import post_daily_pick_messages
+
+        day_key = "2026-04-18"
+        daily_posts = self._make_daily_posts(day_key, completed=False)
+        mock_meta = {"message_id": "msg1", "channel_id": "ch1"}
+
+        with patch("main.is_today_verified", return_value=False), \
+             patch("main.load_discord_daily_posts", return_value=daily_posts), \
+             patch("main.get_target_day_key", return_value=day_key), \
+             patch("main.DISCORD_BOT_TOKEN", "fake_token"), \
+             patch("main.DiscordClient"), \
+             patch("main.post_to_discord_with_metadata", return_value=mock_meta), \
+             patch("main.sleep_briefly"), \
+             patch("main.save_discord_daily_posts"):
+            _, skipped, _ = post_daily_pick_messages(
+                demo_playtest_items=[{"title": "Demo A", "url": "u", "score": 1, "section": "demo_playtest"}],
+                free_items=[],
+                paid_items=[],
+                instagram_posts=[],
+                force_refresh_same_day=True,
+                manual_run=True,
+            )
+
+        assert skipped is False
+        assert daily_posts[day_key]["run_state"].get("completed") is not True, (
+            "manual_run + force_refresh must NOT set completed=True"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Step 3 — run_daily_post() suppression

--- a/tests/test_rolling_explainer.py
+++ b/tests/test_rolling_explainer.py
@@ -169,3 +169,24 @@ def test_step3_posted_to_correct_channel():
     client = FakeClient(last_message=None)
     post_or_edit_rolling_explainer(client, "library-chan", "step-3")
     assert client.posted[0][0] == "library-chan"
+
+
+def test_edits_in_place_when_last_message_from_different_bot_author():
+    """Detection is by prefix only — author is irrelevant (Issue #292 Fix 3).
+
+    A rolling explainer posted by a different bot identity (e.g. XiannGPT Scheduling Bot
+    vs XiannGPT Game Picks Bot) must still be detected and edited in place rather than
+    posting a duplicate. The author field must not influence the decision.
+    """
+    other_bot_message = {
+        "id": "msg-from-other-bot",
+        "content": f"{ROLLING_EXPLAINER_PREFIX} — #step-1-vote-on-games-to-test\n\nOld text.",
+        "author": {"id": "999999999", "username": "XiannGPT Scheduling Bot", "bot": True},
+    }
+    client = FakeClient(last_message=other_bot_message)
+    post_or_edit_rolling_explainer(client, "step1-chan", "step-1")
+    assert len(client.posted) == 0, "Must not post a duplicate when last message has the prefix"
+    assert len(client.edited) == 1, "Must edit the existing message regardless of author"
+    _, edited_id, edited_content = client.edited[0]
+    assert edited_id == "msg-from-other-bot"
+    assert edited_content.startswith(ROLLING_EXPLAINER_PREFIX)


### PR DESCRIPTION
… #292)

Fix 1 (main.py): Only skip completed=True when manual_run AND force_refresh_same_day are both true. Plain workflow_dispatch triggers (including auto-fix bot runs) now set completed=True, preventing the next scheduled cron from re-posting the entire day's picks.

Fix 2 (main.py): Intro edit-in-place now falls back to a fresh post on DiscordMessageNotFoundError instead of silently swallowing the error. This prevents a missing intro when a prior run's intro message was deleted.

Fix 3 (rolling_explainer.py): No code change needed — detection already uses content prefix, not author. Added explicit test to document this.

Fix 4 (post_weekly_availability.py): Confirmed correct channel env var (DISCORD_SCHEDULING_CHANNEL_ID). No code change required.

Updated tests:
- test_retrigger_suppression.py: two new tests covering the fixed manual-run completed-flag logic and the force_refresh escape hatch
- test_main_daily_picks.py: updated two tests that encoded the old (buggy) behaviour; added test for intro 404 re-post fallback
- test_rolling_explainer.py: added cross-bot prefix detection test