### PR TITLE
fix(verify_discord_output): make intro/footer checks embed-aware

### DIFF
--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -73,6 +73,27 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def message_text(msg: Dict[str, Any]) -> str:
+    """Return the human-visible text of a Discord message regardless of where it lives.
+
+    After PR #302, the gaming library and evening-winners workflows post
+    header/footer messages with empty `content` and the actual text in
+    `embeds[0].description`. Verifier code that reads `content` directly
+    would incorrectly mark these messages as missing. This helper returns the
+    `content` if non-empty, otherwise falls back to the first embed's
+    description, otherwise an empty string. Safe for plain-text messages too.
+    """
+    content = str(msg.get("content") or "")
+    if content:
+        return content
+    embeds = msg.get("embeds") or []
+    if isinstance(embeds, list) and embeds:
+        first = embeds[0]
+        if isinstance(first, dict):
+            return str(first.get("description") or "")
+    return ""
+
+
 def get_target_day_key() -> str:
     manual_day = (os.getenv(DAILY_DATE_OVERRIDE_ENV, "") or "").strip()
     if manual_day:
@@ -603,7 +624,7 @@ def verify_step1(
 
     if intro_message_id and intro_channel_id:
         msg = check_message(client, intro_channel_id, intro_message_id, "intro", ch)
-        ch["intro_found"] = msg is not None and bool(msg.get("content"))
+        ch["intro_found"] = msg is not None and bool(message_text(msg))
         if msg is not None:
             ch["section_content_in_intro"] = "store.steampowered.com" in msg.get("content", "").lower()
     else:
@@ -623,7 +644,7 @@ def verify_step1(
             print(f"  MISSING  {section_key} header (no message_id in state)")
             continue
         msg = check_message(client, ch_id, msg_id, f"{section_key} header", ch)
-        if msg is not None and msg.get("content"):
+        if msg is not None and message_text(msg):
             ch["sections_found"].append(section_key)
 
     # --- Navigation footer (conditional on GUILD_ID) ---
@@ -634,9 +655,9 @@ def verify_step1(
 
     if footer_message_id and footer_channel_id:
         msg = check_message(client, footer_channel_id, footer_message_id, "footer", ch)
-        ch["footer_found"] = msg is not None and bool(msg.get("content"))
+        ch["footer_found"] = msg is not None and bool(message_text(msg))
         if msg is not None:
-            ch["footer_missing_separator"] = not msg.get("content", "").strip().endswith(
+            ch["footer_missing_separator"] = not message_text(msg).strip().endswith(
                 "End of Daily Picks ───────────────────"
             )
     else:
@@ -784,7 +805,7 @@ def verify_step2(
 
     if intro_message_id and intro_channel_id:
         msg = check_message(client, intro_channel_id, intro_message_id, "winners intro", ch)
-        ch["intro_found"] = msg is not None and bool(msg.get("content"))
+        ch["intro_found"] = msg is not None and bool(message_text(msg))
         if msg is not None:
             ch["section_content_in_intro"] = "store.steampowered.com" in msg.get("content", "").lower()
     else:
@@ -804,7 +825,7 @@ def verify_step2(
             print(f"  MISSING  {section_key} header (no message_id in state)")
             continue
         msg = check_message(client, ch_id, msg_id, f"winners {section_key} header", ch)
-        if msg is not None and msg.get("content"):
+        if msg is not None and message_text(msg):
             ch["sections_found"].append(section_key)
 
     # --- Footer (conditional on GUILD_ID having been set at post time) ---
@@ -815,9 +836,9 @@ def verify_step2(
 
     if footer_message_id and footer_channel_id:
         msg = check_message(client, footer_channel_id, footer_message_id, "winners footer", ch)
-        ch["footer_found"] = msg is not None and bool(msg.get("content"))
+        ch["footer_found"] = msg is not None and bool(message_text(msg))
         if msg is not None:
-            ch["footer_missing_separator"] = not msg.get("content", "").strip().endswith(
+            ch["footer_missing_separator"] = not message_text(msg).strip().endswith(
                 "End of Daily Winners ───────────────────"
             )
     else:
@@ -951,8 +972,8 @@ def verify_step3(
     if intro_message_id and intro_channel_id:
         try:
             msg = client.get_message(intro_channel_id, intro_message_id, context="verify step-3 intro")
-            ch["intro_found"] = bool(msg.get("content"))
-            intro_content = msg.get("content", "")
+            ch["intro_found"] = bool(message_text(msg))
+            intro_content = message_text(msg)
             print(f"  OK  intro (message_id={intro_message_id})")
         except DiscordMessageNotFoundError:
             ch["messages_missing"].append({"label": "intro", "message_id": intro_message_id})
@@ -979,8 +1000,8 @@ def verify_step3(
     if footer_message_id and footer_channel_id:
         try:
             msg = client.get_message(footer_channel_id, footer_message_id, context="verify step-3 footer")
-            ch["footer_found"] = bool(msg.get("content"))
-            footer_content = msg.get("content", "").strip()
+            ch["footer_found"] = bool(message_text(msg))
+            footer_content = message_text(msg).strip()
             ch["footer_missing_separator"] = not footer_content.endswith(
                 "End of Gaming Library ───────────────────"
             )

--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -337,8 +337,8 @@ def _run_channel_scan(
         m for m in today_messages
         if not is_game_card(m)
         and not m.get("content", "").startswith(ROLLING_EXPLAINER_PREFIX)
-        and _has_divider_line(m.get("content", ""))
-        and intro_marker in m.get("content", "")
+        and _has_divider_line(message_text(m))
+        and intro_marker in message_text(m)
     ]
     if len(intro_candidates) == 0:
         ch["intro_found"] = False
@@ -358,7 +358,7 @@ def _run_channel_scan(
     # --- Footer: must appear exactly once today ---
     footer_candidates = [
         m for m in today_messages
-        if footer_keyword in m.get("content", "")
+        if footer_keyword in message_text(m)
     ]
     if len(footer_candidates) == 0:
         if not ch.get("footer_skipped"):


### PR DESCRIPTION
## What's broken

`scripts/verify_discord_output.py` has been producing false-fail
`gaming_library_pass=false` alerts since PR #302 merged, e.g. the
"Auto-fix Exhausted" message in `#xiann-gpt-bot-health-monitor` at
2026-05-09T03:02:56Z:

> Issue: workflow=Gaming Library Daily Reminder, conclusion=success,
> daily_pass=true, discord_pass=true, **gaming_library_pass=false**

The state on disk and the actual Discord channel content are both correct.
The verifier itself is wrong.

## Why

PR #302 ("render footer/header masked links via embed") changed
`gaming_library.py` and `evening_winners.py` to post header/footer
messages with empty `content` and the actual text in
`embeds[0].description`. That fixes the masked-link rendering but means
`msg.get("content")` now returns `""` for those messages.

The verifier reads `content` directly in 8 places across
`verify_step1`, `verify_step2`, and `verify_step3`:

```python
ch["intro_found"] = msg is not None and bool(msg.get("content"))
ch["footer_found"] = msg is not None and bool(msg.get("content"))
ch["footer_missing_separator"] = not msg.get("content", "").strip().endswith("End of...")
intro_content = msg.get("content", "")  # used for delta-marker check
footer_content = msg.get("content", "").strip()  # used for separator check
```

For embed-rendered messages: `content == ""`, so `intro_found` and
`footer_found` are both `False`, the pass-decision short-circuits, and
`gaming_library_pass` is False even though everything is correct.

The "flapping" framing was a red herring — it's a deterministic regression
introduced by PR #302. Some runs may have appeared to pass briefly due to
Discord eventual-consistency on read-after-write (embed not populated in
time, falling through into a different code path), but the steady state is
"always false."

## What this PR does

- **New helper `message_text(msg)`** at the top of the file: returns
  `msg["content"]` if non-empty, otherwise `msg["embeds"][0]["description"]`,
  otherwise `""`. Backward-compatible with plain-text messages.
- **6 call-site fixes** (12 line changes total) in `verify_step1`,
  `verify_step2`, and `verify_step3`:
  - `intro_found` / `footer_found` checks now use `message_text(msg)`
    instead of `msg.get("content")`
  - `footer_missing_separator` now reads `message_text(msg).strip()`
  - `intro_content` / `footer_content` extraction now uses `message_text(msg)`

## What this PR does NOT do

- Does NOT rewrite every `msg.get("content")` site. The 25 occurrences in
  the file include game-card scans, rolling-explainer prefix detection, and
  Steam-URL filters that all run on plain-text messages and are correct as-is.
  Only the structural intro/footer/header reads were broken by PR #302.
- Does NOT change pass-decision logic. `ch["pass"] = intro_ok and footer_ok
  and ...` is unchanged. The fix is purely in the inputs to those flags.
- Does NOT touch `_run_channel_scan` or `check_rolling_explainer`. Those
  use `startswith(ROLLING_EXPLAINER_PREFIX)` and `intro_marker in content`
  patterns that are correct as-is — the rolling explainer is still posted as
  plain content (PR #302 only migrated header/footer).

## Verification plan

After merge, the next `gaming-library-daily.yml` cron run on `main`
(00:00 UTC tonight, or trigger manually) should produce
`gaming_library_pass=true` in its verification artifact. The next Bot
Health Report run (03:00 UTC, or manual) should NOT include any "Auto-fix
Exhausted" entry for Gaming Library Daily Reminder.

Concretely: check the next `#xiann-gpt-bot-health-monitor` daily scoreboard
— the 🟡 alerts should drop from 2 (Weekly Scheduling Bot + Winners state
missing) to 1 (the genuine Weekly Scheduling Bot failure remains; Winners
state missing was a one-time May 8 artifact and is also expected to clear).
