### PR TITLE
fix(verify): make verify_gaming_library + verify_weekly_schedule embed-aware

### DIFF
--- a/scripts/verify_gaming_library.py
+++ b/scripts/verify_gaming_library.py
@@ -34,6 +34,28 @@ import requests
 
 from discord_api import DiscordApiError, DiscordClient, DiscordMessageNotFoundError
 
+
+def message_text(msg: Dict[str, Any]) -> str:
+    """Return the human-visible text of a Discord message regardless of where it lives.
+
+    After PR #302, the gaming library workflow posts header/footer messages
+    with empty `content` and the actual text in `embeds[0].description`.
+    Verifier code that reads `content` directly would incorrectly mark these
+    messages as missing. This helper returns the `content` if non-empty,
+    otherwise falls back to the first embed description, otherwise an empty
+    string. Safe for plain-text messages too.
+    """
+    content = str(msg.get("content") or "")
+    if content:
+        return content
+    embeds = msg.get("embeds") or []
+    if isinstance(embeds, list) and embeds:
+        first = embeds[0]
+        if isinstance(first, dict):
+            return str(first.get("description") or "")
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -280,7 +302,7 @@ def main() -> None:
             result["errors"].append(f"Duplicate message_id {header_msg_id} for header.")
         seen_message_ids.append(header_msg_id)
         msg = check_message(client, header_ch_id, header_msg_id, "gaming library header", result)
-        result["header_found"] = msg is not None and bool(msg.get("content"))
+        result["header_found"] = msg is not None and bool(message_text(msg))
     else:
         result["errors"].append("Header message_id or channel_id missing from daily_posts.")
         print("  MISSING  header (no message_id in state)")
@@ -341,7 +363,7 @@ def main() -> None:
             result["errors"].append(f"Duplicate message_id {footer_msg_id} for footer.")
         seen_message_ids.append(footer_msg_id)
         msg = check_message(client, footer_ch_id, footer_msg_id, "gaming library footer", result)
-        result["footer_found"] = msg is not None and bool(msg.get("content"))
+        result["footer_found"] = msg is not None and bool(message_text(msg))
     else:
         if spec_required["footer_required"]:
             result["errors"].append("Footer message_id or channel_id missing from daily_posts.")

--- a/scripts/verify_weekly_schedule.py
+++ b/scripts/verify_weekly_schedule.py
@@ -30,6 +30,27 @@ import requests
 
 from discord_api import DiscordApiError, DiscordClient, DiscordMessageNotFoundError
 
+
+def message_text(msg: Dict[str, Any]) -> str:
+    """Return the human-visible text of a Discord message regardless of where it lives.
+
+    Mirror of the helper added to verify_gaming_library.py / verify_discord_output.py
+    in the embed-aware verifier fixes that follow PR #302. The weekly scheduling bot
+    currently posts via plain content, but normalizing on this helper means the
+    verifier stays correct if/when the schedule channel is migrated to embed-rendered
+    messages.
+    """
+    content = str(msg.get("content") or "")
+    if content:
+        return content
+    embeds = msg.get("embeds") or []
+    if isinstance(embeds, list) and embeds:
+        first = embeds[0]
+        if isinstance(first, dict):
+            return str(first.get("description") or "")
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -208,7 +229,7 @@ def main() -> None:
             result["errors"].append(f"Duplicate message_id {intro_message_id} for intro.")
         seen_message_ids.append(intro_message_id)
         msg = check_message(client, channel_id, intro_message_id, "weekly schedule intro", result)
-        result["intro_found"] = msg is not None and bool(msg.get("content"))
+        result["intro_found"] = msg is not None and bool(message_text(msg))
     else:
         print("  SKIPPED  intro (no intro_message_id in state)")
         result["intro_found"] = False


### PR DESCRIPTION
## Where this came from

PR #305 fixed embed-blindness in `scripts/verify_discord_output.py`. After
merging, I triggered `gaming-library-daily.yml` Run #67 on `main` to verify
the fix. The first verifier step ("Verify Discord output") now passes, but
the **next** step ("Verify gaming library output") still produces:

```
--- Header ---
  OK  gaming library header (message_id=1502503794628624456)
--- Footer ---
  OK  gaming library footer (message_id=1502503801234657312)
=== Verification result for 2026-05-09 (step-3-review-existing-games) ===
  pass:                  False
  header_found:          False  ← wrong
  footer_found:          False  ← wrong
  triggered_broken_if (1):
    - missing footer
```

Cause: there are **two parallel verifier scripts** with the same embed-
blindness bug pattern, and PR #305 only patched one of them. A code search
for the exact pattern `bool(msg.get("content"))` returns three call sites
across two files I missed:

- `scripts/verify_gaming_library.py` lines 283 (header_found) and 344
  (footer_found) — **live regression**, currently producing the false-fail
  alerts for `gaming-library-daily.yml`
- `scripts/verify_weekly_schedule.py` line 211 (intro_found) — **latent**;
  `post_weekly_availability.py` still posts via plain content so this is not
  yet broken in production, but the bug is identical and one migration away
  from firing

## What this PR does

Same fix pattern as PR #305:

- Add `message_text(msg)` helper to each file (returns `content` if non-empty,
  else `embeds[0].description`, else `""`). Backward-compatible with plain-text.
- Replace `bool(msg.get("content"))` with `bool(message_text(msg))` at all 3
  call sites (2 in verify_gaming_library, 1 in verify_weekly_schedule).

I considered importing the helper from `verify_discord_output.py` instead of
duplicating it, but the three scripts are intentionally standalone (each runs
as a separate workflow step with its own exit code) and the helper is short
enough that duplication is cheaper than introducing a cross-script import.

## What this PR does NOT do

- Does NOT touch any other `msg.get("content")` site — those run on plain-text
  game cards, intro markers, etc. and are correct as-is.
- Does NOT change pass-decision logic. The fix is purely in the inputs.
- Does NOT investigate the genuine `weekly-scheduling-bot.yml` failure
  surfaced in the Bot Health Report scoreboard — that is a separate issue
  (workflow runs but fails); this PR only makes the verifier embed-aware.

## Verification plan

After merge, trigger `gaming-library-daily.yml` manually on `main`:

- The "Verify gaming library output" step should now produce
  `header_found: True, footer_found: True, pass: True`.
- The next Bot Health Report run should not include any "Auto-fix Exhausted
  — Gaming Library Daily Reminder" alert.

## Self-critique

PR #305 was incomplete because I patched only the file with the most obvious
name (`verify_discord_output.py`) instead of grep-ing for the bug pattern
across the whole `scripts/` directory. This PR is the catch-up. The lesson
— always grep the codebase for the exact bug pattern before declaring a fix
shipped — is internalized for next time.