### PR TITLE
revert(verify_discord_output): remove PR #318 exception (cleanup ran via PR #319)

### DIFF
--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -47,13 +47,6 @@ GAMING_LIBRARY_FILE = "gaming_library.json"
 THUMBS_UP_EMOJI = "\U0001f44d"   # 👍
 BOOKMARK_EMOJI = "\U0001f516"    # 🔖
 ROLLING_EXPLAINER_PREFIX = "📌 How This Works"
-# In #step-3, gaming_library.py also pins a "📋 Bot Commands" reference card via
-# ensure_command_reference_pinned(). On the day that reference is first posted
-# (state had no command_reference_message yet), it sits AFTER the rolling
-# explainer until tomorrow's daily-library cron posts a fresh explainer.
-# Subsequent sync runs edit the existing message in place (no reorder).
-# Allow either prefix as the valid trailing message in step-3.
-COMMAND_REFERENCE_PREFIX = "📋 Bot Commands"
 
 # Honour the same date-override env var that main.py uses so this script can
 # be pointed at a specific day during manual reruns.
@@ -420,28 +413,17 @@ def _run_channel_scan(
             f"{len(explainer_today)} rolling explainers for {day_key}"
         )
     # Verify the explainer is the actual last message in the channel.
-    # Exception: in #step-3, the pinned "📋 Bot Commands" reference card may sit
-    # after the explainer on the day it's first posted. Accept either as valid.
-    last_content = all_messages[0].get("content", "") if all_messages else ""
-    is_explainer_last = last_content.startswith(ROLLING_EXPLAINER_PREFIX)
-    is_cmd_ref_last = (
-        channel_slug == CHANNEL_STEP3
-        and last_content.startswith(COMMAND_REFERENCE_PREFIX)
-    )
-    if all_messages and not (is_explainer_last or is_cmd_ref_last):
+    if all_messages and not all_messages[0].get("content", "").startswith(ROLLING_EXPLAINER_PREFIX):
         ch["rolling_explainer_missing"] = True
-        last_preview = str(last_content)[:60]
+        last_preview = str(all_messages[0].get("content", ""))[:60]
         ch["errors"].append(
             f"rolling explainer is not the last message — "
             f"last: {last_preview!r} (channel scan: {day_key})"
         )
         print(f"  FAIL  channel scan {channel_slug}: rolling explainer is not last message")
-    elif all_messages and is_explainer_last:
+    elif all_messages and all_messages[0].get("content", "").startswith(ROLLING_EXPLAINER_PREFIX):
         ch.setdefault("rolling_explainer_missing", False)
         print(f"  OK  channel scan {channel_slug}: rolling explainer is last message")
-    elif all_messages and is_cmd_ref_last:
-        ch.setdefault("rolling_explainer_missing", False)
-        print(f"  OK  channel scan {channel_slug}: command reference is last message (step-3 pinned reference)")
 
     # --- Cross-channel bot detection ---
     expected_bots = EXPECTED_BOT_AUTHORS.get(channel_slug)


### PR DESCRIPTION
## Where this came from

PR #318 added a defensive exception to the verifier's "rolling explainer
is the last message" check, allowing `📋 Bot Commands` as a valid trailing
message in #step-3. PR #319 then removed the underlying duplicate-message
design entirely (consolidated into the rolling explainer).

I just manually triggered Gaming Library Sync run #199 (1m 51s, success).
Three verifications confirm the cleanup completed:

- `botCmdStillExists: false` — message is deleted from Discord
- `command_reference_message: null` in `gaming_library.json` — state cleared
- Latest message in #step-3 is now `📌 How This Works` (rolling explainer)

The Bot Commands message will never come back — the function that posted
it (`ensure_command_reference_pinned`) was deleted in PR #319 and replaced
with a cleanup-only function (`cleanup_command_reference_message`).

## What this PR does

Reverts PR #318 cleanly:

- Removes the `COMMAND_REFERENCE_PREFIX = "📋 Bot Commands"` constant
- Removes the 6-line comment block above it that explained why the
  exception existed
- Restores the strict last-message check (12 lines vs PR #318's 22 lines)

File size returns to exactly 50804 bytes — byte-for-byte identical to the
pre-PR-#318 state for these regions.

## Why this is safe

- PR #319 already deleted the only message that the PR #318 exception was
  designed to permit. With that message gone, the exception path was
  unreachable defensive code
- Strict check is the original behavior shipped by PR #302/#303 ("rolling
  explainer must be the last message in each step channel")
- If somehow a `📋 Bot Commands` message reappeared in the future (e.g. a
  bug or a revert), the verifier would correctly flag it as a regression
  rather than silently accepting it

## Verification plan

- Next sync cron runs cleanly (no Bot Commands message to delete)
- Tomorrow's daily.yml at 14:38 UTC and evening-winners at 23:00 UTC both
  pass with `discord_pass=true`
- The verifier output reads `OK  channel scan step-3-review-existing-games:
  rolling explainer is last message`