### PR TITLE
refactor: remove 11 unused functions (~310 lines of dead code)

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -283,90 +283,6 @@ def _build_winner_item_lines(item: dict, *, section: str) -> List[str]:
     return lines
 
 
-def build_winners_message_chunks(
-    winners_by_section: Dict[str, List[dict]],
-    *,
-    target_max: int = WINNERS_MESSAGE_TARGET_MAX,
-    hard_limit: int = DISCORD_MESSAGE_CHAR_LIMIT,
-) -> List[str]:
-    full_message = build_winners_message(winners_by_section)
-    if len(full_message) <= hard_limit:
-        return [full_message]
-
-    header = "🏆 Daily Game Picks — Winners"
-    chunks: List[str] = []
-    current_lines: List[str] = [header, ""]
-    has_any_winners = any(isinstance(winners_by_section.get(section), list) and winners_by_section.get(section) for section in SECTION_ORDER)
-
-    def finalize_current_chunk() -> None:
-        if current_lines:
-            rendered = "\n".join(current_lines).strip()
-            if rendered:
-                chunks.append(rendered)
-
-    def can_fit(lines: List[str], extra_lines: List[str]) -> bool:
-        rendered = "\n".join(lines + extra_lines).strip()
-        return len(rendered) <= target_max
-
-    if not has_any_winners:
-        return [full_message]
-
-    for section in SECTION_ORDER:
-        items = winners_by_section.get(section, [])
-        if not items:
-            continue
-
-        section_header_lines = [SECTION_CONFIG[section]]
-        section_full_lines = section_header_lines[:]
-        for item in items:
-            section_full_lines.extend(_build_winner_item_lines(item, section=section))
-
-        if can_fit(current_lines, section_full_lines):
-            current_lines.extend(section_full_lines)
-            continue
-
-        if len("\n".join(current_lines).strip()) > len(header):
-            finalize_current_chunk()
-            current_lines = []
-
-        current_lines.extend(section_header_lines)
-        for item in items:
-            item_lines = _build_winner_item_lines(item, section=section)
-            if not can_fit(current_lines, item_lines):
-                finalize_current_chunk()
-                current_lines = [SECTION_CONFIG[section]]
-            current_lines.extend(item_lines)
-
-    finalize_current_chunk()
-    for chunk in chunks:
-        if len(chunk) > hard_limit:
-            raise RuntimeError("Winners chunk exceeded Discord character limit")
-    return chunks
-
-
-def build_winners_message_compact(winners_by_section: Dict[str, List[dict]]) -> str:
-    lines = ["🏆 Daily Game Picks — Winners", ""]
-    has_any_winners = False
-
-    for section in SECTION_ORDER:
-        items = winners_by_section.get(section, [])
-        if not items:
-            continue
-
-        has_any_winners = True
-        lines.append(SECTION_CONFIG[section])
-        for item in items:
-            vote_word = "vote" if item["human_votes"] == 1 else "votes"
-            lines.append(f"- {item['title']} ({item['human_votes']} {vote_word})")
-            lines.append(f"  {item['url']}")
-        lines.append("")
-
-    if not has_any_winners:
-        lines.append("_No votes yet today._")
-
-    return "\n".join(lines).strip()
-
-
 def normalize_winner_description_for_message(
     description: Optional[str], max_length: int = 110
 ) -> str:
@@ -509,30 +425,6 @@ def build_winner_identity_key(item: dict) -> str:
     channel_id = str(item.get("channel_id") or "").strip()
     message_id = str(item.get("message_id") or "").strip()
     return f"{channel_id}:{message_id}"
-
-
-def collect_recent_announced_winner_keys(
-    daily_posts: Dict[str, dict],
-    *,
-    target_day_key: str,
-    lookback_days: int = WINNERS_LOOKBACK_DAYS,
-) -> set[str]:
-    announced_keys: set[str] = set()
-    for bucket_key in get_lookback_day_keys(target_day_key, lookback_days)[1:]:
-        bucket = daily_posts.get(bucket_key, {})
-        if not isinstance(bucket, dict):
-            continue
-        winners_state = bucket.get("winners_state")
-        if not isinstance(winners_state, dict):
-            continue
-        winner_keys = winners_state.get("winner_keys")
-        if not isinstance(winner_keys, list):
-            continue
-        for winner_key in winner_keys:
-            normalized = str(winner_key).strip()
-            if normalized:
-                announced_keys.add(normalized)
-    return announced_keys
 
 
 def _coerce_int(value: object, default: int = 0) -> int:
@@ -701,14 +593,6 @@ def upsert_winners_messages_for_day(
         if isinstance(entry, dict) and str(entry.get("winner_key") or "").strip()
     }
     return True
-
-
-def post_winners_message(client: DiscordClient, channel_id: str, message: str) -> str:
-    payload = client.post_message(channel_id, message, context="post winners message")
-    message_id = str(payload.get("id", ""))
-    if not message_id:
-        raise RuntimeError("Discord response missing winners message id")
-    return message_id
 
 
 def normalize_winners_message_ids(winners_state: dict) -> List[str]:

