### PR TITLE
fix(gaming-library-sync): wire DISCORD_GAMING_LIBRARY_CHANNEL_ID env (Step-3 !commands)

### DIFF
--- a/.github/workflows/gaming-library-sync.yml
+++ b/.github/workflows/gaming-library-sync.yml
@@ -33,6 +33,11 @@ jobs:
           PYTHONPATH: .
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          # DISCORD_GAMING_LIBRARY_CHANNEL_ID is required for process_library_commands
+          # to run. Without it, run_discord_sync() silently skips the !add/!remove/...
+          # command scanner because of "if channel_id:" guard in gaming_library.py.
+          # Missing this env var meant manual commands never worked (0 processed_command_ids).
+          DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python scripts/sync_gaming_library.py
 


### PR DESCRIPTION
## Where this came from

User asked me to verify the Step-3 manual commands (`!addgame`, `!add`,
`!remove`, `!unassign`, `!rename`, `!archive`) work as intended. They
don't. There's a 24-day-old unprocessed command in `#step-3`:

> `!addgame Bronzebeard's Tavern https://store.steampowered.com/app/2422870/Bronzebeards_Tavern/ <@195462430535581708>`
> *(2026-04-17 by thomasgoh, 0 reactions)*

No ✅ ack. Game is not in `gaming_library.json`. State file shows
`processed_command_ids: []` — the command scanner has **never** processed
a single command since it shipped.

## Root cause

The command scanner lives in `gaming_library.run_discord_sync()`, which is
called by `scripts/sync_gaming_library.py`, run by `gaming-library-sync.yml`
every 3 hours. The relevant code:

```python
def run_discord_sync(...):
    channel_id = DISCORD_GAMING_LIBRARY_CHANNEL_ID  # ← env var lookup
    ...
    commands_processed = 0
    if channel_id:                                  # ← GUARD
        commands_processed = process_library_commands(...)
    ...
```

**`gaming-library-sync.yml` does not set `DISCORD_GAMING_LIBRARY_CHANNEL_ID`**
in its env block:

```yaml
- name: Sync gaming library from Discord reactions
  env:
    PYTHONPATH: .
    DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
    DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
    GITHUB_EVENT_NAME: ${{ github.event_name }}
  run: python scripts/sync_gaming_library.py
```

So at runtime, `os.environ.get("DISCORD_GAMING_LIBRARY_CHANNEL_ID", "")`
returns `""`, the `if channel_id:` is False, and **the command scanner is
silently skipped on every sync run**.

Audit confirms `gaming-library-sync.yml` is the only sync-path workflow
missing this env var. `daily.yml`, `evening-winners.yml`, and
`gaming-library-daily.yml` all set it (because they post TO the channel).
It was just forgotten on the read/scan workflow.

## What this PR does

Adds `DISCORD_GAMING_LIBRARY_CHANNEL_ID: ${{ secrets.DISCORD_GAMING_LIBRARY_CHANNEL_ID }}`
to the env block, with a comment explaining why it's required (so future
editors don't remove it). Same pattern as the other 3 workflows that
already have it.

## Why this is safe

- One env var addition, no logic change
- The other 3 workflows have used this exact secret reference for months
- Worst case: secret is somehow missing, in which case `channel_id` is still
  empty and we fall back to the existing skip behavior — no regression
- Failure case is well-handled (existing `if channel_id:` guard)

## What happens after merge

Next 3-hour cron (or `workflow_dispatch`) will:
1. Fetch last 100 messages from `#step-3-review-existing-games`
2. Find unprocessed `!`-commands (the Apr 17 `!addgame` plus any new ones)
3. Apply them to `gaming_library.json`
4. Add ✅ reaction to acknowledge each one
5. Append each message ID to `processed_command_ids` so it isn't reprocessed

The 24-day-old `!addgame Bronzebeard's Tavern` should land in the library
automatically.

## Verification plan

- Trigger `gaming-library-sync.yml` via `workflow_dispatch` after merge
- Check `gaming_library.json` diff in the autocommit — should contain a new
  game entry for Bronzebeard's Tavern
- Visually confirm ✅ reaction appeared on the Apr 17 message in `#step-3`
- Confirm `processed_command_ids` array is no longer empty