### PR TITLE
fix(bot-health-report): write workflow JSON to file to avoid ARG_MAX exec failure

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
             const workflows = [
               { file: "weekly-scheduling-bot.yml", name: "Weekly Scheduling Bot", staleHours: 168 },
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
@@ -104,7 +105,15 @@ jobs:
               });
             }
 
-            core.setOutput("workflows", JSON.stringify(output));
+            // Write the JSON directly to disk instead of through step outputs.
+            // Step outputs flow through the runner's env block when consumed via
+            // ${{ steps.X.outputs.Y }}, and after enough days of accumulated run
+            // history the JSON exceeds Linux ARG_MAX (~128KB-2MB combined env+args)
+            // and the next bash step fails with "Argument list too long" before it
+            // can even start. Writing to a file bypasses the env block entirely.
+            const json = JSON.stringify(output);
+            fs.writeFileSync("workflow-runs.json", json);
+            core.info(`Wrote ${json.length} bytes of workflow run data to workflow-runs.json`);
 
       - name: Fetch GitHub Actions billing
         id: actions_billing
@@ -135,13 +144,12 @@ jobs:
       - name: Build daily health report
         id: build-report
         env:
-          WORKFLOW_RUNS_JSON: ${{ steps.collect-workflows.outputs.workflows }}
+          # workflow-runs.json is written to disk by the previous github-script
+          # step; only actions-billing.json comes via env (it is small).
           ACTIONS_BILLING_JSON: ${{ steps.actions_billing.outputs.actions_billing_json }}
         run: |
           python - <<'PY'
           import os
-          with open("workflow-runs.json", "w") as f:
-              f.write(os.environ.get("WORKFLOW_RUNS_JSON", "[]"))
           with open("actions-billing.json", "w") as f:
               f.write(os.environ.get("ACTIONS_BILLING_JSON", "{}"))
           PY


### PR DESCRIPTION
## What's broken

`bot-health-report.yml` has been failing every scheduled cron run since at
least Apr 26 2026. Latest failure: run #103, today at 03:00 UTC. The error
annotation is always the same:

> An error occurred trying to start process '/usr/bin/bash' with working
> directory '/home/runner/work/steam-discord-free-games/steam-discord-free-games'.
> **Argument list too long**

## Why

The "Build daily health report" step pulls the previous step's output
`workflows` into an env var:

```yaml
env:
  WORKFLOW_RUNS_JSON: ${{ steps.collect-workflows.outputs.workflows }}
```

`steps.collect-workflows.outputs.workflows` is the JSON-stringified result of
listing 7 workflows × up to 20 recent runs each, with full HTML URLs,
timestamps, statuses, conclusions, etc. After ~2 weeks of accumulated daily
output history, that JSON is large enough that when GitHub Actions starts
`/usr/bin/bash` with `WORKFLOW_RUNS_JSON` in the env block, the combined
env+args exceeds Linux's `ARG_MAX` (~128KB-2MB depending on kernel) and the
exec returns `E2BIG` before any script body can run.

This is the OS, not GitHub. The runner sets up the env, calls `execve(...)`,
and the kernel rejects it.

## What this PR does

- **`Collect workflow run status`** (github-script step): replace
  `core.setOutput("workflows", JSON.stringify(output))` with
  `fs.writeFileSync("workflow-runs.json", json)`. The file lives in the
  runner's working directory and persists for the duration of the job.
- **`Build daily health report`** (run step): drop the
  `WORKFLOW_RUNS_JSON` env var and the heredoc that materialized it from env
  to disk. `workflow-runs.json` is already on disk by the time this step
  runs, and the downstream Python script already consumes it via
  `--workflow-runs-json <path>`.
- `ACTIONS_BILLING_JSON` is unchanged — it's a single billing API response
  (a few hundred bytes). The pattern would be identical if it ever grew large.

## What this PR does NOT do

- Does NOT touch `build_daily_health_report.py` — the script's CLI was already
  file-based; only the YAML had the env-var hop.
- Does NOT change what the report contains. Same data, same format, same
  Discord delivery.
- Does NOT add retention/truncation. If `per_page: 20` ever has to grow,
  the file-based contract scales fine; the env-var contract did not.

## Verification plan

After merge, two ways to verify:

1. **Manual workflow_dispatch on `main`**: triggers immediately. The previously
   failing "Build daily health report" step should pass and the next step
   ("Post health report to Discord") should fire. The `#xiann-gpt-bot-health-monitor`
   channel should receive the daily scoreboard for the first time in 2 weeks.
2. **Wait for tonight's 03:00 UTC scheduled run**. Same expected outcome.

Look in the github-script step's logs for the new info line:
`Wrote N bytes of workflow run data to workflow-runs.json`.

If the fix works, expect N to be in the 50KB-200KB range (well under
ARG_MAX, but well over what env vars practically tolerate when added on top
of everything else GitHub injects).
