### PR TITLE
docs(README): mark watchdog and pattern-analysis crons as disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,7 +337,7 @@ Processed command message IDs are tracked in `gaming_library.json` under `proces
 | `weekly-scheduling-bot.yml` | Weekly Scheduling Bot | 9:00 AM Saturday |
 | `weekly-scheduling-responses-sync.yml` | Weekly Scheduling Responses Sync | Every 3 hours |
 | `bot-health-report.yml` | Bot Health Report | 11:00 PM daily |
-| `watchdog.yml` | Missed-Run Watchdog | Every hour |
+| `watchdog.yml` | Missed-Run Watchdog | Disabled (cron) / on-demand |
 | `auto-fix.yml` | Auto-Fix | Triggered by workflow_run |
 
 Every workflow has a Notify Discord health monitor on failure step that posts to DISCORD_HEALTH_MONITOR_WEBHOOK_URL on failure.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Every workflow posts its status here. Failures trigger auto-fix. Daily health re
 - **Scoring model** — games are scored on review sentiment, multiplayer tags, recency, and friend signal. Only games above a minimum score threshold are posted.
 - **Validator** — after every post, a validator checks Discord output against a spec. If anything is wrong it triggers auto-fix.
 - **Auto-fix loop** — Claude Code automatically diagnoses failures, opens PRs, and merges fixes. Up to 3 attempts per failure with rollback if a fix makes things worse.
-- **Watchdog** — runs hourly. If any scheduled workflow missed its run, the watchdog re-triggers it. Capped at 3 re-triggers per workflow per day.
-- **Pattern analysis** — runs every Sunday. Reviews failure patterns from the week and suggests improvements.
+- **Watchdog** — scheduled cron is currently disabled (was hourly). Workflow remains available via `workflow_dispatch` for ad-hoc use. The hourly retry cascade was found to amplify duplicate-run bugs and was paused on 2026-04-19.
+- **Pattern analysis** — scheduled cron is currently disabled (was Sunday). Workflow remains available via `workflow_dispatch`. The current prompt is over-scoped (all historical runs hit max-turns); cron will be re-enabled after the prompt is trimmed.
 - **State backup** — all state files backed up daily to a separate branch.
 
 ## Workflows
@@ -45,9 +45,9 @@ Every workflow posts its status here. Failures trigger auto-fix. Daily health re
 | `weekly-scheduling-bot.yml` | Saturday 9AM ET | Weekly availability prompt |
 | `weekly-scheduling-responses-sync.yml` | Every 3 hours | Sync availability responses |
 | `bot-health-report.yml` | 11PM ET daily | Daily health summary |
-| `watchdog.yml` | Every hour | Re-trigger missed workflows |
+| `watchdog.yml` | Disabled (cron) / on-demand | Re-trigger missed workflows |
 | `auto-fix.yml` | On failure | Self-healing fix loop |
-| `pattern-analysis.yml` | Sunday midnight | Weekly pattern review |
+| `pattern-analysis.yml` | Disabled (cron) / on-demand | Weekly pattern review |
 | `state-backup.yml` | 11:45PM ET daily | Back up state files |
 
 ## Key files


### PR DESCRIPTION
## What this does

Brings `README.md` and `CLAUDE.md` in sync with the current state of two
workflows whose scheduled crons have been disabled:

1. **`watchdog.yml`** — cron disabled 2026-04-19 (retry cascade was amplifying
   duplicate-run bugs). Workflow still callable via `workflow_dispatch`.
   PR #311 dropped it from the bot health report so it stopped firing chronic
   stale-21d alerts.

2. **`pattern-analysis.yml`** — cron disabled 2026-05-10 (PR #313). All 5
   historical runs hit max-turns; PR #310 bumped from 10→50 but Run #5 still
   failed. Root cause is prompt scope, not turn count. Cron will be re-enabled
   after the prompt is trimmed.

## Changes

**`README.md`** (4 edits):
- Bullet about Watchdog updated: “scheduled cron is currently disabled (was hourly)”
- Bullet about Pattern analysis updated: “scheduled cron is currently disabled (was Sunday)”
- Workflow table row for `watchdog.yml` updated: “Disabled (cron) / on-demand”
- Workflow table row for `pattern-analysis.yml` updated: “Disabled (cron) / on-demand”

**`CLAUDE.md`** (1 edit, follow-up commit):
- Workflow table row for `watchdog.yml` updated to reflect disabled cron

## Why it matters

README is the public-facing front door. Stale claims like “watchdog runs
hourly” directly contradict observable behavior (`Last run: 21d ago`) and
make the repo look broken. CLAUDE.md is the rules-of-the-road for Claude
Code; keeping its workflow table in sync prevents Claude Code from making
assumptions based on stale schedule info.

No behavior change — docs only.