### PR TITLE
fix(gaming-library): skip manual reruns on completed days (prevent Discord 30046 cascade)

### DIFF
--- a/gaming_library.py
+++ b/gaming_library.py
@@ -1259,13 +1259,22 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
 
     # Rule 1 & 5: If already completed AND discord_verification.json shows pass=True
     # for today, suppress all re-triggers (watchdog, manual) — nothing to do.
+    manual_run = is_manual_run()
     _day_entry_check = state.get("daily_posts", {}).get(day_key, {})
     if isinstance(_day_entry_check, dict) and bool(_day_entry_check.get("completed")):
         if is_today_verified(day_key):
             print(f"Run already completed and verified — watchdog re-trigger suppressed for {day_key}")
             return False
+        if manual_run:
+            # Manual workflow_dispatch reruns on an already-completed day try to edit
+            # messages older than 1 hour, which Discord hard-rate-limits with HTTP 429
+            # code 30046 ("Maximum number of edits to messages older than 1 hour reached").
+            # That failure cascades into: 🔴 Failure Detected → auto-fix retries 3× (all fail
+            # with the same 30046) → 🚨 Auto-fix Exhausted. Skip gracefully so the next
+            # scheduled cron at 00:00 UTC posts fresh messages without the edit-rate-limit.
+            print(f"Manual workflow_dispatch on already-completed day {day_key} — skipping (would hit Discord edit-rate-limit, code 30046)")
+            return False
 
-    manual_run = is_manual_run()
     if manual_run:
         print("Gaming library daily post is a manual (workflow_dispatch) run — completed flag will not be set")
 


### PR DESCRIPTION
## Where this came from

I manually triggered Gaming Library Daily Reminder run #72 at 05:10 UTC today
to refresh the rolling pin with the new PR #323 text. It failed with exit
code 1 after 1m 8s. The actual error (line 68 of the job log):

```
discord_api.DiscordApiError: post/edit gaming library footer for 2026-05-12
failed: HTTP 429; body={"message": "Maximum number of edits to messages older
than 1 hour reached.", "retry_after": 0.3, "global": false, "code": 30046}
```

Discord has a hard rate limit (code 30046) on edits to messages older than
1 hour. My manual run tried to edit messages that the morning scheduled cron
had posted at 03:24 UTC (~1h45m old by 05:10 UTC). All 5 retries hit the same
limit and the script crashed.

## Why this is a generally-broken failure mode, not just a one-off

**Any** manual `workflow_dispatch` rerun of `gaming-library-daily.yml` on an
already-completed day will hit this. The failure cascade:

1. Manual run fails with exit code 1
2. 🔴 Failure Detected alert in #health
3. auto-fix.yml fires, retries the script 3×
4. All 3 retries fail with the same 30046
5. 🚨 Auto-fix Exhausted alert in #health

The script *has* an existing early-exit for already-completed days, but it
only fires when `is_today_verified(day_key)` returns true, which reads
`discord_verification.json`. The committed copy of that file on `main` is
just the placeholder `{"date": "", "pass": false}` (real verification only
lives in workflow artifacts, see PR #322), so `is_today_verified` always
returns false on a fresh CI checkout, and the early-exit never fires for
manual reruns.

## What this PR does

In `gaming_library.py` `run_daily_post()`, add a second early-exit branch:

```python
manual_run = is_manual_run()
_day_entry_check = state.get("daily_posts", {}).get(day_key, {})
if isinstance(_day_entry_check, dict) and bool(_day_entry_check.get("completed")):
    if is_today_verified(day_key):
        # existing watchdog-suppress branch — unchanged
        return False
    if manual_run:
        # NEW: skip manual reruns on completed days to avoid 30046 cascade
        print(f"Manual workflow_dispatch on already-completed day {day_key} — skipping (...)")
        return False
```

Scheduled cron runs are unaffected (they're what actually posts each day).
Auto-fix retries are unaffected (they run as `workflow_run`, not
`workflow_dispatch`, so `is_manual_run()` returns False for them).

## Why this is safe

- 1 file changed, +12/-1 lines, no new dependencies, no schema changes
- The new branch ONLY fires when (`completed=True` AND `is_manual_run()=True`)
- Strictly tighter than the existing logic — it suppresses one failure mode
  that previously caused the cascade, and changes nothing else
- If a maintainer needs to genuinely re-post a completed day, they can
  manually clear `state["daily_posts"][day_key]["completed"] = False` in
  `gaming_library.json` first

## Verification plan

- Run #72 (already failed) cannot be cleanly retried until next 00:00 UTC
  cron posts fresh messages (≈19 hours from this PR)
- Tomorrow's scheduled cron at 00:00 UTC will post fresh messages with the
  PR #323 text (Giga Chad + clearer step-3 commands)
- If I or anyone else triggers a manual workflow_dispatch tomorrow when
  the day is complete, it will log the new “skipping” message and exit 0
  cleanly instead of cascading