### PR TITLE
refactor(gaming-library): consolidate command help into rolling explainer

### DIFF
--- a/gaming_library.py
+++ b/gaming_library.py
@@ -96,18 +96,11 @@ _LIBRARY_FOOTER_MISSING_LABELS = {
     CATEGORY_CREATOR_PICKS: "Creator Picks",
 }
 
-COMMAND_REFERENCE_MESSAGE = """\
-📋 Bot Commands — step-3-review-existing-games
-`!add @user GameName` — assign a player to a game
-`!remove @user GameName` — unassign a player from a game
-`!rename GameName NewName` — rename a game
-`!unassign @user` — remove a player from all games
-`!archive GameName` — manually archive a game
-`!addgame GameName SteamURL @user1 @user2` — add game directly to library
-
-React on any game message to update your status:
-✅ Playing · ⏸️ Paused · ❌ Dropped\
-"""
+# COMMAND_REFERENCE_MESSAGE removed: command reference is now consolidated into
+# the rolling explainer (rolling_explainer.py "step-3" variants), which is posted
+# fresh by the daily-library cron. Maintaining a separate pinned message led to
+# divergent wording/formatting between the two messages and broke the verifier
+# check that expects the rolling explainer as the last message.
 
 
 def is_manual_run() -> bool:
@@ -1185,24 +1178,39 @@ def _check_channel_permissions(
     )
 
 
-def ensure_command_reference_pinned(
+def cleanup_command_reference_message(
     state: Dict[str, Any],
     client: DiscordClient,
     channel_id: str,
 ) -> None:
-    """Post or edit the command reference message to keep it current."""
+    """One-shot cleanup: delete the legacy "📋 Bot Commands" pinned message and
+    clear the state field that tracked it.
+
+    Background: an earlier version of this module maintained a separate pinned
+    "Bot Commands" reference card via ensure_command_reference_pinned(). That
+    duplicated the command list already present in the step-3 rolling explainer
+    (see rolling_explainer.py), with subtly divergent wording and formatting,
+    and broke the verifier check that requires the rolling explainer to be the
+    last message in #step-3.
+
+    This function runs every sync cycle but is effectively a no-op once the
+    legacy message has been deleted. The state field is cleared atomically so
+    a partial-success retry won't loop on a stale id.
+    """
     pinned_info = state.get("command_reference_message")
     existing_msg_id = str((pinned_info or {}).get("message_id") or "").strip()
-    if existing_msg_id:
-        try:
-            client.edit_message(channel_id, existing_msg_id, COMMAND_REFERENCE_MESSAGE, context="update command reference")
-        except DiscordMessageNotFoundError:
-            existing_msg_id = ""
     if not existing_msg_id:
-        payload = client.post_message(channel_id, COMMAND_REFERENCE_MESSAGE, context="post command reference")
-        msg_id = str(payload.get("id") or "").strip()
-        if msg_id:
-            state["command_reference_message"] = {"message_id": msg_id, "channel_id": channel_id}
+        return
+    try:
+        client.delete_message(channel_id, existing_msg_id, context="cleanup legacy command reference")
+    except DiscordMessageNotFoundError:
+        # Already gone (user deleted it, or already cleaned up in another run).
+        pass
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"WARN: failed to delete legacy command reference {existing_msg_id}: {exc}")
+        return  # keep state entry so we retry on next run
+    # Either delete succeeded or message was already gone; clear state.
+    state["command_reference_message"] = None
 
 
 def run_discord_sync(state_path: str = GAMING_LIBRARY_FILE, daily_posts_path: str = DISCORD_DAILY_POSTS_FILE) -> Dict[str, int]:
@@ -1233,7 +1241,7 @@ def run_discord_sync(state_path: str = GAMING_LIBRARY_FILE, daily_posts_path: st
         commands_processed = 0
         if channel_id:
             commands_processed = process_library_commands(state, client, channel_id, bot_user_id)
-            ensure_command_reference_pinned(state, client, channel_id)
+            cleanup_command_reference_message(state, client, channel_id)
 
     save_gaming_library(state, state_path)
     return {"promotions": promotions, "status_updates": status_updates, "commands_processed": commands_processed}


### PR DESCRIPTION
## Where this came from

User flagged that `#step-3` has TWO messages explaining the bot commands and
they are redundant, divergent, and visually messy:

1. **The rolling explainer** `📌 How This Works — #step-3-review-existing-games`
   posted by the daily-library cron. Lists commands inline with `·` separators.
   Status labels: ✅ **Active** · ⏸️ Paused · ❌ Dropped.

2. **A separate pinned card** `📋 Bot Commands — step-3-review-existing-games`
   posted by `ensure_command_reference_pinned()`. Lists commands one-per-line
   with backticks + descriptions. Status labels: ✅ **Playing** · ⏸️ Paused · ❌ Dropped.

## The three problems

- **Redundancy**: same six commands listed in two different messages
- **Divergence**: status label inconsistency (“Active” vs “Playing”), command
  ordering differs, and the two will inevitably drift further as code changes
- **Visual mess**: two help cards stacked in the channel; second one breaks
  the verifier check that wants the rolling explainer to be the last message
  (which we patched around in PR #318, but the right fix is to remove the
  duplicate)

## What this PR does

**`gaming_library.py`** — three coordinated edits:

1. **Removes the `COMMAND_REFERENCE_MESSAGE` constant** (lines 99–110).
   Replaced with a comment that explains why it was removed and where the
   command reference now lives (rolling_explainer.py `step-3` variants —
   which already contain the same command list).

2. **Replaces `ensure_command_reference_pinned()` with `cleanup_command_reference_message()`**.
   The new function is a one-shot self-deleting migration: when it sees
   `state["command_reference_message"]`, it calls `client.delete_message()`
   to remove the legacy pinned card, then clears the state field. After
   the message is gone, every subsequent call is a no-op (early return).

   Defensive paths:
   - `DiscordMessageNotFoundError` (user already deleted it): swallow and
     still clear state so we don't loop
   - Other exception: log a warning and keep state so we retry next sync

3. **Updates the call site** (formerly line 1236) to call the new function.

## Why I did NOT also revert PR #318

PR #318 widened the verifier to accept the `📋 Bot Commands` message as a
valid last message in #step-3. After this cleanup runs, that exception path
becomes unreachable defensive code — but I am leaving it in place for now
because:

- This PR's cleanup runs on the next sync workflow (every 3 hours, or one
  manual `workflow_dispatch`)
- Between merge and that next sync, the legacy Bot Commands message will
  still be physically present in the channel, and reverting the verifier
  in the same commit would cause one or two transient 🔴 alerts before
  the cleanup completes
- A small follow-up PR can revert PR #318 once we've confirmed the
  cleanup ran and the Bot Commands message is gone

## Verification plan

1. After merge, trigger Gaming Library Sync via `workflow_dispatch`
2. The run should:
   - Successfully delete message id `1503320290581545030` (the legacy Bot
     Commands card)
   - Commit `gaming_library.json` with `command_reference_message: null`
3. Open `#step-3` in Discord: the latest message should now be the
   `📌 How This Works` rolling explainer (no more `📋 Bot Commands` card)
4. The next daily.yml cron at 14:38 UTC and evening-winners at 23:00 UTC
   should both pass with no `discord_pass=false` alert
5. Once the above is confirmed, a follow-up PR can revert PR #318 to
   restore the strict "rolling explainer must be last" check in #step-3