### PR TITLE
chore(workflows): bump deprecated Node 20 actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download verification artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -55,7 +55,7 @@ jobs:
       - name: Download Discord verification artifact
         id: download_discord
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -70,7 +70,7 @@ jobs:
       - name: Download gaming library verification artifact
         id: download_gaming_library
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -85,7 +85,7 @@ jobs:
       - name: Download weekly schedule verification artifact
         id: download_weekly_schedule
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -100,7 +100,7 @@ jobs:
       - name: Download Discord snapshot artifact
         id: download_snapshots
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Find latest daily.yml run ID
         id: find-daily-run
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
@@ -56,7 +56,7 @@ jobs:
         id: download-state-sanity
         continue-on-error: true
         if: steps.find-daily-run.outputs.run_id != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-daily-run.outputs.run_id }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Collect workflow run status
         id: collect-workflows
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require("fs");
@@ -167,7 +167,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload scheduling diagnostics artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: workflow-schedule-diagnostics
           path: workflow-schedule-diagnostics.json

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload state sanity artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: state-sanity-${{ github.run_id }}
           path: state_sanity.json
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload Discord snapshot artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-snapshots-${{ github.run_id }}
           path: |
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload verification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: daily-verification-${{ github.run_id }}
           path: daily_verification.json
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload Discord verification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-verification-${{ github.run_id }}
           path: discord_verification.json

--- a/.github/workflows/evening-winners.yml
+++ b/.github/workflows/evening-winners.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Discord snapshot artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-snapshots-${{ github.run_id }}
           path: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload Discord verification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-verification-${{ github.run_id }}
           path: discord_verification.json

--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Discord snapshot artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-snapshots-${{ github.run_id }}
           path: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload gaming library verification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gaming-library-verification-${{ github.run_id }}
           path: gaming_library_verification.json

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check workflows and trigger overdue ones
         id: check
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const WATCHED = [

--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Discord snapshot artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discord-snapshots-${{ github.run_id }}
           path: |
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload weekly schedule verification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: weekly-schedule-verification-${{ github.run_id }}
           path: weekly_schedule_verification.json


### PR DESCRIPTION
## Where this came from

Inspecting recent workflow run logs (e.g. Auto Fix Loop #462), I noticed
this annotation appearing on every run:

> Node.js 20 actions are deprecated. The following actions are running on
> Node.js 20 and may not work as expected: actions/download-artifact@v4.
> Actions will be forced to run with Node.js 24 by default starting
> June 2nd, 2026.

June 2 is about 3 weeks away. Better to bump pre-emptively now than scramble
when the forced migration hits.

## What this PR does

Bumps the three deprecated Node-20-pinned actions to their latest Node-24
major versions across all workflows that use them:

| Action | Before | After | Files touched |
|---|---|---|---|
| `actions/upload-artifact` | `@v4` | `@v6` | daily.yml, evening-winners.yml, gaming-library-daily.yml, weekly-scheduling-bot.yml, bot-health-report.yml |
| `actions/download-artifact` | `@v4` | `@v5` | bot-health-report.yml, auto-fix.yml |
| `actions/github-script` | `@v7` | `@v8` | bot-health-report.yml, watchdog.yml |

`actions/checkout@v5` and `actions/setup-python@v6` are already Node-24
native, so no change needed there.

## Why this is safe

- All three new versions only update the runtime (Node 20 -> Node 24).
  No breaking changes to the action input/output API.
- Minimum required runner is v2.327.1. GitHub-hosted runners auto-update
  and are well past that — GitHub enforces v2.329.0+ for new self-hosted
  registrations as of March 16, 2026.
- We don't pin to Ubuntu-old or use exotic runners; we use `ubuntu-latest`
  everywhere.
- The deprecation warnings disappear from workflow logs.
- Eliminates the need for any `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var
  workaround after June 2.

## Why bundle them into one PR

Same root cause (Node 20 deprecation), same blast radius (workflow logs
become quieter), no inter-dependency between the action bumps. Easier to
review as one set, easier to revert if anything goes wrong.

## Workflows NOT touched

- gaming-library-sync.yml, weekly-scheduling-responses-sync.yml,
  state-backup.yml, gaming-library-manage.yml, pattern-analysis.yml,
  claude-code-review.yml, claude.yml, claude-issue-worker.yml — these
  don't use any Node-20-pinned action, so nothing to bump.