### PR TITLE
fix(verify_discord_output): accept Bot Commands as trailing message in step-3 (PR #317 follow-up)

### DIFF
--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -47,6 +47,13 @@ GAMING_LIBRARY_FILE = "gaming_library.json"
 THUMBS_UP_EMOJI = "\U0001f44d"   # 👍
 BOOKMARK_EMOJI = "\U0001f516"    # 🔖
 ROLLING_EXPLAINER_PREFIX = "📌 How This Works"
+# In #step-3, gaming_library.py also pins a "📋 Bot Commands" reference card via
+# ensure_command_reference_pinned(). On the day that reference is first posted
+# (state had no command_reference_message yet), it sits AFTER the rolling
+# explainer until tomorrow's daily-library cron posts a fresh explainer.
+# Subsequent sync runs edit the existing message in place (no reorder).
+# Allow either prefix as the valid trailing message in step-3.
+COMMAND_REFERENCE_PREFIX = "📋 Bot Commands"
 
 # Honour the same date-override env var that main.py uses so this script can
 # be pointed at a specific day during manual reruns.
@@ -413,17 +420,28 @@ def _run_channel_scan(
             f"{len(explainer_today)} rolling explainers for {day_key}"
         )
     # Verify the explainer is the actual last message in the channel.
-    if all_messages and not all_messages[0].get("content", "").startswith(ROLLING_EXPLAINER_PREFIX):
+    # Exception: in #step-3, the pinned "📋 Bot Commands" reference card may sit
+    # after the explainer on the day it's first posted. Accept either as valid.
+    last_content = all_messages[0].get("content", "") if all_messages else ""
+    is_explainer_last = last_content.startswith(ROLLING_EXPLAINER_PREFIX)
+    is_cmd_ref_last = (
+        channel_slug == CHANNEL_STEP3
+        and last_content.startswith(COMMAND_REFERENCE_PREFIX)
+    )
+    if all_messages and not (is_explainer_last or is_cmd_ref_last):
         ch["rolling_explainer_missing"] = True
-        last_preview = str(all_messages[0].get("content", ""))[:60]
+        last_preview = str(last_content)[:60]
         ch["errors"].append(
             f"rolling explainer is not the last message — "
             f"last: {last_preview!r} (channel scan: {day_key})"
         )
         print(f"  FAIL  channel scan {channel_slug}: rolling explainer is not last message")
-    elif all_messages and all_messages[0].get("content", "").startswith(ROLLING_EXPLAINER_PREFIX):
+    elif all_messages and is_explainer_last:
         ch.setdefault("rolling_explainer_missing", False)
         print(f"  OK  channel scan {channel_slug}: rolling explainer is last message")
+    elif all_messages and is_cmd_ref_last:
+        ch.setdefault("rolling_explainer_missing", False)
+        print(f"  OK  channel scan {channel_slug}: command reference is last message (step-3 pinned reference)")
 
     # --- Cross-channel bot detection ---
     expected_bots = EXPECTED_BOT_AUTHORS.get(channel_slug)


### PR DESCRIPTION
## Where this came from

Today's natural daily.yml cron (the first one after PR #317 + my manual
Gaming Library Sync #192 trigger) fired both:

- 16:16:36 UTC 🔴 Failure Detected — Steam Free Games — May 11, 2026
- 16:22:18 UTC 🚨 Auto-fix Exhausted — Steam Free Games — May 11, 2026

And tonight's evening-winners cron at 23:55 UTC also fired:

- 23:56:38 UTC 🔴 Failure Detected — Daily Game Picks Winners — May 11
- 00:04:09 UTC 🚨 Auto-fix Exhausted — Daily Game Picks Winners — May 12

All four have the same root cause: `discord_pass=false`.

## Root cause

Reading the verifier log for run #25681101969:

```
--- Step-3 channel scan ---
  channel scan step-3-review-existing-games: 100 fetched, 4 from 2026-05-11
  OK   channel scan step-3-review-existing-games: intro found
  OK   channel scan step-3-review-existing-games: footer found
  OK   channel scan step-3-review-existing-games: 0 game cards
  FAIL channel scan step-3-review-existing-games: rolling explainer is not last message
```

This is a **collision between PR #317 and the verifier**:

1. PR #317 wired `DISCORD_GAMING_LIBRARY_CHANNEL_ID` so the sync workflow
   would actually call `process_library_commands()`.
2. That call path also invokes `ensure_command_reference_pinned()`
   (gaming_library.py:1236) which posts a `📋 Bot Commands` reference card
   the first time it runs without `state["command_reference_message"]`.
3. The first run happened at 08:58 UTC May 11 (my manual workflow_dispatch),
   which posted the Bot Commands message AFTER the rolling explainer that
   was posted by the daily-library cron at 03:36 UTC.
4. The verifier (verify_discord_output.py:418) enforces "rolling explainer
   must be the actual last message" — a check that was correct *before*
   PR #317 took effect but is now too strict.

Currently `#step-3` looks like this:

```
08:58:07  📋 Bot Commands  ← latest (pinned reference card)
03:36:46  📌 How This Works  ← rolling explainer
03:36:45  [daily library footer embed]
03:36:42  [daily library intro embed]
```

The verifier wants `📌 How This Works` as the last message, but `📋 Bot
Commands` legitimately sits there.

## What this PR does

Adds `COMMAND_REFERENCE_PREFIX = "📋 Bot Commands"` and extends the last-
message check to accept either prefix as valid in #step-3 only:

```python
last_content = all_messages[0].get("content", "") if all_messages else ""
is_explainer_last = last_content.startswith(ROLLING_EXPLAINER_PREFIX)
is_cmd_ref_last = (
    channel_slug == CHANNEL_STEP3
    and last_content.startswith(COMMAND_REFERENCE_PREFIX)
)
if all_messages and not (is_explainer_last or is_cmd_ref_last):
    # ... FAIL ...
```

Step-1 and Step-2 verifiers continue to enforce "explainer is last" strictly
(no Bot Commands message in those channels).

## Why this is safe

- Strictly **widens** an acceptance criterion for #step-3 only
- Step-1, Step-2 checks unchanged
- Bot Commands message is a known, intentional, structural element (posted by
  `ensure_command_reference_pinned()`) — not a random unexpected message
- Subsequent sync runs only **edit** the Bot Commands message in place (no
  reorder), so this exception applies indefinitely without re-posting

## Verification plan

- Tomorrow's daily.yml cron at 14:38 UTC should NOT fire 🔴 Failure for
  step-3 (verifier will say "command reference is last message")
- Tomorrow's evening-winners 23:00 UTC should NOT fire 🚨 either
- `discord_pass` should return to `true` in alerts