### PR TITLE
fix(bot-health-report): bump staleHours for daily workflows to account for once-per-day cadence

### DIFF
--- a/.github/workflows/bot-health-report.yml
+++ b/.github/workflows/bot-health-report.yml
@@ -72,9 +72,9 @@ jobs:
             const workflows = [
               { file: "weekly-scheduling-bot.yml", name: "Weekly Scheduling Bot", staleHours: 168 },
               { file: "weekly-scheduling-responses-sync.yml", name: "Weekly Scheduling Responses Sync", staleHours: 6 },
-              { file: "daily.yml", name: "Steam Free Games", staleHours: 20 },
-              { file: "evening-winners.yml", name: "Daily Game Picks Winners", staleHours: 12 },
-              { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 20 },
+              { file: "daily.yml", name: "Steam Free Games", staleHours: 26 },
+              { file: "evening-winners.yml", name: "Daily Game Picks Winners", staleHours: 26 },
+              { file: "gaming-library-daily.yml", name: "Gaming Library Daily Reminder", staleHours: 26 },
               { file: "gaming-library-sync.yml", name: "Gaming Library Sync", staleHours: 4 },
             ];
 


### PR DESCRIPTION
## Problem

PR #340 silenced the two yellow state-check alarms (today_missing, summary_stale). Triggering a manual run of bot-health-report after the merge revealed a third false-positive class: the per-workflow `staleHours` thresholds are too tight for daily-cadence workflows.

A daily-cadence workflow naturally ages from 0h to 24h between scheduled runs. If `staleHours < 24`, the bot will report 🔴 stale for some fraction of every day, every day, even when nothing is wrong.

## Concrete example from run #110

`evening-winners.yml` runs daily at 23:00 UTC. I manually triggered bot-health-report at 19:00 UTC. The most recent evening-winners run was 19h ago. With `staleHours: 12`, that triggers 🔴. But the workflow's own Schedule check on the same run says “Scheduled run found in expected window” 🟢 — the workflow ran when it was supposed to. The two checks disagree.

## Fix

Bump `staleHours` for the three daily-cadence workflows to **26h** (24h cron interval + 2h grace for GitHub Actions cron delay):

- `daily.yml`: 20 → 26
- `evening-winners.yml`: 12 → 26
- `gaming-library-daily.yml`: 20 → 26

## What stays unchanged

- `weekly-scheduling-bot.yml` (cron weekly): staleHours=168 already correct
- `weekly-scheduling-responses-sync.yml` (cron every 3h): staleHours=6 already correct
- `gaming-library-sync.yml` (cron every 3h): staleHours=4 already correct

## Expected outcome

The stale check will only fire 🔴 when a daily workflow is genuinely more than 2 hours past its next expected run — a real signal that the cron failed. The bot's own schedule diagnostics (`workflow.scheduled_window_satisfied` vs `workflow.expected_scheduled_run_missing`) handle the real missed-cron detection independently and produce 🟡, so we don't lose coverage.