### PR TITLE
chore: final polish — fix bot-health-report errors, bump download-artifact, update stale comment

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -56,7 +56,7 @@ jobs:
         id: download-state-sanity
         continue-on-error: true
         if: steps.find-daily-run.outputs.run_id != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-daily-run.outputs.run_id }}
@@ -122,17 +122,26 @@ jobs:
         run: |
           echo "Attempting to fetch Actions billing data..."
 
+          # gh api returns exit-code 0 even when the response is a {"message":"Not Found"}
+          # error payload. Treat both empty/curl-failed and Not-Found responses as missing.
+          is_unavailable() {
+            local body="$1"
+            [ -z "$body" ] || [ "$body" = "{}" ] && return 0
+            echo "$body" | grep -q '"message":[[:space:]]*"Not Found"' && return 0
+            return 1
+          }
+
           minutes_json="$(gh api \
             /repos/${{ github.repository }}/actions/billing \
             2>/dev/null || echo '{}')"
 
-          if [ "$minutes_json" = "{}" ]; then
+          if is_unavailable "$minutes_json"; then
             minutes_json="$(gh api \
               /orgs/${{ github.repository_owner }}/settings/billing/actions \
               2>/dev/null || echo '{}')"
           fi
 
-          if [ "$minutes_json" = "{}" ]; then
+          if is_unavailable "$minutes_json"; then
             echo "actions_billing_json={}" >> "$GITHUB_OUTPUT"
             echo "INFO: Actions billing data unavailable for this account type"
           else

--- a/gaming_library.py
+++ b/gaming_library.py
@@ -1257,8 +1257,7 @@ def run_daily_post(state_path: str = GAMING_LIBRARY_FILE) -> bool:
     if not channel_id:
         raise RuntimeError("DISCORD_GAMING_LIBRARY_CHANNEL_ID is not set")
 
-    # Rule 1 & 5: If already completed AND discord_verification.json shows pass=True
-    # for today, suppress all re-triggers (manual) — nothing to do.
+    # If today is already completed, suppress manual workflow_dispatch re-triggers
     manual_run = is_manual_run()
     _day_entry_check = state.get("daily_posts", {}).get(day_key, {})
     if isinstance(_day_entry_check, dict) and bool(_day_entry_check.get("completed")):


### PR DESCRIPTION
## Findings from full final audit

Three issues found that we missed in earlier passes. All low-risk, all worth fixing for true "perfect" state.

### 1. `bot-health-report.yml`: 2 errors on every single run

Every daily Bot Health Report run (latest: #108 at 2026-05-13 06:15 UTC) shows `Success` overall but has these annotations:
- `Invalid format '  "message": "Not Found",
'`
- `Unable to process file command 'output' successfully.`

**Root cause**: the `Fetch GitHub Actions billing` step calls `gh api /repos/.../actions/billing`. For personal accounts, that endpoint returns a 200 OK with body `{"message": "Not Found", "documentation_url": "..."}` instead of failing. The existing `|| echo '{}'` guard only catches curl failures, not Not-Found payloads, so the literal multi-line JSON gets shoved into `$GITHUB_OUTPUT` which expects strict `key=value\n` format — producing those two errors on every run.

**Fix**: add an `is_unavailable()` shell helper that detects both `{}` AND `"message": "Not Found"` responses, then route both code paths through it. The empty `actions_billing_json={}` already-handled-downstream behavior is preserved.

### 2. `bot-health-report.yml`: stale `actions/download-artifact@v5`

PR #329 bumped most actions to Node 24-compatible versions but missed this one. v5 still runs on Node 20, generating a deprecation warning on every health report run. v7 is current Node 24. Bumping.

### 3. `gaming_library.py:1260`: stale comment

PR #336 removed the `is_today_verified()` dead-code guard but left the comment block that described it. The comment said:
> `# Rule 1 & 5: If already completed AND discord_verification.json shows pass=True`
> `# for today, suppress all re-triggers (manual) — nothing to do.`

But the code below only does the `manual_run` check now. Updated to:
> `# If today is already completed, suppress manual workflow_dispatch re-triggers`

## What I deliberately did NOT touch

- `daily.yml:125` and `evening-winners.yml:90` still upload `discord_verification.json` as a workflow artifact. The verifier (`scripts/verify_discord_output.py`) writes that file, and uploading it as an artifact is legitimately useful for external review even though no source code reads it back. Keeping.
- `CLAUDE.md:375` describes `discord_verification.json` as "Runtime artifact from scripts/verify_discord_output.py — live Discord read-back checks" — accurate description, no change needed.

## Verification

- `bot-health-report.yml` on branch verified via Contents API: 12,592 bytes, has `download-artifact@v7`, has `is_unavailable()` helper, no `@v5` reference
- `gaming_library.py` on branch: stale comment replaced, `manual_run` block intact
- Next scheduled `bot-health-report.yml` cron (03:00 UTC) will run with clean annotations