### PR TITLE
fix(daily): restore INSTAGRAM_USERNAME + DISCORD_DEBUG_CHANNEL_ID (revert of PR #335)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -66,6 +66,8 @@ jobs:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_STEP1_CHANNEL_ID: ${{ secrets.DISCORD_STEP1_CHANNEL_ID }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_DEBUG_CHANNEL_ID: ${{ secrets.DISCORD_DEBUG_CHANNEL_ID }}
+          INSTAGRAM_USERNAME: ${{ secrets.INSTAGRAM_USERNAME }}
           DAILY_DATE_UTC: ${{ inputs.daily_date_utc }}
           FORCE_REFRESH_SAME_DAY: ${{ inputs.force_refresh_same_day || false }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## What happened

PR #335 removed `INSTAGRAM_USERNAME` and `DISCORD_DEBUG_CHANNEL_ID` from `daily.yml`'s env block, claiming both had "0 references in any source file". The grep used to verify that claim was incomplete — both vars ARE referenced in `main.py`:

- `main.py:29`: `DISCORD_DEBUG_CHANNEL_ID = os.getenv("DISCORD_DEBUG_CHANNEL_ID")`
- `main.py:1402-1428`: posts a debug summary to that channel after every daily run, behind a `if not DISCORD_DEBUG_CHANNEL_ID` guard
- `main.py:2731`: `instagram_username = os.getenv("INSTAGRAM_USERNAME")`
- `main.py:2734-2736`: **early-returns from Instagram fetch** if not set: `print("INSTAGRAM_USERNAME missing; skipping Instagram"); return []`

## Empirical evidence of the production break

PR #335 merged at 2026-05-13T03:06 UTC. Today's daily.yml run #121 fired at 2026-05-13T15:39 UTC — the FIRST scheduled run after the bad merge.

- `instagram_fetch_summary.json` last updated: **2026-05-12T15:59 UTC** (yesterday's run). Today's run did NOT update it. Confirmed via git log on the file.
- `#step-1-vote-on-games-to-test` today: Free Picks (5) + Paid Picks (5) + End-of-Day summary. **No "📸 Instagram Creator Picks" section.**
- `#step-1-vote-on-games-to-test` yesterday (May 12): Free + Paid + **📸 Instagram Creator Picks (@sharedxp_official, @biffmatictv)** + End. Section was present and populated.

Tomorrow's 13:00 UTC cron would continue to skip Instagram fetching every day until this is reverted.

## Fix

Restore the two env vars in `daily.yml` between `DISCORD_GUILD_ID` and `DAILY_DATE_UTC`. Both still have graceful fallbacks in `main.py` if the secret value is empty, so this is a strict superset of current behavior.

## Lesson for the audit log

A getenv() reference can be missed by a simple substring grep when the variable name has unrelated occurrences elsewhere (e.g., in comments, print statements, error messages). Future env-var-removal PRs should test the change with a manual workflow_dispatch BEFORE merging.