### PR TITLE
chore(daily): remove unused DISCORD_DEBUG_CHANNEL_ID and INSTAGRAM_USERNAME env vars

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -66,8 +66,6 @@ jobs:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-          DISCORD_DEBUG_CHANNEL_ID: ${{ secrets.DISCORD_DEBUG_CHANNEL_ID }}
-          INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Evidence

A comprehensive grep across all 21 source files in main.py / evening_winners.py / gaming_library.py / state_utils.py / discord_api.py / rolling_explainer.py / daily_section_config.py / scripts/*.py found:

- `DISCORD_DEBUG_CHANNEL_ID`: **0 references** in any source file
- `INSTAGRAM_USERNAME`: **0 references** in any source file

Yet `daily.yml` passes both as env vars to `main.py` (lines 69-70). They're dead pass-throughs — likely leftovers from earlier code paths that have since been refactored:
- `DISCORD_DEBUG_CHANNEL_ID`: probably used by removed debug-logging code
- `INSTAGRAM_USERNAME`: superseded by the base64 session-file approach (`INSTAGRAM_SESSION_B64` is decoded into `instaloader.session` directly; no separate username lookup needed)

## Scope

Remove 2 lines from `.github/workflows/daily.yml`:
```yaml
          DISCORD_DEBUG_CHANNEL_ID: ${{ secrets.DISCORD_DEBUG_CHANNEL_ID }}
          INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
```

## What stays

- The repo-level GitHub Secrets `DISCORD_DEBUG_CHANNEL_ID` and `INSTAGRAM_USERNAME` themselves are NOT deleted by this PR (they're managed in repo Settings, not in YAML). This PR just stops passing them as unused env vars. The user can delete the secret values via repo Settings if they want to fully clean up.
- `INSTAGRAM_SESSION_B64` stays — that's the actual mechanism by which Instagram auth works.

## Verification

- No other workflow (`evening-winners.yml`, `gaming-library-daily.yml`, etc.) references either of these env vars
- 0 source files reference either variable
- The next scheduled `daily.yml` cron at 13:00 UTC will run without these env vars and behavior should be identical (since nothing was reading them)