### PR TITLE
fix: render Discord footer/header masked links via embed (3 files)

### DIFF
--- a/discord_api.py
+++ b/discord_api.py
@@ -172,12 +172,47 @@ class DiscordClient:
         )
         return self._parse_json_array(response, f"{context} JSON")
 
-    def post_message(self, channel_id: str, content: str, *, context: str) -> dict[str, Any]:
-        response = self.request("POST", f"{DISCORD_API_BASE}/channels/{channel_id}/messages", context=context, json_payload={"content": content})
+    def post_message(
+        self,
+        channel_id: str,
+        content: str,
+        *,
+        context: str,
+        embed: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        # Note: existing callers that don't pass `embed=` produce an identical
+        # JSON payload to before. When `embed=` is provided, Discord renders
+        # masked-link markdown ([label](url)) inside the embed description,
+        # which it does NOT do for plain bot-message content.
+        payload: dict[str, Any] = {"content": content}
+        if embed is not None:
+            payload["embeds"] = [embed]
+        response = self.request(
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+            context=context,
+            json_payload=payload,
+        )
         return self._parse_json_object(response, f"{context} JSON")
 
-    def edit_message(self, channel_id: str, message_id: str, content: str, *, context: str) -> dict[str, Any]:
-        response = self.request("PATCH", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}", context=context, json_payload={"content": content})
+    def edit_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        *,
+        context: str,
+        embed: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"content": content}
+        if embed is not None:
+            payload["embeds"] = [embed]
+        response = self.request(
+            "PATCH",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}",
+            context=context,
+            json_payload=payload,
+        )
         return self._parse_json_object(response, f"{context} JSON")
 
     def put_reaction(self, channel_id: str, message_id: str, encoded_emoji: str, *, context: str) -> None:
@@ -204,7 +239,7 @@ class DiscordClient:
         """Return the bot's effective permission bitfield for the given channel.
 
         Fetches guild member roles, role permissions, and channel permission overwrites,
-        then computes the effective bitfield.  Returns 0 on any API error (best-effort
+        then computes the effective bitfield. Returns 0 on any API error (best-effort
         check — the caller should treat 0 as "permissions unknown").
         """
         try:

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -730,19 +730,22 @@ def _ensure_post_or_edit_message(
     state_entry: dict,
     content: str,
     context_prefix: str,
+    as_embed: bool = False,
 ) -> dict:
     existing_message_id = str(state_entry.get("message_id") or "").strip()
     existing_channel_id = str(state_entry.get("channel_id") or channel_id).strip() or channel_id
+    embed_payload = {"description": content} if as_embed else None
+    body_text = "" if as_embed else content
     if existing_message_id:
         try:
             client.get_message(existing_channel_id, existing_message_id, context=f"verify {context_prefix}")
-            client.edit_message(existing_channel_id, existing_message_id, content, context=f"edit {context_prefix}")
+            client.edit_message(existing_channel_id, existing_message_id, body_text, context=f"edit {context_prefix}", embed=embed_payload)
             state_entry["message_id"] = existing_message_id
             state_entry["channel_id"] = existing_channel_id
             return state_entry
         except DiscordMessageNotFoundError:
             print(f"RECOVER: stale/deleted {context_prefix}; posting replacement")
-    payload = client.post_message(channel_id, content, context=f"post {context_prefix}")
+    payload = client.post_message(channel_id, body_text, context=f"post {context_prefix}", embed=embed_payload)
     message_id = str(payload.get("id") or "").strip()
     if not message_id:
         raise RuntimeError(f"Discord response missing message id for {context_prefix}")
@@ -777,6 +780,7 @@ def publish_winners_for_entries(
         state_entry=intro_state,
         content=build_winners_header_placeholder(day_key),
         context_prefix=f"winners intro for {day_key}",
+        as_embed=True,
     )
 
     posted_section_keys: List[str] = []
