### PR TITLE
refactor: remove 4 cascading orphan functions (~58 lines)

### DIFF
--- a/evening_winners.py
+++ b/evening_winners.py
@@ -242,34 +242,6 @@ def build_winners_navigation_footer(
     return f"{first_line}\n{WINNERS_FOOTER_SEPARATOR}"
 
 
-def build_winners_message(winners_by_section: Dict[str, List[dict]]) -> str:
-    lines = ["🏆 Daily Game Picks — Winners", ""]
-    has_any_winners = False
-
-    for section in SECTION_ORDER:
-        items = winners_by_section.get(section, [])
-        if not items:
-            continue
-
-        has_any_winners = True
-        lines.append(SECTION_CONFIG[section])
-        for item in items:
-            lines.append(item["title"])
-            description = resolve_winner_description_for_message(item, section=section)
-            if description:
-                lines.append(description)
-            lines.append(item["url"])
-            vote_word = "vote" if item["human_votes"] == 1 else "votes"
-            lines.append(f"👍 {item['human_votes']} {vote_word}")
-            lines.append(f"Voters — {format_voter_names_for_message(item['voter_names'])}")
-            lines.append("")
-
-    if not has_any_winners:
-        lines.append("_No votes yet today._")
-
-    return "\n".join(lines).strip()
-
-
 def _build_winner_item_lines(item: dict, *, section: str) -> List[str]:
     lines = [item["title"]]
     description = resolve_winner_description_for_message(item, section=section)

--- a/main.py
+++ b/main.py
@@ -1741,18 +1741,6 @@ def type_label(item_type: str) -> str:
     return "Free Game"
 
 
-def format_item_block(item: dict, idx: int, paid: bool = False) -> str:
-    lines = []
-    lines.append(f"**{idx}. {item['title']}**")
-    lines.append(f"Type: {'Paid Under $20' if paid else type_label(item['type'])}")
-    lines.append(f"Score: {item['score']}")
-    if item["description"]:
-        lines.append(item["description"][:180])
-    lines.append(item["url"])
-    lines.append("")
-    return "\n".join(lines)
-
-
 def format_steam_item_message(item: dict, idx: int, paid: bool = False, demo_playtest: bool = False) -> str:
     emoji = "💸" if paid else ("🧪" if demo_playtest else "🎮")
     if paid:
@@ -1780,19 +1768,6 @@ def format_instagram_item_message(post: dict, idx: int) -> str:
         f"@{post['username']} — {post['caption']}\n"
         f"{post['url']}"
     )
-
-
-def post_to_discord(message: str) -> None:
-    if not WEBHOOK_URL:
-        raise RuntimeError("DISCORD_WEBHOOK_URL is not set.")
-
-    response = requests.post(
-        WEBHOOK_URL,
-        json={"content": message},
-        headers={"Content-Type": "application/json"},
-        timeout=30,
-    )
-    response.raise_for_status()
 
 
 def post_to_discord_with_metadata(message: str, capture_metadata: bool = False) -> Optional[dict]:

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -271,11 +271,6 @@ def build_create_message_url(channel_id: str) -> str:
     return f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
 
 
-def build_edit_message_url(channel_id: str, message_id: str) -> str:
-    """Build the Discord API URL for editing an existing channel message."""
-    return f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
-
-
 def fetch_channel_messages(session: requests.Session, channel_id: str) -> list[dict[str, Any]]:
     """Fetch all messages in a channel, handling pagination."""
     all_messages: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

After PR #346 removed 11 unused functions, this re-scan found 4 cascading orphans — functions whose only callers were just deleted. Each one was verified to have exactly 1 reference (its own def line) across the entire codebase (21 source files, 17 test files, 11 workflow YAMLs, README, CLAUDE.md).

## Files changed

### `main.py` (-2 functions, ~25 lines)

- `format_item_block(item, idx, paid=False)` L1744 — 12 lines, item block string builder; was only called from the (now-removed) message chunk functions
- `post_to_discord(message)` L1785 — 13 lines, basic webhook poster using `WEBHOOK_URL`; the live caller is `post_to_discord_with_metadata` (which remains, with consumers at L2161 and L2287)

### `evening_winners.py` (-1 function, ~28 lines)

- `build_winners_message(winners_by_section)` L245 — 28 lines, alternate winners string builder; the actual winners flow uses `_build_winner_item_lines` and a different message builder

### `scripts/sync_weekly_schedule_responses.py` (-1 function, ~5 lines)

- `build_edit_message_url(channel_id, message_id)` L274 — 3 lines, URL builder for editing messages; was only used by the (removed in PR #346) `edit_channel_message` function

## Safety improvements after the PR #346 → #347 hotfix experience

PR #346 accidentally removed 5 module-level constants because they were spatially co-located with a dead function (between two `def` lines). The fix in PR #347 restored them.

This PR uses an upgraded removal algorithm to prevent recurrence:

1. **Find function body END precisely** — walk forward only while lines are blank or indented (function body), stop at first non-indented non-blank line. This guarantees no surrounding constants get caught in the removal range.
2. **Pre-deletion definition snapshot** — collect every module-level def/class/assignment/import in the original.
3. **Post-deletion verification** — collect the same in the patched version. Any name that disappeared from the defined set but was NOT in the expected-removal list is treated as unexpected loss.
4. **Reference check** — for any unexpectedly-lost name, scan the patched file for remaining references. If any exist, abort the paste.

Every patch in this PR passed: `unexpectedLost: []` and `unexpectedStillReferenced: []`.

## Verification

- All 4 functions confirmed truly orphaned (1 ref each = just the def line) across full codebase scan
- All 5 critical constants restored by PR #347 still present in `main.py`
- All critical live functions preserved: `format_steam_item_message`, `post_to_discord_with_metadata`, `run_daily_workflow`, `main`, `build_daily_picks_intro_content`, `build_daily_picks_footer_content`, `_build_winner_item_lines`, `fetch_channel_messages`, `build_create_message_url`
- Will be empirically verified by triggering a fresh `daily.yml` run immediately after merge

## Diff size

- `main.py`: 109,045 → 108,587 bytes (-458 bytes)
- `evening_winners.py`: 40,758 → 39,984 bytes (-774 bytes)
- `scripts/sync_weekly_schedule_responses.py`: 48,965 → 48,806 bytes (-159 bytes)
- Total: ~58 lines / ~1.4 KB of dead code removed