### PR TITLE
chore: remove dead is_today_verified() function and 3 guards

### DIFF
--- a/discord_verification.json
+++ b/discord_verification.json
@@ -1,1 +1,0 @@
-{"date": "", "pass": false}

--- a/evening_winners.py
+++ b/evening_winners.py
@@ -9,7 +9,7 @@ import requests
 from daily_section_config import DAILY_SECTION_DISPLAY_LABELS, DAILY_SECTION_ORDER
 from discord_api import DiscordClient, DiscordMessageNotFoundError
 from rolling_explainer import post_or_edit_rolling_explainer
-from state_utils import is_today_verified, load_json_object, save_json_object_atomic
+from state_utils import load_json_object, save_json_object_atomic
 
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
 THUMBS_UP_EMOJI = "👍"
@@ -915,14 +915,6 @@ def main() -> None:
     if not isinstance(today_entry, dict):
         today_entry = {}
         daily_posts[day_key] = today_entry
-
-    # Rule 1 & 5: If winners already posted AND discord_verification.json shows pass=True
-    # for today, suppress all re-triggers (manual) — nothing to do.
-    _winners_state_check = today_entry.get("winners_state") or {}
-    if isinstance(_winners_state_check, dict) and _winners_state_check.get("winner_messages"):
-        if is_today_verified(day_key):
-            print(f"Run already completed and verified — re-trigger suppressed for {day_key}")
-            return
 
     lookback_day_keys = get_lookback_day_keys(day_key)
     items: List[dict] = []

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -14,7 +14,7 @@ from discord_api import (
     PERM_READ_MESSAGE_HISTORY,
     PERM_SEND_MESSAGES,
 )
-from state_utils import is_today_verified, load_json_object, save_json_object_atomic
+from state_utils import load_json_object, save_json_object_atomic
 
 GAMING_LIBRARY_FILE = "gaming_library.json"
 DISCORD_DAILY_POSTS_FILE = "discord_daily_posts.json"
@@ -1262,9 +1262,6 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
     manual_run = is_manual_run()
     _day_entry_check = state.get("daily_posts", {}).get(day_key, {})
     if isinstance(_day_entry_check, dict) and bool(_day_entry_check.get("completed")):
-        if is_today_verified(day_key):
-            print(f"Run already completed and verified — re-trigger suppressed for {day_key}")
-            return False
         if manual_run:
             # Manual workflow_dispatch reruns on an already-completed day try to edit
             # messages older than 1 hour, which Discord hard-rate-limits with HTTP 429

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ from discord_api import DiscordClient, DiscordMessageNotFoundError
 from daily_section_config import DAILY_SECTION_CONFIG, DAILY_SECTION_ORDER
 from rolling_explainer import post_or_edit_rolling_explainer
 from state_utils import (
-    is_today_verified,
     load_json_object,
     prune_latest_iso_dates,
     save_json_object_atomic,
@@ -2276,13 +2275,6 @@ def post_daily_pick_messages(
         day_entry["run_state"] = run_state
     run_state.setdefault("section_headers", {})
     run_state["last_attempt_at_utc"] = utc_now_iso()
-
-    # Rule 1 & 5: If already completed AND discord_verification.json shows pass=True
-    # for today, suppress all re-triggers (watchdog, force_refresh, manual) — nothing to do.
-    if bool(run_state.get("completed")) and is_today_verified(day_key):
-        print(f"Run already completed and verified — watchdog re-trigger suppressed for {day_key}")
-        save_discord_daily_posts(daily_posts)
-        return run_counts, True, {}
 
     if bool(run_state.get("completed")) and not force_refresh_same_day and not manual_run:
         print(f"SKIP: daily picks already completed for {day_key}; rerun protection active (force_refresh_same_day=false)")

--- a/state_utils.py
+++ b/state_utils.py
@@ -90,23 +90,6 @@ def save_json_object_atomic(path: str, data: dict[str, Any]) -> None:
             os.remove(temp_path)
 
 
-DISCORD_VERIFICATION_FILE = "discord_verification.json"
-
-
-def is_today_verified(day_key: str, *, verification_file: str = DISCORD_VERIFICATION_FILE) -> bool:
-    """Return True if discord_verification.json shows pass=True for day_key.
-
-    Used by workflow entry-points to detect when today's run is already
-    completed and fully verified, so manual re-triggers can be
-    suppressed without doing any Discord work.
-
-    Returns False (not verified) when the file is absent, unreadable, or
-    covers a different date — callers should treat False as "safe to run".
-    """
-    data = load_json_object(verification_file)
-    return bool(data.get("date") == day_key and data.get("pass") is True)
-
-
 def prune_latest_keys(data: dict[str, Any], keep_last: int) -> dict[str, Any]:
     if len(data) <= keep_last:
         return data


### PR DESCRIPTION
## Why

The `is_today_verified()` function and its 3 caller-side guards (`main.py`, `evening_winners.py`, `gaming_library.py`) read from `discord_verification.json` at repo root. That file is uploaded as a workflow artifact each run, but **never committed back to main** — only 5 specific state files are committed in the `git add` list (seen_ids, page_state, instagram_seen, discord_daily_posts, instagram_fetch_summary). So the file at repo root has been the stub `{"date":"","pass":false}` since April 18, and `is_today_verified()` always returns False. The guards are dead code that look like a safety layer but never fire.

## What this PR does

- **state_utils.py**: delete `is_today_verified()` function and `DISCORD_VERIFICATION_FILE` constant (-698 bytes)
- **main.py**: remove `is_today_verified` from multi-line import + drop the guard block before `if bool(run_state.get("completed"))` (-456 bytes)
- **evening_winners.py**: remove import + drop the entire winner_messages/is_today_verified guard (-492 bytes)
- **gaming_library.py**: remove import + drop ONLY the inner `if is_today_verified(day_key):` block. The `if manual_run:` protection at gaming_library.py:1268 that actually prevents the 30046 Discord rate-limit cascade STAYS INTACT (-178 bytes)
- **discord_verification.json**: delete the unused stub file from repo root

## Real rerun protection

The protection that actually prevents the 30046 "Maximum number of edits to messages older than 1 hour" cascade is the independent `manual_run` guard in `gaming_library.py` (commented in PR #324). That guard is unchanged by this PR.

## Verification

- All 4 source files verified post-commit via GitHub Contents API (which bypasses raw.githubusercontent.com CDN staleness)
- `is_today_verified` references across all source files: 0
- `discord_verification.json` returns 404 on the branch
- `manual_run` guard in gaming_library.py: preserved (verified)

Next scheduled `daily.yml` cron (13:00 UTC) and `evening-winners.yml` cron (23:00 UTC) will execute the same logic minus the dead guards. No behavior change.