--- a/main.py
+++ b/main.py
@@ -1529,14 +1529,6 @@ def extract_review_sentiment(soup: BeautifulSoup) -> Optional[str]:
     return None
 
 
-def extract_review_score(soup: BeautifulSoup) -> int:
-    sentiment = extract_review_sentiment(soup)
-    if sentiment is None:
-        return 0
-
-    return REVIEW_SENTIMENT_SCORES[sentiment]
-
-
 def inspect_game(source: str, app_id: str) -> Optional[dict]:
     url = f"https://store.steampowered.com/app/{app_id}/"
     try:
@@ -1790,49 +1782,6 @@ def format_instagram_item_message(post: dict, idx: int) -> str:
     )
 
 
-def build_message_chunks(title_line: str, items: List[dict], paid: bool = False) -> List[str]:
-    if not items:
-        return []
-
-    chunks = []
-    current = f"{title_line}\n\n"
-
-    for idx, item in enumerate(items, start=1):
-        block = format_item_block(item, idx, paid=paid)
-
-        if len(current) + len(block) > DISCORD_CHAR_LIMIT:
-            chunks.append(current.rstrip())
-            current = block
-        else:
-            current += block
-
-    if current.strip():
-        chunks.append(current.rstrip())
-
-    return chunks
-    
-def build_instagram_chunks(posts: List[dict]) -> List[str]:
-    title = "📸 **New Instagram Creator Picks**"
-    chunks = []
-    current = title + "\n\n"
-
-    for idx, post in enumerate(posts, start=1):
-        block = (
-            f"{idx}. @{post['username']} — {post['caption']}\n"
-            f"{post['url']}\n\n"
-        )
-
-        if len(current) + len(block) > DISCORD_CHAR_LIMIT:
-            chunks.append(current.rstrip())
-            current = title + "\n\n" + block
-        else:
-            current += block
-
-    if current.strip():
-        chunks.append(current.rstrip())
-
-    return chunks
-
 def post_to_discord(message: str) -> None:
     if not WEBHOOK_URL:
         raise RuntimeError("DISCORD_WEBHOOK_URL is not set.")
