### PR TITLE
fix(winners): persist SKIP-marked winners_state and treat it as healthy

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -1056,8 +1056,13 @@ def main() -> None:
                     day_key=prior_day,
                     winners_channel_id=winners_channel_id,
                 )
-            if prior_days_requiring_updates:
-                save_discord_daily_posts(daily_posts)
+            # Mark winners_state with a SKIP status so the health report knows
+            # we ran for this day and intentionally posted nothing. Without this
+            # marker, the health report flags day_key as winners.state_missing.
+            winners_state["status"] = "skipped"
+            winners_state["skipped_reason"] = "no_eligible_winners"
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            save_discord_daily_posts(daily_posts)
             print(f"SKIP: no eligible winners in last {WINNERS_LOOKBACK_DAYS} days for {day_key}")
             return
 
@@ -1100,8 +1105,12 @@ def main() -> None:
                     day_key=prior_day,
                     winners_channel_id=winners_channel_id,
                 )
-            if prior_days_requiring_updates:
-                save_discord_daily_posts(daily_posts)
+            # Stamp updated_at_utc so the health report can confirm this run
+            # actually re-checked the day. winner_entries already exist from a
+            # previous run, so no SKIP marker is needed here — the existing
+            # winners_state is fully valid.
+            winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
+            save_discord_daily_posts(daily_posts)
             print(f"SKIP: no newly eligible winners for {day_key}")
             post_or_edit_rolling_explainer(client, winners_channel_id, "step-2")
             return

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -1082,6 +1082,10 @@ def main() -> None:
         ]
 
         if keys_unchanged and not had_previous_vote_snapshot and not manual_run:
+            # Same SKIP-clear as the main publish path: this branch updates real
+            # vote_counts / winner_entries, so any prior SKIP marker is stale.
+            winners_state.pop("status", None)
+            winners_state.pop("skipped_reason", None)
             winners_state["winner_vote_counts"] = current_winner_vote_counts
             winners_state["winner_entries"] = current_winner_entries
             winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
@@ -1137,6 +1141,13 @@ def main() -> None:
             day_key=day_key,
             winner_entries_by_key={entry["winner_key"]: entry for entry in current_winner_entries},
         )
+        # Clear any SKIP marker from a prior no-winners run on the same day:
+        # this run is publishing real winners, so the state should reflect that.
+        # Without this clear, the health report's SKIP-aware short-circuit would
+        # suppress message_id / winner_keys / freshness checks against an actually
+        # published state, hiding genuine inconsistencies.
+        winners_state.pop("status", None)
+        winners_state.pop("skipped_reason", None)
         winners_state["last_action"] = "edit" if previous_message_ids else "create"
         winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
         if not previous_message_ids:

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -581,7 +581,12 @@ def compute_state_issues(*, now_utc: datetime | None = None) -> list[Issue]:
                     file_path="discord_daily_posts.json",
                     day_key=winners_day,
                 )
-            if isinstance(winners_state, dict):
+            # SKIP-marked state means evening_winners.py ran for this day and
+            # intentionally posted nothing (no eligible winners in the lookback
+            # window). The presence of the dict satisfies the missing-state check
+            # above, but we skip the message_id / winner_keys / freshness checks
+            # below since they do not apply to a no-winners state.
+            if isinstance(winners_state, dict) and winners_state.get("status") != "skipped":
                 message_id = winners_state.get("message_id")
                 winner_keys = winners_state.get("winner_keys")
                 if not isinstance(message_id, str) or not message_id.strip():


### PR DESCRIPTION
## Where this came from

Bot Health Report run #104 surfaced the warning:
> 🟡 Winners state missing for 2026-05-08

I dismissed it earlier as a one-time artifact, but a closer look at evening-
winners run #88 (May 8 19:52 EDT, status: success) shows it is a real bug.
Run logs for that day:

