### PR TITLE
chore(gitignore): remove stale daily_stop_go_result.json entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ env/
 #   copy would be re-read by build_daily_health_report.py and surface dead
 #   errors/warnings as fresh issues.
 state_sanity.json
-daily_stop_go_result.json


### PR DESCRIPTION
Follow-up to PR #343. The `daily_stop_go_result.json` file is no longer produced by `main.py` (the `export_stop_go_result()` function and `STOP_GO_RESULT_FILE` constant were removed). This entry in `.gitignore` is now stale.

Small, low-risk cleanup.