@@ -847,8 +851,9 @@ def publish_winners_for_entries(
             client.edit_message(
                 intro_channel_id,
                 intro_message_id,
-                header_content,
+                "",
                 context=f"edit winners header with jump links for {day_key}",
+                embed={"description": header_content},
             )
         except DiscordMessageNotFoundError:
             print(f"WARN: winners header message missing; skip header jump-link edit for {day_key}")
@@ -868,6 +873,7 @@ def publish_winners_for_entries(
             state_entry=footer_state,
             content=footer_content,
             context_prefix=f"winners footer for {day_key}",
+            as_embed=True,
         )
 
     message_ids: List[str] = []

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -636,17 +636,26 @@ def _post_or_edit_message(
     *,
     context: str,
     existing_info: Optional[Dict[str, str]],
+    as_embed: bool = False,
 ) -> tuple[Dict[str, Any], bool]:
-    """Post or edit a message. Returns (payload, is_new_message)."""
+    """Post or edit a message. Returns (payload, is_new_message).
+
+    When as_embed=True, the content is sent as an embed description rather than
+    plain message content. Discord renders [label](url) masked links in embed
+    descriptions but NOT in regular bot-message content, so headers/footers
+    that need clickable jump links must use as_embed=True.
+    """
     existing_channel_id = str((existing_info or {}).get("channel_id") or channel_id).strip()
     existing_message_id = str((existing_info or {}).get("message_id") or "").strip()
+    embed_payload = {"description": content} if as_embed else None
+    body_text = "" if as_embed else content
     if existing_message_id:
         try:
-            payload = client.edit_message(existing_channel_id, existing_message_id, content, context=context)
+            payload = client.edit_message(existing_channel_id, existing_message_id, body_text, context=context, embed=embed_payload)
             return payload, False
         except DiscordMessageNotFoundError:
             pass
-    payload = client.post_message(channel_id, content, context=context)
+    payload = client.post_message(channel_id, body_text, context=context, embed=embed_payload)
     return payload, True
 
 
@@ -685,6 +694,7 @@ def post_daily_library_reminder(
             message["content"],
             context=f"post/edit gaming library {message['type']} for {day_key}",
             existing_info=existing_info,
+            as_embed=message["type"] in ("header", "footer"),
         )
         changed = True
 
@@ -714,7 +724,7 @@ def post_daily_library_reminder(
             posted_section_keys=posted_section_keys,
             state=state,
         )
-        client.edit_message(header_ch_id, header_msg_id, nav_header, context=f"update gaming library header with jump links for {day_key}")
+        client.edit_message(header_ch_id, header_msg_id, "", context=f"update gaming library header with jump links for {day_key}", embed={"description": nav_header})
 
     # --- Footer ---
     footer_content = build_library_footer(
@@ -731,6 +741,7 @@ def post_daily_library_reminder(
         footer_content,
         context=f"post/edit gaming library footer for {day_key}",
         existing_info=existing_messages.get("footer"),
+        as_embed=True,
     )
     footer_msg_id = str(footer_payload.get("id") or "")
     if not footer_msg_id:


### PR DESCRIPTION
## What's broken
The "End of Daily Picks" footer in #step-1 renders as clickable hyperlinks. The
"End of Daily Winners" footer in #step-2 and the "End of Gaming Library" footer
in #step-3 render the same Markdown text as literal plaintext (`[💰 Paid](url)`
shows up as those exact characters instead of a hyperlink).

## Root cause (verified via Discord API on 2026-05-07)
- #step-1 footer is posted via webhook (`webhook_id` populated, author discriminator `"0000"`).
- #step-2 / #step-3 footers are posted via the bot user (no `webhook_id`).

Discord renders masked-link Markdown only inside webhook messages and embed
descriptions — not inside regular bot-content messages. The text in all three
channels is byte-identical (same flags, same message type); the difference is
purely the send route.

## What this PR changes
**This PR (1 of 3 in the fix):** add an optional `embed=` keyword argument
to `DiscordClient.post_message` and `DiscordClient.edit_message`. When
provided, the JSON payload includes `embeds: [embed]` alongside `content`.

**Existing callers are unaffected** — they don't pass `embed=`, so the JSON
payload they send is byte-identical to today.

## Follow-up PRs needed
- `evening_winners.py`: thread an `as_embed=True` flag through
  `_ensure_post_or_edit_message` for the intro header / footer (NOT the game
  messages, which have no masked links and should stay as plain content).
- `gaming_library.py`: same change in `_post_or_edit_message` and the
  standalone `client.edit_message` call that adds jump links to the header.

## Verification plan after merge
1. Trigger `evening-winners.yml` via workflow_dispatch.
2. Wait ~3 min, then in #step-2 confirm the new footer renders `💰 Paid`,
   `📸 Creator`, `⬆️ Top` as live blue clickable hyperlinks instead of
   literal `[💰 Paid](url)` text.
3. Same for `gaming-library-daily.yml` → #step-3.
4. #step-1 daily picks should be unaffected (still posted via webhook).

## Out of scope
- Does NOT bring #step-2 back to life. Channel data confirms 35 game messages
  in #step-1 currently have only the bot's auto-👍, zero human reactions,
  so `evening_winners.py` legitimately hits its no-eligible-winners SKIP path.
- Does NOT touch `bot-health-report.yml` (failing daily since at least Apr 26).
- Does NOT fix the `scripts/verify_discord_output.py` flapping behavior.
