### PR TITLE
fix(post-daily-gaming-library): skip rolling explainer post when run_daily_post returns False

### DIFF
--- a/scripts/post_daily_gaming_library.py
+++ b/scripts/post_daily_gaming_library.py
@@ -10,9 +10,17 @@ if __name__ == "__main__":
     posted = run_daily_post()
     print(f"daily gaming library posted={posted}")
 
+    # PR #324 follow-up: if run_daily_post() returned False, the day was already
+    # complete (or watchdog suppression fired) and we MUST NOT touch the rolling
+    # explainer either — it's an existing message older than 1 hour, and Discord
+    # rate-limits edits to old messages (HTTP 429 code 30046). The script would
+    # exit 1 from rolling_explainer's crash even though run_daily_post() succeeded
+    # cleanly. continue-on-error: true in the workflow swallows the failure but
+    # the annotation "Process completed with exit code 1" still appears on the
+    # workflow run page, which is noise.
     channel_id = os.getenv("DISCORD_GAMING_LIBRARY_CHANNEL_ID", "").strip()
     token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
-    if channel_id and token:
+    if posted and channel_id and token:
         with requests.Session() as _expl_session:
             _expl_session.headers.update({
                 "Authorization": f"Bot {token}",


### PR DESCRIPTION
## Where this came from

PR #324 added a manual-rerun guard to `gaming_library.py:run_daily_post()`
that returns False on workflow_dispatch reruns of already-completed days,
to prevent the Discord 30046 ("max edits per hour") cascade.

Tested this in production with manual workflow run #73 (just now). Result:

- Workflow overall: ✅ SUCCESS (33s, vs run #72's 1m8s FAILURE)
- Health monitor: not alerted (PR #324's intent)
- BUT: annotation "1 error: Process completed with exit code 1" still
  appears on the run page

## Root cause

In `scripts/post_daily_gaming_library.py`, after calling `run_daily_post()`,
the script unconditionally calls `post_or_edit_rolling_explainer(...)`:

```python
if __name__ == "__main__":
    posted = run_daily_post()  # ← with PR #324, returns False on manual reruns
    ...
    if channel_id and token:
        post_or_edit_rolling_explainer(...)  # ← still tries to edit existing 8h-old explainer
```

`post_or_edit_rolling_explainer` finds the existing explainer (posted at
today's 03:24 UTC scheduled cron) and tries to edit it. The message is
~8h old by the time of any later manual rerun, so Discord rate-limits the
edit with HTTP 429 code 30046. The script crashes → exit code 1.

The step has `continue-on-error: true` so the workflow still succeeds, but
the failure annotation persists on the run page. PR #324 prevented the
*cascade* (no more 🔴 → auto-fix → 🚨) but didn't fully clean up the underlying
exit code.

## What this PR does

In `scripts/post_daily_gaming_library.py`, gate the rolling explainer call
on `posted` being truthy:

```diff
- if channel_id and token:
+ if posted and channel_id and token:
```

When `run_daily_post()` returned False (manual rerun on completed day, or
watchdog suppression), there is no new content to anchor below the explainer,
so the explainer doesn't need to be re-pinned. The script exits 0 cleanly.

## Why this is safe

- 1 file changed, +13/-1 lines (mostly explanatory comment)
- When `posted=True` (scheduled cron, the only path that actually publishes
  fresh content): behavior is unchanged — rolling explainer is re-pinned
- When `posted=False`: rolling explainer call is skipped — nothing to anchor
  below, the existing explainer is still the last message in #step-3, so
  the verifier still passes
- Combined with PR #324, manual workflow_dispatch reruns are now fully
  no-op (no failures, no annotations, no health alerts)

## Verification plan

- Tomorrow's scheduled cron at 00:00 UTC posts fresh messages — unchanged
  behavior since `posted=True`
- Trigger a manual workflow_dispatch later today — should exit 0 with no
  annotation