### PR TITLE
fix(weekly-scheduling-bot): retry git push with pull-rebase on race condition

### DIFF
--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -107,7 +107,23 @@ jobs:
           fi
 
           git commit -m "chore: update weekly schedule message state"
-          git push
+
+          # Retry push with pull --rebase on conflict. Concurrent workflow
+          # runs that also push state files (winners-state, gaming-library)
+          # can cause non-fast-forward push failures even with the workflow-
+          # level concurrency group, since other workflows are not in this
+          # group. Up to 5 attempts with exponential backoff.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed weekly schedule state on attempt $attempt"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed, pulling and retrying..."
+            git pull --rebase --autostash origin main
+            sleep $((attempt * 2))
+          done
+          echo "Failed to push weekly schedule state after 5 attempts" >&2
+          exit 1
 
       - name: Notify Discord health monitor on failure
         if: ${{ failure() && env.DISCORD_HEALTH_MONITOR_WEBHOOK_URL != '' }}


### PR DESCRIPTION
## What was broken

`weekly-scheduling-bot.yml` has 23 historical failed runs, the latest being
run #35 on May 2 2026. The Bot Health Report run #104 scoreboard surfaced
🔴 Weekly Scheduling Bot. Drilling into run #35:

```
[main 4e89215] chore: update weekly schedule message state
 1 file changed, 17 insertions(+)
To https://github.com/XiannGoh/steam-discord-free-games
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 
       'https://github.com/XiannGoh/steam-discord-free-games'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally...
```

## Why

The "Commit weekly schedule state" step does a naive `git push` with no
retry. The workflow checks out main, posts the weekly schedule, mutates
`data/scheduling/weekly_schedule_messages.json`, commits, and pushes. If a
*different* workflow on the repo (e.g. `evening-winners.yml` updating its
own state file, or `gaming-library-daily.yml` similarly) pushes to main
between this workflow's checkout and push, the push is rejected as
non-fast-forward.

The workflow-level `concurrency: weekly-schedule-state` group prevents
self-overlap (the 13:00 + 13:10 paired cron entries serialize correctly),
but it does NOT prevent races against other workflows that touch other
state files. Those other workflows are in different concurrency groups and
push freely, which is the conflict path that has been firing intermittently
for ~7 weeks.

## What this PR does

Replaces the unconditional `git push` with a 5-attempt retry loop:

```bash
for attempt in 1 2 3 4 5; do
  if git push; then
    echo "Pushed weekly schedule state on attempt $attempt"
    exit 0
  fi
  echo "Push attempt $attempt failed, pulling and retrying..."
  git pull --rebase --autostash origin main
  sleep $((attempt * 2))
done
echo "Failed to push weekly schedule state after 5 attempts" >&2
exit 1
```

`git pull --rebase --autostash` re-bases this run's commit on top of any
concurrent pushes. `--autostash` handles the unlikely case of an
uncommitted dirty file (shouldn't happen here since we just committed, but
it makes the loop robust). Exponential backoff (2s, 4s, 6s, 8s, 10s) gives
the upstream a chance to settle.

Five attempts is generous: if a single race takes one retry, two concurrent
racers might take two retries. Five gives margin for the unlikely worst
case where multiple workflows happen to all be racing for main at the same
second.

## What this PR does NOT do

- Does NOT change the schedule, the `concurrency:` group, or the idempotent
  SKIP/REUSE path inside `post_weekly_availability.py`. Those are correct.
- Does NOT touch other workflows that have the same naive-push pattern.
  Several likely do (e.g. `evening-winners.yml`, `gaming-library-daily.yml`),
  and those are candidates for a follow-up if/when they fail. Keeping this
  PR scoped to the workflow currently surfaced as 🔴 in the health report.
- Does NOT introduce a Workflow-app `permissions:` change. The existing
  `permissions: contents: write` block is sufficient for `git pull --rebase`.

## Verification plan

After merge: cron fires next Saturday (May 16). Either:

- The push succeeds first try (no race) → log shows `Pushed weekly
  schedule state on attempt 1` (no behavior change for the happy path).
- A race occurs → log shows `Push attempt 1 failed, pulling and retrying...`
  followed by a successful attempt 2 (or higher).

Either outcome is fine. Run #35's exact failure mode no longer drops the
workflow into red.