### PR TITLE
feat: add fetched/skipped_caption counters to Instagram per-creator d…

### DIFF
--- a/main.py
+++ b/main.py
@@ -2773,17 +2773,20 @@ def fetch_instagram_posts():
     creator_stats: Dict[str, Dict] = {}
 
     for username in INSTAGRAM_CREATORS:
-        creator_stats[username] = {"collected": 0, "skipped_seen": 0, "skipped_age": 0, "failed": False, "failure_reason": None}
+        creator_stats[username] = {"fetched": 0, "collected": 0, "skipped_seen": 0, "skipped_age": 0, "skipped_caption": 0, "failed": False, "failure_reason": None}
         try:
             if username not in seen:
                 seen[username] = []
 
             profile = instaloader.Profile.from_username(loader.context, username)
             count = 0
+            fetched = 0
             skipped_age = 0
             skipped_seen = 0
+            skipped_caption = 0
 
             for post in profile.get_posts():
+                fetched += 1
                 # Posts are returned newest-first; stop as soon as we pass the age cutoff.
                 post_date = post.date_utc.replace(tzinfo=timezone.utc)
                 if post_date < cutoff_utc:
@@ -2819,9 +2822,11 @@ def fetch_instagram_posts():
                 caption_lower = caption.lower()
                 if any(phrase in caption_lower for phrase in blocked_caption_phrases):
                     print(f"INSTAGRAM SKIP: @{username} — unavailable caption")
+                    skipped_caption += 1
                     continue
                 if any(re.search(p, caption_lower) for p in blocked_caption_patterns):
                     print(f"INSTAGRAM SKIP: @{username} — future release caption")
+                    skipped_caption += 1
                     continue
 
                 all_new_posts.append({
@@ -2838,17 +2843,22 @@ def fetch_instagram_posts():
 
             seen[username] = seen[username][-INSTAGRAM_SEEN_RETENTION_PER_CREATOR:]
 
+            creator_stats[username]["fetched"] = fetched
             creator_stats[username]["collected"] = count
             creator_stats[username]["skipped_seen"] = skipped_seen
             creator_stats[username]["skipped_age"] = skipped_age
+            creator_stats[username]["skipped_caption"] = skipped_caption
 
             if count == 0:
                 print(
                     f"INSTAGRAM ZERO POSTS: @{username} returned 0 new posts "
-                    f"(skipped_seen={skipped_seen}, skipped_age={skipped_age})"
+                    f"(fetched={fetched}, skipped_seen={skipped_seen}, skipped_age={skipped_age}, skipped_caption={skipped_caption})"
                 )
             else:
-                print(f"INSTAGRAM: @{username} collected {count} new post(s) (skipped_seen={skipped_seen}, skipped_age={skipped_age})")
+                print(
+                    f"INSTAGRAM: @{username} collected {count} new post(s) "
+                    f"(fetched={fetched}, skipped_seen={skipped_seen}, skipped_age={skipped_age}, skipped_caption={skipped_caption})"
+                )
 
         except Exception as e:
             print(f"Instagram scrape failed for {username}: {e}")
@@ -2859,6 +2869,7 @@ def fetch_instagram_posts():
     save_instagram_seen(seen)
     total_posts = len(all_new_posts)
     total_skipped_seen = sum(s["skipped_seen"] for s in creator_stats.values())
+    total_skipped_caption = sum(s["skipped_caption"] for s in creator_stats.values())
     creators_with_posts = sum(1 for s in creator_stats.values() if s["collected"] > 0)
     failed_creators = [u for u, s in creator_stats.items() if s["failed"]]
     print(f"Instagram posts found this run: {total_posts}")
@@ -2869,6 +2880,7 @@ def fetch_instagram_posts():
         "creators_with_posts": creators_with_posts,
         "total_posts_collected": total_posts,
         "total_skipped_seen": total_skipped_seen,
+        "total_skipped_caption": total_skipped_caption,
         "failed_creators": failed_creators,
         "creators": creator_stats,
     }

--- a/tests/test_build_daily_health_report.py
+++ b/tests/test_build_daily_health_report.py
@@ -315,7 +315,7 @@ def test_health_report_chunk_labels_never_push_labeled_chunks_past_discord_limit
 def test_health_report_workflow_keeps_post_chunk_label_overflow_guardrails():
     workflow_file = Path(".github/workflows/bot-health-report.yml").read_text(encoding="utf-8")
 
-    assert "max_prefix_len = len(f\"\xf0\x9f\x93\x8b Bot Health Report ({total_chunks}/{total_chunks})\\n\")" in workflow_file
+    assert "max_prefix_len = len(f\"📋 Bot Health Report ({total_chunks}/{total_chunks})\\n\")" in workflow_file
     assert "reserved_hard_limit = 2000 - max_prefix_len" in workflow_file
     assert "if reserved_hard_limit <= 0:" in workflow_file
     assert "rechunked = split_discord_content(" in workflow_file


### PR DESCRIPTION
…ebug logging

- Track fetched (total posts examined) and skipped_caption (unavailable/future-release captions) per creator
- Include both counters in per-creator summary log lines and creator_stats/fetch_summary JSON
- Fix test assertion using byte escapes instead of actual 📋 emoji (caused by PR #290 fixing the workflow file encoding but not the test)
- All 4 audit areas confirmed correct: 2-post cap, 7-day cutoff, seen pruning, same-game dedup

Closes #281