### PR TITLE
fix(verify_discord_output): treat winners.status==skipped as healthy (PR #308 follow-up)

### DIFF
--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -792,6 +792,25 @@ def verify_step2(
         ch["skipped_reason"] = f"No winners_state in discord_daily_posts.json for {day_key}."
         print(f"\n--- Step-2 skipped: no winners_state for {day_key} ---")
         return ch
+    if winners_state.get("status") == "skipped":
+        # SKIP-marked state means evening_winners.py ran for this day and
+        # intentionally posted nothing (no eligible winners in the lookback
+        # window). The intro / section header / footer / item checks below
+        # do not apply to a no-winners state; the SKIP marker IS the "we ran
+        # and decided not to post" signal the verifier wants. Treat it the
+        # same as an absent winners_state — skipped, pass=True.
+        ch["checked"] = False
+        ch["pass"] = True
+        skipped_reason = winners_state.get("skipped_reason") or "unknown"
+        ch["skipped_reason"] = (
+            f"winners_state.status=skipped (reason={skipped_reason}) "
+            f"for {day_key}: evening_winners.py ran but found no eligible winners."
+        )
+        print(
+            f"\n--- Step-2 skipped: winners_state.status=skipped "
+            f"(reason={skipped_reason}) for {day_key} ---"
+        )
+        return ch
 
     ch["checked"] = True
 


### PR DESCRIPTION
## Where this came from

Tonight's natural evening-winners cron at 23:00 UTC May 10 (the first
one with PR #308 deployed) fired two alerts in
`#xiann-gpt-bot-health-monitor`:

- 23:48:21 UTC: 🔴 Failure Detected — Daily Game Picks Winners May 10
  (discord_pass=false)
- 23:51:06 UTC: 🚨 Auto-fix Exhausted — Daily Game Picks Winners May 10
  (all 3 attempts failed)

The workflow itself succeeded (Run #90, SHA `3e9603d`, 2m 50s, status:
Success) but the inline `Verify Discord output` step set
`discord_pass=false`, which the auto-fix bot picked up.

## Why this is a regression from PR #308

PR #308 introduced a `winners_state` SKIP marker so that days when
`evening_winners.py` finds no eligible winners persist a dict with
`status="skipped"` instead of writing nothing:

```json
{
  "winners_state": {
    "status": "skipped",
    "skipped_reason": "no_eligible_winners"
  }
}
```

PR #308 updated `build_daily_health_report.py` to treat that marker as
healthy. **It did NOT update `scripts/verify_discord_output.py`**.

The Step-2 verifier in `verify_discord_output.py` (line 787) has an
early-out only for the case where `winners_state` is *absent*:

```python
winners_state = day_entry.get("winners_state")
if not isinstance(winners_state, dict):
    ch["checked"] = False
    ch["pass"] = True  # not posted yet — not a failure
    return ch

ch["checked"] = True
# ... then proceeds into intro / section / footer / item checks ...
```

With PR #308's SKIP marker, `winners_state` **is** a dict (it has
`status` and `skipped_reason` keys), so the isinstance check passes and
the verifier proceeds into the intro/section/footer/items checks. Those
all fail because the SKIP path didn't post anything, so
`winners_state.get("intro")` is `{}`, all `message_id`s are missing, and
the verifier reports failures → `discord_pass=false` → alert fires.

## What this PR does

Adds a second early-out right after the existing one:

```python
if winners_state.get("status") == "skipped":
    ch["checked"] = False
    ch["pass"] = True
    skipped_reason = winners_state.get("skipped_reason") or "unknown"
    ch["skipped_reason"] = (
        f"winners_state.status=skipped (reason={skipped_reason}) "
        f"for {day_key}: evening_winners.py ran but found no eligible winners."
    )
    print(
        f"\n--- Step-2 skipped: winners_state.status=skipped "
        f"(reason={skipped_reason}) for {day_key} ---"
    )
    return ch
```

This mirrors the gating I added to `build_daily_health_report.py` in
PR #308. The SKIP marker IS the "we ran and decided not to post" signal;
verifying the intro/footer/items on top of it makes no sense.

## Why I missed this in PR #308

PR #308 added the SKIP marker to `winners_state` and updated the
health-report consumer (`build_daily_health_report.py`). I should have
grepped for all consumers of `winners_state` at the time. There are three:

1. `evening_winners.py` — writer (added SKIP in PR #308) ✅
2. `build_daily_health_report.py` — reader (updated in PR #308) ✅
3. `verify_discord_output.py` — reader (THIS PR) ✅

Lesson noted: when adding a status marker, find all consumers first.

## Verification plan

Next evening-winners cron (May 11 23:00 UTC) is the canonical test. With
this fix:

- Workflow Run #91 should complete with status: Success (same as #90)
- Inline verifier should print "--- Step-2 skipped: winners_state.status
  =skipped (reason=...) for 2026-05-11 ---"
- `discord_verification.json` should have step-2 `pass=True, checked=False`
- No 🔴 Failure Detected alert in `#xiann-gpt-bot-health-monitor`
- No 🚨 Auto-fix Exhausted alert either

If step-2 has ACTUAL winners that day (someone votes in step-1 today),
`winners_state` will not have `status=skipped` and the existing checks
apply as before. No behavior change for the happy path.