### PR TITLE
fix(health-report): silence two false-positive yellow alarms

### DIFF
--- a/scripts/build_daily_health_report.py
+++ b/scripts/build_daily_health_report.py
@@ -501,23 +501,6 @@ def compute_state_issues(*, now_utc: datetime | None = None) -> list[Issue]:
                         file_path="data/scheduling/weekly_schedule_bot_outputs.json",
                         week_key=current_week_key,
                     )
-                else:
-                    responses_mtime = WEEKLY_PATHS["responses"].stat().st_mtime if WEEKLY_PATHS["responses"].exists() else None
-                    outputs_mtime = WEEKLY_PATHS["outputs"].stat().st_mtime if WEEKLY_PATHS["outputs"].exists() else None
-                    newest_source_mtime = max(
-                        value for value in [responses_mtime, outputs_mtime] if value is not None
-                    ) if any(value is not None for value in [responses_mtime, outputs_mtime]) else None
-                    if newest_source_mtime is not None:
-                        newest_source_time = datetime.fromtimestamp(newest_source_mtime, tz=timezone.utc)
-                        if newest_source_time - summary_last_synced > timedelta(minutes=20):
-                            issues["stale_weekly_summary"] = _new_issue(
-                                "weekly.summary_stale",
-                                "warning",
-                                "Weekly summary appears stale",
-                                "Summary freshness timestamp is behind latest responses/outputs state.",
-                                file_path="data/scheduling/weekly_schedule_bot_outputs.json",
-                                week_key=current_week_key,
-                            )
 
     users = roster.get("users") if isinstance(roster, dict) else None
     if not isinstance(users, dict):
@@ -549,7 +532,11 @@ def compute_state_issues(*, now_utc: datetime | None = None) -> list[Issue]:
         )
     else:
         today_entry = daily_posts.get(today_key)
-        if not isinstance(today_entry, dict):
+        # daily.yml runs at 13:00 UTC. Health check at 03:00 UTC always runs BEFORE
+        # daily.yml has executed, so today's entry won't exist yet. Allow a 2-hour
+        # grace window after the expected daily run time to avoid false alarms.
+        daily_run_expected_by = now_utc.replace(hour=15, minute=0, second=0, microsecond=0)
+        if not isinstance(today_entry, dict) and now_utc >= daily_run_expected_by:
             issues["missing_today_entry"] = _new_issue(
                 "daily.today_missing",
                 "warning",


### PR DESCRIPTION
## Problem

The Bot Health Report has been reporting **✋✋ Overall: Follow-up recommended** every single day, even when nothing is wrong. Two of its state-check rules fire on every run regardless of actual state:

### 1. `daily.today_missing` — always fires before 13:00 UTC

The health report cron runs at **03:00 UTC** but `daily.yml` runs at **13:00 UTC**. So for the 10-hour window between them, today's entry doesn't exist yet in `discord_daily_posts.json` — not because anything is broken, but because the daily run hasn't happened yet. The current code unconditionally fires `daily.today_missing` warning during this window.

**Fix**: only fire the warning if `now_utc >= 15:00 UTC` (the daily cron plus 2-hour grace window for actions delay). Before that, we expect no entry to exist.

### 2. `weekly.summary_stale` — false positive due to git checkout mtimes

The check (was lines 504-520) does:
```python
responses_mtime = WEEKLY_PATHS["responses"].stat().st_mtime
outputs_mtime = WEEKLY_PATHS["outputs"].stat().st_mtime
newest_source_mtime = max(...)
newest_source_time = datetime.fromtimestamp(newest_source_mtime, tz=timezone.utc)
if newest_source_time - summary_last_synced > timedelta(minutes=20):
    # alarm
```

But `actions/checkout@v5` sets all file mtimes to the checkout time, NOT the original commit time. So `newest_source_mtime` is effectively "now" on every workflow run, while `summary_last_synced_at_utc` (a logical timestamp inside the JSON) is from whenever the sync last actually committed changes. They're different by definition, so this alarm fires whenever `weekly-scheduling-responses-sync.yml` runs idempotently (no changes to commit). Currently been firing for 3+ days because nobody has changed their availability since May 10.

**Fix**: delete the broken mtime-based check entirely. The structural integrity checks above (signature consistency at lines 480-491, summary_message_id presence, summary_data_signature presence) already catch genuine state corruption — real issues like a half-committed sync would still trip those. Filesystem mtimes are not a meaningful freshness signal in CI environments.

## Why these are false positives, verified

- All workflows are green. All state files have the expected contents.
- The bot has been showing yellow status every day for at least 3 days when the system is actually healthy.
- This trains the operator to ignore yellow alerts, which defeats the entire health monitor.

## What stays unchanged

- All other workflow status checks (Steam Free Games, Daily Game Picks Winners, Gaming Library, Weekly Scheduling) — these correctly use GitHub Actions run history, not filesystem mtimes
- All other state checks (signature consistency, summary_message_id presence, roster validity, winners state) — these check logical/structural invariants
- Instagram fetch reporting

## Expected outcome

Tomorrow's health report at 03:00 UTC should show **✋ Overall: All good** as long as everything actually is good.