### PR TITLE
docs(readme): remove stale "self-healing" claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Weekly Scheduling Responses Sync](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-responses-sync.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/weekly-scheduling-responses-sync.yml)
 [![Bot Health Report](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/bot-health-report.yml/badge.svg)](https://github.com/XiannGoh/steam-discord-free-games/actions/workflows/bot-health-report.yml)
 
-A fully automated, self-healing Discord bot pipeline for multiplayer Steam game discovery. Runs daily, fixes itself when things break, and posts picks to a 5-channel Discord server.
+A fully automated Discord bot pipeline for multiplayer Steam game discovery. Runs daily and posts picks to a 5-channel Discord server.
 
 ## What it does
 


### PR DESCRIPTION
The README tagline said the bot is "self-healing" and "fixes itself when things break". That capability was the `auto-fix.yml` workflow which we deleted in PR #332 weeks ago. With PR #343 we just removed the last remnants of its supporting code (`export_stop_go_result`, retry loop, etc).

The README has been silently lying about the bot's capabilities. This PR removes the false claim. The bot still has good monitoring (validator + health reports) but it does not self-heal.

Before:
> A fully automated, self-healing Discord bot pipeline for multiplayer Steam game discovery. Runs daily, fixes itself when things break, and posts picks to a 5-channel Discord server.

After:
> A fully automated Discord bot pipeline for multiplayer Steam game discovery. Runs daily and posts picks to a 5-channel Discord server.