### PR TITLE
fix(rolling_explainer): clean up stale "How This Works" between runs

### DIFF
--- a/discord_api.py
+++ b/discord_api.py
@@ -215,6 +215,17 @@ class DiscordClient:
         )
         return self._parse_json_object(response, f"{context} JSON")
 
+    def delete_message(self, channel_id: str, message_id: str, *, context: str) -> None:
+        """Delete a message. Treats "unknown message" (already deleted) as success."""
+        try:
+            self.request(
+                "DELETE",
+                f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}",
+                context=context,
+            )
+        except DiscordMessageNotFoundError:
+            pass
+
     def put_reaction(self, channel_id: str, message_id: str, encoded_emoji: str, *, context: str) -> None:
         self.request("PUT", f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}/reactions/{encoded_emoji}/@me", context=context)
 

--- a/rolling_explainer.py
+++ b/rolling_explainer.py
@@ -148,6 +148,49 @@ def get_rolling_content(slug: str, *, _today: date | None = None) -> str:
     return variants[idx]
 
 
+# How many pages of channel history to scan when looking for a stale explainer.
+# Each page is up to 100 messages, so this caps the search at ~500 messages.
+# A typical Step 3 daily run posts on the order of `1 header + N section
+# headers + M game messages + 1 footer + 1 explainer`. Five pages is plenty
+# for libraries with hundreds of games while still bounding the worst-case
+# Discord API cost to a handful of GETs.
+ROLLING_EXPLAINER_MAX_SCAN_PAGES = 5
+ROLLING_EXPLAINER_PAGE_SIZE = 100
+
+
+def _find_stale_explainer_id(
+    client: DiscordClient,
+    channel_id: str,
+    slug: str,
+    *,
+    after_message_id: str,
+) -> str | None:
+    """Page back through channel history looking for the most recent rolling
+    explainer older than `after_message_id`.
+
+    Returns the message id of the first explainer found, or None if no
+    explainer was found within `ROLLING_EXPLAINER_MAX_SCAN_PAGES` pages.
+    Stopping bounded means a hopelessly polluted channel doesn't cause an
+    unbounded scan; if a stale explainer is buried deeper than the cap, the
+    next workflow run still gets another chance.
+    """
+    cursor = after_message_id
+    for page in range(ROLLING_EXPLAINER_MAX_SCAN_PAGES):
+        batch = client.get_channel_messages(
+            channel_id,
+            context=f"rolling explainer scan page {page} for {slug}",
+            limit=ROLLING_EXPLAINER_PAGE_SIZE,
+            before=cursor,
+        )
+        if not batch:
+            return None
+        for m in batch:
+            if str(m.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
+                return str(m["id"])
+        cursor = str(batch[-1]["id"])
+    return None
+
+
 def post_or_edit_rolling_explainer(
     client: DiscordClient,
     channel_id: str,
@@ -160,25 +203,45 @@ def post_or_edit_rolling_explainer(
     before the new explainer is posted. This prevents accumulating one stale
     "How This Works" message per workflow run while still satisfying the
     verifier's expectation that the explainer is the literal last message.
+
+    The cleanup pages back through channel history until it finds an explainer
+    or hits `ROLLING_EXPLAINER_MAX_SCAN_PAGES`. This handles channels where
+    today's run posts more than one page of messages (e.g. Step 3 with a large
+    gaming library) before the explainer is posted, which limit=20 alone could
+    not reach.
     """
     content = get_rolling_content(slug)
-    # Look back further than 1 so we can find and clean up a stale explainer.
-    messages = client.get_channel_messages(channel_id, context=f"rolling explainer fetch {slug}", limit=20)
-    last = messages[0] if messages else None
+    first_page = client.get_channel_messages(
+        channel_id,
+        context=f"rolling explainer fetch {slug}",
+        limit=ROLLING_EXPLAINER_PAGE_SIZE,
+    )
+    last = first_page[0] if first_page else None
     if last and str(last.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
         client.edit_message(channel_id, str(last["id"]), content, context=f"edit rolling explainer {slug}")
         print(f"EDIT: rolling explainer for {slug} (message_id={last['id']})")
         return
-    # Last message isn't an explainer. Look back through recent messages for a
-    # stale explainer (from a previous run) and delete it before posting the
-    # new one. Stop at the first match — there should be at most one.
-    for m in messages[1:]:
+    # Last message isn't an explainer. Look for a stale explainer to clean up
+    # before posting a fresh one.
+    stale_id: str | None = None
+    # First check the current page (cheap — no extra API call).
+    for m in first_page[1:]:
         if str(m.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
-            try:
-                client.delete_message(channel_id, str(m["id"]), context=f"delete stale rolling explainer {slug}")
-                print(f"DELETE: stale rolling explainer for {slug} (message_id={m['id']})")
-            except Exception as e:
-                print(f"WARN: could not delete stale rolling explainer for {slug} (message_id={m.get('id')}): {e}")
+            stale_id = str(m["id"])
             break
+    # If not found on page 1 and there are more messages to scan, page back.
+    if stale_id is None and first_page:
+        stale_id = _find_stale_explainer_id(
+            client,
+            channel_id,
+            slug,
+            after_message_id=str(first_page[-1]["id"]),
+        )
+    if stale_id is not None:
+        try:
+            client.delete_message(channel_id, stale_id, context=f"delete stale rolling explainer {slug}")
+            print(f"DELETE: stale rolling explainer for {slug} (message_id={stale_id})")
+        except Exception as e:
+            print(f"WARN: could not delete stale rolling explainer for {slug} (message_id={stale_id}): {e}")
     msg = client.post_message(channel_id, content, context=f"post rolling explainer {slug}")
     print(f"CREATE: rolling explainer for {slug} (message_id={msg.get('id')})")

--- a/rolling_explainer.py
+++ b/rolling_explainer.py
@@ -153,13 +153,32 @@ def post_or_edit_rolling_explainer(
     channel_id: str,
     slug: str,
 ) -> None:
-    """Post the rolling explainer as the last message, or edit it if already last."""
+    """Post the rolling explainer as the last message, or edit it if already last.
+
+    If a previous rolling explainer exists earlier in the channel (e.g. from a
+    previous workflow run that posted other messages after it), it is deleted
+    before the new explainer is posted. This prevents accumulating one stale
+    "How This Works" message per workflow run while still satisfying the
+    verifier's expectation that the explainer is the literal last message.
+    """
     content = get_rolling_content(slug)
-    messages = client.get_channel_messages(channel_id, context=f"rolling explainer fetch {slug}", limit=1)
+    # Look back further than 1 so we can find and clean up a stale explainer.
+    messages = client.get_channel_messages(channel_id, context=f"rolling explainer fetch {slug}", limit=20)
     last = messages[0] if messages else None
     if last and str(last.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
         client.edit_message(channel_id, str(last["id"]), content, context=f"edit rolling explainer {slug}")
         print(f"EDIT: rolling explainer for {slug} (message_id={last['id']})")
-    else:
-        msg = client.post_message(channel_id, content, context=f"post rolling explainer {slug}")
-        print(f"CREATE: rolling explainer for {slug} (message_id={msg.get('id')})")
+        return
+    # Last message isn't an explainer. Look back through recent messages for a
+    # stale explainer (from a previous run) and delete it before posting the
+    # new one. Stop at the first match — there should be at most one.
+    for m in messages[1:]:
+        if str(m.get("content", "")).startswith(ROLLING_EXPLAINER_PREFIX):
+            try:
+                client.delete_message(channel_id, str(m["id"]), context=f"delete stale rolling explainer {slug}")
+                print(f"DELETE: stale rolling explainer for {slug} (message_id={m['id']})")
+            except Exception as e:
+                print(f"WARN: could not delete stale rolling explainer for {slug} (message_id={m.get('id')}): {e}")
+            break
+    msg = client.post_message(channel_id, content, context=f"post rolling explainer {slug}")
+    print(f"CREATE: rolling explainer for {slug} (message_id={msg.get('id')})")

--- a/tests/test_rolling_explainer.py
+++ b/tests/test_rolling_explainer.py
@@ -17,15 +17,21 @@ from rolling_explainer import (
 # ---------------------------------------------------------------------------
 
 class FakeClient:
-    def __init__(self, last_message=None):
-        self.last_message = last_message  # dict or None
+    def __init__(self, last_message=None, prior_messages=None):
+        # last_message: dict or None — the literal most recent message in the channel
+        # prior_messages: list of dicts (newest-first) — older messages in the channel
+        self.last_message = last_message
+        self.prior_messages = list(prior_messages or [])
         self.posted = []   # list of (channel_id, content)
         self.edited = []   # list of (channel_id, message_id, content)
+        self.deleted = []  # list of (channel_id, message_id)
 
     def get_channel_messages(self, channel_id, *, context, limit=100, before=None, after=None):
-        if self.last_message is None:
-            return []
-        return [self.last_message]
+        msgs = []
+        if self.last_message is not None:
+            msgs.append(self.last_message)
+        msgs.extend(self.prior_messages)
+        return msgs[:limit]
 
     def post_message(self, channel_id, content, *, context):
         msg_id = f"new-{len(self.posted) + 1}"
@@ -35,6 +41,9 @@ class FakeClient:
     def edit_message(self, channel_id, message_id, content, *, context):
         self.edited.append((channel_id, message_id, content))
         return {"id": message_id}
+
+    def delete_message(self, channel_id, message_id, *, context):
+        self.deleted.append((channel_id, message_id))
 
 
 # ---------------------------------------------------------------------------
@@ -190,3 +199,37 @@ def test_edits_in_place_when_last_message_from_different_bot_author():
     _, edited_id, edited_content = client.edited[0]
     assert edited_id == "msg-from-other-bot"
     assert edited_content.startswith(ROLLING_EXPLAINER_PREFIX)
+
+
+def test_deletes_stale_explainer_when_last_message_not_explainer():
+    """When a stale explainer exists earlier in the channel, it should be
+    deleted before posting the new one (prevents day-over-day accumulation)."""
+    stale = {"id": "stale-explainer", "content": f"{ROLLING_EXPLAINER_PREFIX} — stale content"}
+    last = {"id": "today-footer", "content": "📅 End of Gaming Library"}
+    client = FakeClient(last_message=last, prior_messages=[stale])
+    post_or_edit_rolling_explainer(client, "chan-1", "step-3")
+    assert client.deleted == [("chan-1", "stale-explainer")]
+    assert len(client.posted) == 1
+    assert len(client.edited) == 0
+
+
+def test_no_delete_when_no_stale_explainer():
+    """When the channel has no prior explainer, nothing is deleted."""
+    last = {"id": "today-footer", "content": "📅 End of Gaming Library"}
+    other = {"id": "earlier-msg", "content": "Some other thing"}
+    client = FakeClient(last_message=last, prior_messages=[other])
+    post_or_edit_rolling_explainer(client, "chan-1", "step-3")
+    assert client.deleted == []
+    assert len(client.posted) == 1
+
+
+def test_only_first_stale_explainer_deleted():
+    """If multiple stale explainers exist, only the most recent one is deleted
+    in this run. Subsequent runs will clean up the rest one at a time."""
+    older = {"id": "older-explainer", "content": f"{ROLLING_EXPLAINER_PREFIX} — older"}
+    newer = {"id": "newer-explainer", "content": f"{ROLLING_EXPLAINER_PREFIX} — newer"}
+    last = {"id": "today-footer", "content": "📅 End of Gaming Library"}
+    client = FakeClient(last_message=last, prior_messages=[newer, older])
+    post_or_edit_rolling_explainer(client, "chan-1", "step-3")
+    assert client.deleted == [("chan-1", "newer-explainer")]
+    assert len(client.posted) == 1

--- a/tests/test_rolling_explainer.py
+++ b/tests/test_rolling_explainer.py
@@ -27,10 +27,18 @@ class FakeClient:
         self.deleted = []  # list of (channel_id, message_id)
 
     def get_channel_messages(self, channel_id, *, context, limit=100, before=None, after=None):
+        # Build the channel newest-first, then optionally page from a cursor.
         msgs = []
         if self.last_message is not None:
             msgs.append(self.last_message)
         msgs.extend(self.prior_messages)
+        if before is not None:
+            # Skip past and including the message with id == before
+            try:
+                idx = next(i for i, m in enumerate(msgs) if str(m.get("id")) == str(before))
+            except StopIteration:
+                return []
+            msgs = msgs[idx + 1:]
         return msgs[:limit]
 
     def post_message(self, channel_id, content, *, context):
@@ -232,4 +240,35 @@ def test_only_first_stale_explainer_deleted():
     client = FakeClient(last_message=last, prior_messages=[newer, older])
     post_or_edit_rolling_explainer(client, "chan-1", "step-3")
     assert client.deleted == [("chan-1", "newer-explainer")]
+    assert len(client.posted) == 1
+
+
+def test_deletes_stale_explainer_via_paging_when_buried_past_first_page():
+    # When the run posts more than ROLLING_EXPLAINER_PAGE_SIZE messages
+    # before the explainer (e.g. a large gaming library), the stale explainer
+    # is on a later page. The cleanup must page back to find it.
+    last = {"id": "today-footer", "content": "📅 End of Gaming Library"}
+    today_games = [{"id": f"today-game-{i}", "content": f"Game {i}"} for i in range(150)]
+    stale = {"id": "stale-explainer", "content": f"{ROLLING_EXPLAINER_PREFIX} — yesterday"}
+    prior = today_games + [stale]
+    client = FakeClient(last_message=last, prior_messages=prior)
+    post_or_edit_rolling_explainer(client, "chan-1", "step-3")
+    assert client.deleted == [("chan-1", "stale-explainer")]
+    assert len(client.posted) == 1
+
+
+def test_paging_gives_up_after_max_pages():
+    # If the stale explainer is buried beyond the bounded scan, this run
+    # does not delete it. The next run gets another chance.
+    from rolling_explainer import (
+        ROLLING_EXPLAINER_MAX_SCAN_PAGES,
+        ROLLING_EXPLAINER_PAGE_SIZE,
+    )
+    cap = ROLLING_EXPLAINER_MAX_SCAN_PAGES * ROLLING_EXPLAINER_PAGE_SIZE
+    last = {"id": "today-footer", "content": "📅 End of Gaming Library"}
+    filler = [{"id": f"filler-{i}", "content": f"Game {i}"} for i in range(cap + 5)]
+    stale = {"id": "way-buried", "content": f"{ROLLING_EXPLAINER_PREFIX} — ancient"}
+    client = FakeClient(last_message=last, prior_messages=filler + [stale])
+    post_or_edit_rolling_explainer(client, "chan-1", "step-3")
+    assert client.deleted == []
     assert len(client.posted) == 1


### PR DESCRIPTION
## What's broken

Every workflow run, the "📌 How This Works" message gets posted to its
channel as a brand-new message instead of being edited in place. After 9 days of
audit data: 9 stale "How This Works" messages accumulating in #step-3, one per
run.

## Why

`post_or_edit_rolling_explainer` only checks the literal **last** message
(`get_channel_messages(..., limit=1)`) to decide between edit-in-place vs
post-new. By the time it runs, the same workflow has already posted Header,
sections, and Footer — so the last message is the Footer it just posted, not
yesterday's explainer. The function falls through to "post new" every single
time, and yesterday's explainer becomes an orphan.

The verifier (`scripts/verify_discord_output.py`'s `check_rolling_explainer`)
expects the explainer to be the literal last message in the channel — which IS
satisfied by the current behavior. So we must keep posting a fresh explainer at
the end. We just also need to clean up the stale one before it accumulates.

## What this PR does

1. **`discord_api.py`**: add a `delete_message` helper that swallows
   `DiscordMessageNotFoundError` (idempotent delete, e.g. if the message was
   manually deleted between runs).
2. **`rolling_explainer.py`**: bump `limit=1` → `limit=20`, add a cleanup
   step in the post-new branch. Before posting the new explainer, scan
   `messages[1:]` for any earlier message starting with
   `ROLLING_EXPLAINER_PREFIX` and delete the first match. `break` after one
   delete — there should be at most one stale per run.
3. **`tests/test_rolling_explainer.py`**: extend `FakeClient` with
   `prior_messages` and a `deleted` list; add 3 new tests covering the
   cleanup paths. All existing tests still pass (their setups never put a stale
   explainer in `prior_messages`).

## What this PR does NOT do

- Does NOT change the verifier's expectation. The new explainer is still posted
  last, so the verifier still passes.
- Does NOT delete more than one stale explainer per run. If 9 stales already
  exist (current state of #step-3), the next 9 runs will each remove one. This
  is intentional — it bounds the per-run blast radius. If we wanted aggressive
  cleanup, we could change `break` to a full sweep, but I'd rather see one run
  succeed first.
- Does NOT touch any other channel-posting logic. The masked-link fix from
  PR #302 is unaffected.

## Verification plan

After merge, watch tonight's 00:00 UTC `gaming-library-daily.yml` cron run
on `main`:
- Channel #step-3 should still end the run with "📌 How This Works" as the
  last message (verifier passes).
- The previous run's "How This Works" should be **deleted**, not orphaned.
- Net effect: channel grows by 0 messages day-over-day (instead of +1 per day).
- Look for log line: `DELETE: stale rolling explainer for step-3 (message_id=...)`
