### PR TITLE
fix(gaming-library-daily): remove misplaced verify_discord_output step

### DIFF
--- a/.github/workflows/gaming-library-daily.yml
+++ b/.github/workflows/gaming-library-daily.yml
@@ -74,14 +74,6 @@ jobs:
             data/snapshot_health.json
           if-no-files-found: ignore
 
-      - name: Verify Discord output
-        continue-on-error: true
-        env:
-          PYTHONPATH: .
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          LIBRARY_DATE_UTC: ${{ inputs.library_date_utc }}
-        run: python scripts/verify_discord_output.py
-
       - name: Verify gaming library output
         continue-on-error: true
         env:


### PR DESCRIPTION
## Root cause of the persistent "Process completed with exit code 1" annotation

Every run of `Gaming Library Daily Reminder` has been showing a "1 error"
annotation that says "Process completed with exit code 1", even when the
workflow itself succeeds. This was a long-standing cosmetic issue, NOT
caused by my recent PRs (#324, #330) — it appears in every scheduled cron
run going back as far as I checked.

Traced it by downloading the actual `discord_verification.json` artifact
from `daily.yml` run #119 (where the same annotation appears). The verifier
has two hard exit(1) paths that fire in this workflow's context:

### 1. Architectural mismatch (gaming-library-daily.yml @ 00:00 UTC)

`scripts/verify_discord_output.py` line 1132 exits 1 when:
> No entry for {day_key} in discord_daily_posts.json. Daily picks may not have run yet.

At 00:00 UTC, today's Step-1 entry doesn't exist yet (`daily.yml` runs at
13:00 UTC). So the verifier ALWAYS fails when run from this workflow's
context.

### 2. Step-3 last-message check (transient)

A legacy "📋 Bot Commands" message was tracked in
`state["command_reference_message"]` and would intermittently become the
last message in #step-3 between scheduled cron runs, breaking the
verifier's rolling-explainer-is-last-message check.

I verified this is already resolved — `cleanup_command_reference_message`
in `gaming_library.py:1181` deletes the legacy message and clears the state
field. Current `gaming_library.json` shows `command_reference_message: null`
and #step-3 channel has the rolling explainer (📌 How This Works) as the last
message. Today's `daily.yml` at 13:00 UTC should pass cleanly.

## What this PR does

Removes the `Verify Discord output` step from `gaming-library-daily.yml`.
The verifier is still run in `daily.yml` (13:00 UTC) and `evening-winners.yml`
(23:00 UTC) where it has the correct context.

Keeps in place:
- `Read Discord channel snapshots` — useful for diagnostics
- `Upload Discord snapshot artifact` — keeps channel-state archive
- `Verify gaming library output` — step-3-specific verifier that DOES work
  here (it doesn't need step-1 data)

## Why this is safe

- 1 file changed, -8 lines (just the misfit verifier step)
- The verifier still runs in `daily.yml` and `evening-winners.yml`, so
  step-1/step-2 verification coverage is unchanged
- `verify_gaming_library.py` (which DOES work in this context) still runs
  and provides step-3 verification
- No code change to any verifier script — just removing one workflow step
  that was always going to fail by design
- The exit-1 annotation will disappear from every `gaming-library-daily`
  run going forward

## Verification plan

- Next scheduled cron at 00:00 UTC tomorrow will run without the misfit step
- Manual `workflow_dispatch` runs will exit cleanly without any annotations
- `daily.yml`/`evening-winners.yml` verifier runs continue unchanged