### PR TITLE
fix(health-report): correct SCHEDULE_EXPECTATIONS for Gaming Library Sync + Daily Reminder

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -62,19 +62,19 @@ SCHEDULE_EXPECTATIONS: dict[str, dict[str, Any]] = {
     },
     "Gaming Library Daily Reminder": {
         "kind": "daily",
-        "cron": "0 14 * * *",
-        "cadence": "daily 14:00 UTC",
-        "hour": 14,
+        "cron": "0 0 * * *",
+        "cadence": "daily 00:00 UTC",
+        "hour": 0,
         "minute": 0,
         "window_before_minutes": 90,
     },
     "Gaming Library Sync": {
         "kind": "interval",
-        "cron": "15 * * * *",
-        "cadence": "every hour at :15 UTC",
-        "interval_hours": 1,
-        "minute": 15,
-        "window_before_minutes": 30,
+        "cron": "0 */3 * * *",
+        "cadence": "every 3 hours (UTC)",
+        "interval_hours": 3,
+        "minute": 0,
+        "window_before_minutes": 90,
     },
     # Missed-Run Watchdog was intentionally disabled in watchdog.yml on
     # 2026-04-19 (the cron entry is commented out; only workflow_dispatch


### PR DESCRIPTION
## Where this came from

Today's Bot Health Report (May 11, 2026 06:27 UTC) fired:

- 🟡 Gaming Library Sync: "Latest run is scheduled but appears older than
  the most recent expected schedule window"
- 🟡 Daily picks missing current-day entry

The first one is a chronic false positive caused by `SCHEDULE_EXPECTATIONS`
in `scripts/build_daily_health_report.py` being out of sync with the actual
workflow crons. Auditing all 6 entries against the YAML files:

| Workflow | Actual cron | Expected (in code) | Match? |
|---|---|---|---|
| Weekly Scheduling Bot | `0 13 * * 6` | `0 13 * * 6` | ✅ |
| Weekly Scheduling Responses Sync | `0 */3 * * *` | `0 */3 * * *` | ✅ |
| Steam Free Games | `0 13 * * *` | `0 13 * * *` | ✅ |
| Daily Game Picks Winners | `0 23 * * *` | `0 23 * * *` | ✅ |
| **Gaming Library Sync** | **`0 */3 * * *`** | **`15 * * * *`** | **🔴** |
| **Gaming Library Daily Reminder** | **`0 0 * * *`** | **`0 14 * * *`** | **🔴** |

Two workflows have wrong expectations. The crons in `.github/workflows/`
are the source of truth and were both recent changes that the health report
never picked up.

## What this PR does

Updates `SCHEDULE_EXPECTATIONS` entries for the two mismatched workflows so
the health report's "window satisfied" check has correct reference values:

**Gaming Library Sync**:
- `"cron": "15 * * * *"` → `"cron": "0 */3 * * *"`
- `"cadence": "every hour at :15 UTC"` → `"cadence": "every 3 hours (UTC)"`
- `"interval_hours": 1` → `"interval_hours": 3`
- `"minute": 15` → `"minute": 0`
- `"window_before_minutes": 30` → `"window_before_minutes": 90` (consistent
  with the other 3-hour interval workflow)

**Gaming Library Daily Reminder**:
- `"cron": "0 14 * * *"` → `"cron": "0 0 * * *"`
- `"cadence": "daily 14:00 UTC"` → `"cadence": "daily 00:00 UTC"`
- `"hour": 14` → `"hour": 0`

## Why this is safe

- Data-only change in `SCHEDULE_EXPECTATIONS` dict
- No logic change, no schedule change
- Worst case: if I got an actual cron wrong, the next bot health report
  would surface the mismatch again — same self-correcting feedback loop
- File size: 43031 → 43027 bytes (4 bytes shorter)

## Verification plan

- Tomorrow's 03:00 UTC Bot Health Report should show:
  - 🟢 Gaming Library Sync (was 🟡) — expected cadence will match actual cron
  - 🟢 Gaming Library Daily Reminder (still 🟢) — schedule window check
    will use the correct hour reference