### PR TITLE
fix(health-report): drop Missed-Run Watchdog from SCHEDULE_EXPECTATIONS

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -76,7 +76,9 @@ jobs:
               { file: "evening-winners.yml", name: "Daily Game Picks Winners", staleHours: 12 },
               { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 20 },
               { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 4 },
-              { file: "watchdog.yml", name: "Missed-Run Watchdog", staleHours: 2 },
+              // Missed-Run Watchdog removed 2026-05-10: cron disabled in watchdog.yml
+              // since 2026-04-19, so the workflow is never expected to fire. Re-add this entry
+              // (with appropriate staleHours) if the cron is re-enabled.
             ];
 
             const output = [];

--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -76,14 +76,12 @@ SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
         "minute": 15,
         "window_before_minutes": 30,
     },
-    "Missed-Run Watchdog": {
-        "kind": "interval",
-        "cron": "0 * * * *",
-        "cadence": "every hour",
-        "interval_hours": 1,
-        "minute": 0,
-        "window_before_minutes": 90,
-    },
+    # Missed-Run Watchdog was intentionally disabled in watchdog.yml on
+    # 2026-04-19 (the cron entry is commented out; only workflow_dispatch
+    # remains). Keeping it in SCHEDULE_EXPECTATIONS would cause the health
+    # report to fire a chronic "stale 21d ago" alert on every run, since
+    # the workflow is no longer expected to fire on its hourly cadence.
+    # Re-add this entry if the cron is re-enabled in watchdog.yml.
 }
 
 


### PR DESCRIPTION
## Where this came from

Today's bot health report (2026-05-10 05:54:50 UTC) still fires:
> 🔴 Missed-Run Watchdog
> Last run: success (21d ago) — stale
> Expected freshness: ≤2h
> Trigger: schedule
> Last run time: Apr 19, 2026 at 1:06 PM ET
> Expected cadence: every hour (cron: 0 * * * *)
> Schedule check: Latest run is scheduled but appears older than the most
> recent expected schedule window.

It's the LAST remaining 🔴 in today's report. With this gone, we drop to 0
items requiring attention.

## Why this is a false positive

The `Missed-Run Watchdog` workflow's cron schedule was intentionally
disabled in `.github/workflows/watchdog.yml` on 2026-04-19 with the
comment:

```yaml
on:
  workflow_dispatch:
  # schedule:  # disabled 2026-04-19 (retry cascade amplifies duplicate-
  #             run bugs; workflow_dispatch still works)
  #   - cron: "0 * * * *"
```

But `scripts/build_daily_health_report.py` still lists the workflow in
`SCHEDULE_EXPECTATIONS` with `"cadence": "every hour"` and
`"interval_hours": 1`. The health report has no way to know the schedule
is disabled at the YAML level, so it keeps comparing the last run
(Apr 19) to its expected hourly cadence and flagging chronic staleness.

## What this PR does

Removes the `"Missed-Run Watchdog"` entry from `SCHEDULE_EXPECTATIONS`,
replacing it with a 6-line comment explaining:
- Why it was removed (cron is disabled in watchdog.yml)
- When (2026-04-19)
- Why removal matters (chronic stale alert otherwise)
- How to undo (re-add the entry if cron is re-enabled)

```diff
-    "Missed-Run Watchdog": {
-        "kind": "interval",
-        "cron": "0 * * * *",
-        "cadence": "every hour",
-        "interval_hours": 1,
-        "minute": 0,
-        "window_before_minutes": 90,
-    },
+    # Missed-Run Watchdog was intentionally disabled in watchdog.yml on
+    # 2026-04-19 (the cron entry is commented out; only workflow_dispatch
+    # remains). Keeping it in SCHEDULE_EXPECTATIONS would cause the health
+    # report to fire a chronic "stale 21d ago" alert on every run, since
+    # the workflow is no longer expected to fire on its hourly cadence.
+    # Re-add this entry if the cron is re-enabled in watchdog.yml.
```

## Verification plan

Tonight's natural cron at 03:00 UTC (= 23:00 EDT today) produces a new
bot health report. With this fix deployed:
- The watchdog row disappears from the "Workflow Status" section entirely
- The "Overall: Action needed" headline should flip to "Overall: All
  systems healthy" (or whatever the 0-issues message is)
- This is the FIRST fully-green daily health report since the audit began