### PR TITLE
refactor(main): remove dead orchestrator/fixer code (~100 lines)

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,8 +39,6 @@ FORCE_REFRESH_SAME_DAY_ENV = "FORCE_REFRESH_SAME_DAY"
 GITHUB_EVENT_NAME_ENV = "GITHUB_EVENT_NAME"
 DAILY_DEBUG_SUMMARY_FILE = "daily_debug_summary.json"
 DAILY_VERIFICATION_FILE = "daily_verification.json"
-STOP_GO_RESULT_FILE = "daily_stop_go_result.json"
-MAX_RETRY_ATTEMPTS = 3
 
 INSTAGRAM_CREATORS = [
     "gemgamingnetwork",
@@ -2895,56 +2893,6 @@ def fetch_instagram_posts():
 
     return all_new_posts
     
-def load_daily_verification_artifact(path: str = DAILY_VERIFICATION_FILE) -> dict:
-    return load_json_object(path, default={})
-
-
-def verification_passed_for_day(day_key: str, artifact: dict) -> bool:
-    if not isinstance(artifact, dict):
-        return False
-    return artifact.get("day_key") == day_key and bool(artifact.get("pass"))
-
-
-def export_stop_go_result(
-    *,
-    day_key: str,
-    decision: str,
-    reason: str,
-    attempt: Optional[int] = None,
-    max_attempts: int = MAX_RETRY_ATTEMPTS,
-    verification_file: str = DAILY_VERIFICATION_FILE,
-    path: Optional[str] = None,
-) -> None:
-    """Write a machine-readable stop/go decision artifact for external orchestration."""
-    signal = decision
-    escalation_target = None
-    if decision == "give_up":
-        signal = "escalate_to_fixer"
-        escalation_target = "claude_code"
-
-    result = {
-        "day_key": day_key,
-        "decision": decision,
-        "signal": signal,
-        "reason": reason,
-        "attempt": attempt,
-        "max_attempts": max_attempts,
-        "verification_file": verification_file,
-        "orchestrator": "openhands",
-        "fixer": "claude_code",
-        "escalation_target": escalation_target,
-        "generated_at_utc": utc_now_iso(),
-    }
-    result_path = path or STOP_GO_RESULT_FILE
-    save_json_object_atomic(result_path, result)
-    print(
-        "STOP_GO_RESULT "
-        f"file={result_path} day_key={day_key} decision={decision} signal={signal} "
-        f"attempt={attempt if attempt is not None else 'na'}/{max_attempts} "
-        f"reason={reason}"
-    )
-
-
 def run_daily_workflow(*, force_refresh_same_day: bool = False, manual_run: bool = False) -> None:
     state = load_state()
     print(f"Daily run target date (UTC): {get_target_day_key()}")
@@ -3253,58 +3201,8 @@ def run_daily_workflow(*, force_refresh_same_day: bool = False, manual_run: bool
 
 
 def main():
-    day_key = get_target_day_key()
-    artifact = load_daily_verification_artifact()
-    if verification_passed_for_day(day_key, artifact):
-        export_stop_go_result(
-            day_key=day_key,
-            decision="stop",
-            reason="verification_pass",
-            attempt=0,
-        )
-        print(
-            "STOP_GO decision=stop "
-            f"reason=verification_pass day_key={day_key} verification_file={DAILY_VERIFICATION_FILE}"
-        )
-        return
+    run_daily_workflow()
 
-    for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
-        if attempt > 1:
-            export_stop_go_result(
-                day_key=day_key,
-                decision="retry",
-                reason="verification_failed",
-                attempt=attempt,
-            )
-            print(
-                "STOP_GO decision=retry "
-                f"reason=verification_failed attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
-            )
-        run_daily_workflow(force_refresh_same_day=(attempt > 1))
-        artifact = load_daily_verification_artifact()
-        if verification_passed_for_day(day_key, artifact):
-            export_stop_go_result(
-                day_key=day_key,
-                decision="stop",
-                reason="verification_pass",
-                attempt=attempt,
-            )
-            print(
-                "STOP_GO decision=stop "
-                f"reason=verification_pass attempt={attempt}/{MAX_RETRY_ATTEMPTS}"
-            )
-            return
-
-    export_stop_go_result(
-        day_key=day_key,
-        decision="give_up",
-        reason="max_retry_attempts_reached",
-        attempt=MAX_RETRY_ATTEMPTS,
-    )
-    print(
-        "STOP_GO decision=give_up "
-        f"reason=max_retry_attempts_reached attempts={MAX_RETRY_ATTEMPTS}/{MAX_RETRY_ATTEMPTS}"
-    )
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main_daily_picks.py
+++ b/tests/test_main_daily_picks.py
@@ -1204,94 +1204,13 @@ def test_export_verification_artifact_section_header_counts_by_key(tmp_path):
     assert artifact["pass"] is True
 
 
-def test_main_stop_go_stops_immediately_when_verification_passes(monkeypatch):
+def test_main_invokes_run_daily_workflow_once(monkeypatch):
     calls = []
-    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
-    monkeypatch.setattr(
-        main,
-        "load_daily_verification_artifact",
-        lambda: {"day_key": "2026-04-12", "pass": True},
-    )
     monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
 
     main.main()
 
-    assert calls == []
-
-
-def test_main_stop_go_retries_until_verification_passes(monkeypatch):
-    calls = []
-    artifacts = iter(
-        [
-            {"day_key": "2026-04-12", "pass": False},
-            {"day_key": "2026-04-12", "pass": False},
-            {"day_key": "2026-04-12", "pass": True},
-        ]
-    )
-    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
-    monkeypatch.setattr(main, "load_daily_verification_artifact", lambda: next(artifacts))
-    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
-
-    main.main()
-
-    assert calls == [{"force_refresh_same_day": False}, {"force_refresh_same_day": True}]
-
-
-def test_main_stop_go_gives_up_after_max_attempts(monkeypatch, capsys):
-    calls = []
-    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
-    monkeypatch.setattr(
-        main,
-        "load_daily_verification_artifact",
-        lambda: {"day_key": "2026-04-12", "pass": False},
-    )
-    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
-
-    main.main()
-
-    captured = capsys.readouterr()
-    assert len(calls) == main.MAX_RETRY_ATTEMPTS
-    assert "STOP_GO decision=give_up" in captured.out
-
-
-def test_export_stop_go_result_uses_escalate_signal_for_give_up(tmp_path):
-    out = tmp_path / "stop_go.json"
-    main.export_stop_go_result(
-        day_key="2026-04-12",
-        decision="give_up",
-        reason="max_retry_attempts_reached",
-        attempt=3,
-        path=str(out),
-    )
-
-    artifact = json.loads(out.read_text(encoding="utf-8"))
-    assert artifact["decision"] == "give_up"
-    assert artifact["signal"] == "escalate_to_fixer"
-    assert artifact["orchestrator"] == "openhands"
-    assert artifact["fixer"] == "claude_code"
-    assert artifact["escalation_target"] == "claude_code"
-
-
-def test_main_stop_go_writes_give_up_artifact(monkeypatch, tmp_path):
-    calls = []
-    out = tmp_path / "stop_go.json"
-    monkeypatch.setattr(main, "STOP_GO_RESULT_FILE", str(out))
-    monkeypatch.setattr(main, "get_target_day_key", lambda: "2026-04-12")
-    monkeypatch.setattr(
-        main,
-        "load_daily_verification_artifact",
-        lambda: {"day_key": "2026-04-12", "pass": False},
-    )
-    monkeypatch.setattr(main, "run_daily_workflow", lambda **kwargs: calls.append(kwargs))
-
-    main.main()
-
-    artifact = json.loads(out.read_text(encoding="utf-8"))
-    assert len(calls) == main.MAX_RETRY_ATTEMPTS
-    assert artifact["decision"] == "give_up"
-    assert artifact["signal"] == "escalate_to_fixer"
-    assert artifact["reason"] == "max_retry_attempts_reached"
-    assert artifact["attempt"] == main.MAX_RETRY_ATTEMPTS
+    assert calls == [{}]
 
 
 def test_post_discord_debug_summary_posts_compact_message(monkeypatch):


### PR DESCRIPTION
## What this removes

Dead code in `main.py` left over from the auto-fix bot system (deleted in PR #332):

- `STOP_GO_RESULT_FILE` constant (L42) — pointed to `daily_stop_go_result.json`
- `MAX_RETRY_ATTEMPTS = 3` constant (L43)
- `load_daily_verification_artifact()` function (L2898-2899)
- `verification_passed_for_day()` function (L2902-2905)
- `export_stop_go_result()` function (L2908-2946) — wrote `{"orchestrator": "openhands", "fixer": "claude_code", "escalation_target": "claude_code"}` to a file no longer read by anything
- The retry loop in `main()` (L3271-3307) that called these helpers

## Why it's safe

**Cross-reference scan**: each removed symbol was searched across all 21 source files, all 11 workflows, and `CLAUDE.md` / `README.md`. All references to all 5 names were confined to `main.py` itself — zero external callers.

**The retry loop never worked correctly anyway**: it called `load_daily_verification_artifact()` to check if today's daily picks had passed verification, but `verify_discord_output.py` runs in a SEPARATE `daily.yml` step AFTER `main.py` exits. So the artifact always contained yesterday's data and the check always failed, sending the loop through `MAX_RETRY_ATTEMPTS = 3` iterations. Iterations 2 and 3 hit the `completed=True` idempotency gate inside `run_daily_workflow` and returned early as no-ops. The orchestrator/fixer signal it produced was supposed to be picked up by `auto-fix.yml`, but that workflow was deleted in PR #332.

## What replaces it

New `main()`:

```python
def main():
    run_daily_workflow()
```

## What stays

- `DAILY_VERIFICATION_FILE` constant — still used by `export_verification_artifact()` (called from `run_daily_workflow`)
- `export_verification_artifact()` — still writes the artifact uploaded by `daily.yml`
- `verify_discord_output.py` — still runs as a separate workflow step and uploads its artifact

## Diff size

- `main.py`: 117,620 → 114,206 bytes (−3,414 bytes, ~102 lines removed)
- Net effect on production: identical (the removed code was no-op infrastructure)

## Follow-up

- `.gitignore` still has `daily_stop_go_result.json` — will remove in a separate small PR after this merges and tomorrow's scheduled `daily.yml` run confirms nothing breaks.