@@ -2005,131 +1954,8 @@ def record_posted_item(
         print(f"RECORD DAILY DISCORD ITEM FAILED: title={title} | error={e}")
 
 
-def post_message_chunks(chunks: List[str]) -> None:
-    for chunk in chunks:
-        post_to_discord(chunk)
-        sleep_briefly()
-
-
 def build_discord_message_link(guild_id: str, channel_id: str, message_id: str) -> str:
     return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
-
-
-def build_daily_navigation_footer(
-    run_state: dict,
-    guild_id: Optional[str],
-    target_day_key: str,
-    posted_section_keys: List[str],
-) -> Optional[str]:
-    if not isinstance(guild_id, str) or not guild_id.strip():
-        print("WARN: DISCORD_GUILD_ID missing; skipping daily navigation footer.")
-        return None
-
-    intro_state = run_state.get("intro")
-    if not isinstance(intro_state, dict):
-        print("WARN: intro state missing; skipping daily navigation footer.")
-        return None
-
-    intro_channel_id = intro_state.get("channel_id")
-    intro_message_id = intro_state.get("message_id")
-    if not (isinstance(intro_channel_id, str) and isinstance(intro_message_id, str)):
-        print("WARN: intro message metadata missing; skipping daily navigation footer.")
-        return None
-
-    section_labels = {
-        "demo_playtest": "🧪 Demo & Playtest Picks",
-        "free": "🎮 Free Picks",
-        "paid": "💸 Paid Picks",
-        "instagram": "📸 Creator Picks",
-    }
-    section_headers = run_state.get("section_headers", {})
-    lines = [
-        f"🗓️ Daily Picks for {format_daily_picks_footer_date(target_day_key)}",
-        "",
-        f"🎯 Intro / Top of Post → [Jump]({build_discord_message_link(guild_id, intro_channel_id, intro_message_id)})",
-    ]
-
-    for section_key in DAILY_SECTION_ORDER:
-        if section_key not in posted_section_keys:
-            continue
-        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
-        if not isinstance(section_state, dict):
-            print(f"WARN: {section_key} header state missing; skipping daily navigation footer.")
-            return None
-        channel_id = section_state.get("channel_id")
-        message_id = section_state.get("message_id")
-        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
-            print(f"WARN: {section_key} header metadata missing; skipping daily navigation footer.")
-            return None
-        section_label = section_labels.get(section_key)
-        if not section_label:
-            continue
-        lines.append(f"{section_label} → [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
-
-    return "\n".join(lines)
-
-
-def build_daily_picks_navigation_content(
-    run_state: dict,
-    guild_id: Optional[str],
-    target_day_key: str,
-    posted_section_keys: List[str],
-) -> Optional[str]:
-    if not isinstance(guild_id, str) or not guild_id.strip():
-        return None
-
-    lines = [
-        f"📅 Daily Picks - {format_daily_picks_footer_date(target_day_key)}",
-        "Vote 👍 on any game you want to try. Every vote advances to Step 2.",
-    ]
-
-    section_labels = {
-        "demo_playtest": "🧪 Demo & Playtest Picks",
-        "free": "🎮 Free Picks",
-        "paid": "💸 Paid Picks",
-        "instagram": "📸 Creator Picks",
-    }
-    section_headers = run_state.get("section_headers", {})
-
-    for section_key in DAILY_SECTION_ORDER:
-        if section_key not in posted_section_keys:
-            continue
-        section_state = section_headers.get(section_key) if isinstance(section_headers, dict) else None
-        if not isinstance(section_state, dict):
-            continue
-        channel_id = section_state.get("channel_id")
-        message_id = section_state.get("message_id")
-        if not (isinstance(channel_id, str) and isinstance(message_id, str)):
-            continue
-        section_label = section_labels.get(section_key)
-        if not section_label:
-            continue
-        lines.append(f"{section_label} ⟹ [Jump]({build_discord_message_link(guild_id, channel_id, message_id)})")
-
-    return "\n".join(lines)
-
-
-DAILY_INTRO_DIVIDER = "─────────────────────────────────────────"
-DAILY_FOOTER_SEPARATOR = "─────────────────── End of Daily Picks ───────────────────"
-
-_DAILY_INTRO_SECTION_LABELS = {
-    "demo_playtest": ("🎮", "Demos & Playtests"),
-    "free": ("🆓", "Free Picks"),
-    "paid": ("💰", "Paid Under $20"),
-    "instagram": ("📸", "Instagram Picks"),
-}
-_DAILY_FOOTER_SECTION_LABELS = {
-    "demo_playtest": "🎮 Demos",
-    "free": "🆓 Free",
-    "paid": "💰 Paid",
-    "instagram": "📸 Instagram",
-}
-_DAILY_MISSING_SECTION_LABELS = {
-    "demo_playtest": "Demos & Playtests",
-    "free": "Free Picks",
-    "paid": "Paid Under $20",
-    "instagram": "Instagram Picks",
-}
 
 
 def build_daily_picks_intro_content(

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -801,21 +801,6 @@ def post_channel_message(session: requests.Session, channel_id: str, content: st
     return str(message_id)
 
 
-def edit_channel_message(
-    session: requests.Session, channel_id: str, message_id: str, content: str
-) -> None:
-    """Edit an existing Discord channel message in place."""
-    response = session.patch(
-        build_edit_message_url(channel_id, message_id),
-        json={"content": content},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-    check_response(
-        response,
-        f"Failed to edit channel message for channel_id={channel_id}, message_id={message_id}",
-    )
-
-
 def current_new_york_local_date() -> str:
     """Return the current New York calendar date in ISO format."""
     return datetime.now(NEW_YORK_TIMEZONE).date().isoformat()


### PR DESCRIPTION
## Summary

Removes 11 functions that are defined but never called anywhere in source, tests, or workflows. Each function was verified via exhaustive cross-reference scan — they only appear on their own `def` line.

## Files changed

### `main.py` (-6 functions, ~174 lines)

- `extract_review_score()` L1532 — 7 lines, calls `extract_review_sentiment` (which IS still used; this wrapper isn't)
- `build_message_chunks()` L1793 — 20 lines, builds Discord message chunks
- `build_instagram_chunks()` L1814 — 21 lines, builds `📸 **New Instagram Creator Picks**` chunks (the real Instagram posting flow uses a different path)
- `post_message_chunks()` L2008 — 5 lines, looped `post_to_discord` over chunks
- `build_daily_navigation_footer()` L2018 — 53 lines, daily navigation footer builder
- `build_daily_picks_navigation_content()` L2072 — 62 lines, daily picks navigation content

### `evening_winners.py` (-4 functions, ~112 lines)

- `build_winners_message_chunks()` L286 — 60 lines, winners message chunk builder
- `build_winners_message_compact()` L347 — 22 lines, compact `🏆 Daily Game Picks — Winners` builder
- `collect_recent_announced_winner_keys()` L514 — 23 lines, winner key collector
- `post_winners_message()` L706 — 7 lines, single-message poster wrapper

### `scripts/sync_weekly_schedule_responses.py` (-1 function, ~14 lines)

- `edit_channel_message()` L804 — 14 lines, channel message editor wrapper

## Verification

For each of the 11 functions, ran a cross-reference scan across:
- All 21 production source files
- All 17 test files
- All 11 workflow YAML files
- `CLAUDE.md` + `README.md` + `.gitignore`

Each function name appeared ONLY on its own `def` line — zero callers, zero `getattr`/string-based references, zero test monkeypatches. Confirmed truly orphaned.

## Diff size

- `main.py`: 114,206 → 108,491 bytes (-5,715 bytes)
- `evening_winners.py`: 45,080 → 40,991 bytes (-4,089 bytes)
- `scripts/sync_weekly_schedule_responses.py`: 49,517 → 49,031 bytes (-486 bytes)
- Total: ~310 lines of dead code removed

## Risk

Low — these functions have no callers. Production behavior is unchanged. Tomorrow's scheduled `daily.yml` + `evening-winners.yml` + `weekly-scheduling-responses-sync.yml` runs will empirically confirm no break.