### PR TITLE
fix(pattern-analysis): disable schedule cron until prompt is trimmed

### DIFF
--- a/.github/workflows/pattern-analysis.yml
+++ b/.github/workflows/pattern-analysis.yml
@@ -1,9 +1,12 @@
 name: Pattern Analysis
 
 on:
-  schedule:
-    # Runs every Sunday at midnight UTC
-    - cron: "0 0 * * 0"
+  # schedule:  # disabled 2026-05-10: 5 consecutive failures — prompt scope
+  #               exceeds even 50 turns (PR #310 raised it from 10→50 and Run #5
+  #               still hit the cap). Re-enable after the prompt is trimmed and
+  #               manually verified via workflow_dispatch.
+  #   # Runs every Sunday at midnight UTC
+  #   - cron: "0 0 * * 0"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Where this came from

After merging PR #310 (bumped Pattern Analysis `--max-turns` from 10 to 50),
I manually triggered `pattern-analysis.yml` via `workflow_dispatch` to verify
the fix. Run #5 still failed:

> Action failed with error: SDK execution error: Error: Claude Code returned
> an error result: Reached maximum number of turns (50)

Bumping from 10 → 50 just made the failure take longer (6m 53s vs ~1m). The
root cause is **prompt scope**, not turn count. The prompt asks Claude Code
to do 6 things including:

1. Read `data/health_monitor_log.json` and review all failures + patterns
2. Identify recurring patterns
3. Update / add pattern entries
4. **Investigate root cause and open a PR if a systemic fix is suggested**
5. Post a pattern report to the health monitor webhook
6. Commit the updated log

Step 4 alone (a full root-cause investigation + branch creation + PR open)
would consume dozens of turns. Combined with the rest, 50 is structurally
insufficient. Run history confirms: **all 5 runs have failed** since the
workflow was created on Apr 19.

| Run | Date | Status | Duration | Turn cap |
|---|---|---|---|---|
| #5 | May 10 | ❌ failed | 6m 53s | 50 |
| #4 | May 10 | ❌ failed | 1m 11s | 10 |
| #3 | May 3 | ❌ failed | 1m 51s | 10 |
| #2 | Apr 26 | ❌ failed | 1m 18s | 10 |
| #1 | Apr 19 | ❌ failed | 1m 24s | 10 |

## Why disable rather than bump further

Options I considered:
- **Bump to 100**: speculative, no evidence Claude would finish; just burns
  more Anthropic API tokens to fail more slowly.
- **Trim the prompt**: the right long-term fix, but requires careful design
  (do we drop step 4 entirely? collapse 5+6 into one webhook call? etc.).
- **Disable the cron**: stops the weekly Discord alert noise immediately,
  preserves the workflow for later trimming via `workflow_dispatch`. This
  matches the precedent set by `watchdog.yml` on 2026-04-19 (“retry cascade
  amplifies duplicate-run bugs; workflow_dispatch still works”).

Disabling is the lowest-risk move that immediately stops the noise.

## What this PR does

```diff
on:
-  schedule:
-    # Runs every Sunday at midnight UTC
-    - cron: "0 0 * * 0"
+  # schedule:  # disabled 2026-05-10: 5 consecutive failures — prompt scope
+  #               exceeds even 50 turns (PR #310 raised it from 10→50 and
+  #               Run #5 still hit the cap). Re-enable after the prompt is
+  #               trimmed and manually verified via workflow_dispatch.
+  #   # Runs every Sunday at midnight UTC
+  #   - cron: "0 0 * * 0"
  workflow_dispatch: {}
```

No companion change needed in the health report: `pattern-analysis.yml` is
not in `SCHEDULE_EXPECTATIONS` (in `build_daily_health_report.py`) nor in
the collected workflow list (in `bot-health-report.yml`). So the disable
doesn't create a false-positive stale alert (Codex review on PR #311 taught
me to check both).

## What this does NOT do

Does not redesign the prompt. That's a separate, more-effort task: decide
what the workflow should actually do, possibly:
  * Drop step 4 (auto-PR opening) since Codex/Claude Code Review already
    cover code-fix suggestions in PR review.
  * Drop step 5 (webhook post) if the value is just in the log file.
  * Or just have it do step 1+2 (read + classify) and exit.

Defer until someone wants pattern analysis back.

## Verification plan

Next Sunday (May 17 00:00 UTC) should produce no Pattern Analysis run at
all (the cron is disabled). No new 🔴 alert in
`#xiann-gpt-bot-health-monitor` for “Pattern Analysis” after that point.

Workflow remains callable via `workflow_dispatch` for ad-hoc runs.