### PR TITLE
fix: harden Instagram session validation with real test_login() auth …

### DIFF
--- a/main.py
+++ b/main.py
@@ -2753,20 +2753,25 @@ def fetch_instagram_posts():
         )
         return []
 
-    # Session health check — verify the loaded session is still authenticated.
+    # Session auth check — make a real authenticated API call to verify the session.
     try:
-        session_username = loader.context.username
-        if not session_username:
-            print("WARN: Instagram session health check failed — context.username is empty; session may have expired")
+        authed_user = loader.test_login()
+        if not authed_user:
+            print(f"WARN: Instagram session auth check failed — test_login() returned None for {instagram_username}")
             _notify_health_monitor(
-                f"⚠️ Instagram session may have expired for {instagram_username}.\n"
-                f"context.username is empty after loading session. "
+                f"⚠️ Instagram session auth check failed for {instagram_username}.\n"
+                f"test_login() returned None — session may have expired. "
                 f"Re-authenticate and update the INSTAGRAM_SESSION secret."
             )
-        else:
-            print(f"Instagram session health check OK: logged in as @{session_username}")
+            return []
+        print(f"Instagram session valid: logged in as @{authed_user}")
     except Exception as e:
-        print(f"WARN: Instagram session health check raised an exception: {e}")
+        print(f"WARN: Instagram session auth check raised an exception: {e}")
+        _notify_health_monitor(
+            f"⚠️ Instagram session auth check raised an exception for {instagram_username}: {e}\n"
+            f"Re-authenticate and update the INSTAGRAM_SESSION secret."
+        )
+        return []
 
     cutoff_utc = datetime.now(timezone.utc) - timedelta(days=INSTAGRAM_MAX_POST_AGE_DAYS)
 

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -1401,6 +1401,9 @@ class FakeInstaloader:
         def load_session_from_file(self, username, path):
             pass
 
+        def test_login(self):
+            return "testuser"
+
         @property
         def context(self):
             return None
@@ -1535,6 +1538,72 @@ def test_instagram_age_filter_boundary_exactly_7_days_excluded(monkeypatch, tmp_
 
     results = _patched_fetch_instagram_direct(monkeypatch, fake_profiles, now)
     assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #283 — Instagram session auth check (test_login)
+# ---------------------------------------------------------------------------
+
+class TestInstagramSessionAuthCheck:
+    """Tests for the real auth check added after load_session_from_file()."""
+
+    def _setup(self, monkeypatch, tmp_path):
+        session_path = tmp_path / "instaloader.session"
+        session_path.write_text("session")
+        monkeypatch.setenv("INSTAGRAM_USERNAME", "testuser")
+        monkeypatch.chdir(tmp_path)
+
+    def test_auth_check_returns_none_skips_instagram(self, monkeypatch, tmp_path):
+        self._setup(monkeypatch, tmp_path)
+        posted = []
+        monkeypatch.setattr(main, "_notify_health_monitor", lambda msg: posted.append(msg))
+        monkeypatch.setattr(main, "INSTAGRAM_CREATORS", [])
+
+        class NullLoginInstaloader(FakeInstaloader.Instaloader):
+            def test_login(self):
+                return None
+
+        fake_il = FakeInstaloader()
+        fake_il.Instaloader = NullLoginInstaloader
+        monkeypatch.setattr(main, "instaloader", fake_il)
+        monkeypatch.setattr(main, "INSTAGRAM_STATE_FILE", str(tmp_path / "instagram_seen.json"))
+
+        result = main.fetch_instagram_posts()
+        assert result == []
+        assert any("test_login() returned None" in msg for msg in posted)
+
+    def test_auth_check_raises_skips_instagram(self, monkeypatch, tmp_path):
+        self._setup(monkeypatch, tmp_path)
+        posted = []
+        monkeypatch.setattr(main, "_notify_health_monitor", lambda msg: posted.append(msg))
+        monkeypatch.setattr(main, "INSTAGRAM_CREATORS", [])
+
+        class RaisingLoginInstaloader(FakeInstaloader.Instaloader):
+            def test_login(self):
+                raise RuntimeError("network error")
+
+        fake_il = FakeInstaloader()
+        fake_il.Instaloader = RaisingLoginInstaloader
+        monkeypatch.setattr(main, "instaloader", fake_il)
+        monkeypatch.setattr(main, "INSTAGRAM_STATE_FILE", str(tmp_path / "instagram_seen.json"))
+
+        result = main.fetch_instagram_posts()
+        assert result == []
+        assert any("network error" in msg for msg in posted)
+
+    def test_auth_check_succeeds_continues(self, monkeypatch, tmp_path):
+        self._setup(monkeypatch, tmp_path)
+        posted = []
+        monkeypatch.setattr(main, "_notify_health_monitor", lambda msg: posted.append(msg))
+        monkeypatch.setattr(main, "INSTAGRAM_CREATORS", [])
+
+        fake_il = FakeInstaloader()
+        monkeypatch.setattr(main, "instaloader", fake_il)
+        monkeypatch.setattr(main, "INSTAGRAM_STATE_FILE", str(tmp_path / "instagram_seen.json"))
+
+        result = main.fetch_instagram_posts()
+        assert result == []
+        assert posted == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…check

Replaces the context.username pseudo-check with loader.test_login(), which makes a real authenticated API call to Instagram after load_session_from_file(). If test_login() returns None or raises: logs WARN, posts warning to DISCORD_HEALTH_MONITOR_WEBHOOK_URL, skips Instagram scraping, continues. If test_login() succeeds: logs "Instagram session valid: logged in as @<user>".

Adds test_login() stub to FakeInstaloader.Instaloader and TestInstagramSessionAuthCheck with 3 targeted tests.

Closes #283