```
Starting evening winners for day=2026-05-08
DISCORD RETRY: fetch votes for ...; status=429 ... (x22 retries)
SKIP: no eligible winners in last 10 days for 2026-05-08
```

The script reached a SKIP path, printed, and exited. The next-day Bot Health
Report saw no `winners_state` for May 8 in `discord_daily_posts.json` and
flagged it as missing.

## Why

In `evening_winners.py`, the SKIP path at line ~1058 ("no eligible winners
in last X days") creates an empty `winners_state` dict on `today_entry` at
line 1027 but only persists it conditionally:

```python
winners_state = today_entry.get("winners_state")
if not isinstance(winners_state, dict):
    winners_state = {}
    today_entry["winners_state"] = winners_state
...
if not current_winner_keys and not previous_message_ids:
    for prior_day in sorted(...):
        upsert_winners_messages_for_day(...)
    if prior_days_requiring_updates:
        save_discord_daily_posts(daily_posts)  # only if other days had updates
    print(f"SKIP: no eligible winners ...")
    return
```

On 2026-05-08 `prior_days_requiring_updates` was empty, so save was skipped,
so the empty `winners_state` for May 8 was lost on process exit. Health
report sees nothing → fires `winners.state_missing`.

The same bug exists in the second SKIP path at line ~1094 ("no newly eligible
winners") with the same conditional save guard.

## What this PR does

### `evening_winners.py` (2 SKIP paths fixed)

**Path 1** (no eligible winners): write a status marker and save unconditionally:

```python
winners_state["status"] = "skipped"
winners_state["skipped_reason"] = "no_eligible_winners"
winners_state["updated_at_utc"] = datetime.now(timezone.utc).isoformat()
save_discord_daily_posts(daily_posts)
```

**Path 2** (no newly eligible winners, prior winners unchanged): just stamp
`updated_at_utc` and save unconditionally. No SKIP marker is needed because
`winner_entries` already exist from a previous run, so the existing
`winners_state` is fully valid — we just need to confirm we re-checked.

### `scripts/build_daily_health_report.py` (1 line gated)

Old:
```python
if isinstance(winners_state, dict):
    message_id = winners_state.get("message_id")
    winner_keys = winners_state.get("winner_keys")
```

New:
```python
if isinstance(winners_state, dict) and winners_state.get("status") != "skipped":
    message_id = winners_state.get("message_id")
    winner_keys = winners_state.get("winner_keys")
```

The earlier `has_picks and not isinstance(winners_state, dict)` check is
unaffected: a SKIP-marked dict still passes `isinstance`, so the missing-
state warning does not fire either. SKIP-marked entries produce zero issues.

## Why both files together

Fixing only `evening_winners.py` would convert ONE warning
(`winners.state_missing`) into THREE errors (`winners.message_id_missing`,
`winners.keys_malformed`, `winners.empty_winner_keys`) because the empty
SKIP-marked dict trips every downstream consistency check. Both files have
to ship together.

## Verification plan

Tonight 2026-05-09 23:00 UTC, evening-winners.yml fires on its cron with
these fixes deployed. Two outcomes:

- If there are eligible winners (humans actually voted today) — the workflow
  proceeds via the success path. `winners_state` gets full message_id +
  winner_keys. Tomorrow's health report has nothing to flag for 2026-05-09.
- If there are no eligible winners (likely, given the chronic zero-vote
  pattern) — the workflow takes SKIP path 1. `winners_state` is persisted
  as `{"status": "skipped", "skipped_reason": "no_eligible_winners",
  "updated_at_utc": ...}`. Tomorrow's health report sees the dict, sees
  status=="skipped", silently passes — no 🟡 alert.

Either way: the existing 2026-05-08 alert remains until that backfill is
addressed (separate concern — we cannot retroactively reconstruct what May 8
should have written; we can either leave it or run a one-shot script to mark
May 8 as `status="skipped", skipped_reason="backfill"`).