### PR TITLE
chore(watchdog): bump actions/checkout@v4 -> @v5 for workflow consistency

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # ------------------------------------------------------------------ #
       # Check each scheduled workflow for missed runs and trigger if overdue.


### PR DESCRIPTION
## Where this came from

Repo-wide consistency audit found that `watchdog.yml` was the only
workflow still pinned to `actions/checkout@v4`. All other 14 workflows
use `actions/checkout@v5`.

## What this PR does

Single-line bump in `.github/workflows/watchdog.yml`:

```diff
- uses: actions/checkout@v4
+ uses: actions/checkout@v5
```

## Why this is safe

- `actions/checkout@v5` is what every other workflow in this repo already
  uses (daily, evening-winners, gaming-library-daily, gaming-library-sync,
  weekly-scheduling-bot, weekly-scheduling-responses-sync, bot-health-report,
  state-backup, auto-fix, pattern-analysis, gaming-library-manage, claude-*).
  All run successfully.
- `watchdog.yml`'s scheduled cron is currently disabled (since 2026-04-19),
  so the only execution path is `workflow_dispatch`. Even if v5 had a
  surprise regression for our usage, blast radius is small.
- `actions/checkout@v5` is GA and a non-breaking upgrade from v4 for the
  default config we use here.