### PR TITLE
style: drop 12 useless f-prefixes across 4 files (F541)

### DIFF
--- a/gaming_library.py
+++ b/gaming_library.py
@@ -1169,12 +1169,12 @@ def _check_channel_permissions(
     )
     print(f"WARN: {warning}")
     _notify_health_monitor(
-        f"⚠️ Gaming Library — Missing Discord Permissions\n\n"
+        "⚠️ Gaming Library — Missing Discord Permissions\n\n"
         f"Context: {context}\n"
         f"Channel: <#{channel_id}>\n"
         f"Missing: {', '.join(missing)}\n\n"
-        f"The bot will attempt to continue but errors may occur. "
-        f"Please grant the required permissions to the bot in that channel."
+        "The bot will attempt to continue but errors may occur. "
+        "Please grant the required permissions to the bot in that channel."
     )
 
 

--- a/main.py
+++ b/main.py
@@ -758,7 +758,7 @@ def is_vr_content(title: str, description: str, text: str, tags: List[str]) -> b
 def get_price_info(app_id: str) -> Tuple[Optional[float], bool, Optional[int], Optional[str]]:
     try:
         url = (
-            f"https://store.steampowered.com/api/appdetails"
+            "https://store.steampowered.com/api/appdetails"
             f"?appids={app_id}&cc=us"
         )
         response = requests.get(url, headers=HEADERS, timeout=30)
@@ -2568,7 +2568,7 @@ def fetch_instagram_posts():
         print(f"Instagram session load failed: {e}")
         _notify_health_monitor(
             f"⚠️ Instagram session load failed for {instagram_username}: {e}\n"
-            f"Instagram session may have expired — re-authenticate and update INSTAGRAM_SESSION secret."
+            "Instagram session may have expired — re-authenticate and update INSTAGRAM_SESSION secret."
         )
         return []
 
@@ -2579,8 +2579,8 @@ def fetch_instagram_posts():
             print(f"WARN: Instagram session auth check failed — test_login() returned None for {instagram_username}")
             _notify_health_monitor(
                 f"⚠️ Instagram session auth check failed for {instagram_username}.\n"
-                f"test_login() returned None — session may have expired. "
-                f"Re-authenticate and update the INSTAGRAM_SESSION secret."
+                "test_login() returned None — session may have expired. "
+                "Re-authenticate and update the INSTAGRAM_SESSION secret."
             )
             return []
         print(f"Instagram session valid: logged in as @{authed_user}")
@@ -2588,7 +2588,7 @@ def fetch_instagram_posts():
         print(f"WARN: Instagram session auth check raised an exception: {e}")
         _notify_health_monitor(
             f"⚠️ Instagram session auth check raised an exception for {instagram_username}: {e}\n"
-            f"Re-authenticate and update the INSTAGRAM_SESSION secret."
+            "Re-authenticate and update the INSTAGRAM_SESSION secret."
         )
         return []
 

--- a/scripts/sync_weekly_schedule_responses.py
+++ b/scripts/sync_weekly_schedule_responses.py
@@ -1151,7 +1151,7 @@ def main() -> None:
                 if missing_user_ids != previous_missing_users:
                     if last_reminder_local_date == reminder_local_date:
                         print(
-                            f"SKIP: reminder already posted on New York date "
+                            "SKIP: reminder already posted on New York date "
                             f"{reminder_local_date} for week {posting_week_key}; skipping reminder post"
                         )
                     else:

--- a/scripts/verify_discord_output.py
+++ b/scripts/verify_discord_output.py
@@ -417,7 +417,7 @@ def _run_channel_scan(
         ch["rolling_explainer_missing"] = True
         last_preview = str(all_messages[0].get("content", ""))[:60]
         ch["errors"].append(
-            f"rolling explainer is not the last message — "
+            "rolling explainer is not the last message — "
             f"last: {last_preview!r} (channel scan: {day_key})"
         )
         print(f"  FAIL  channel scan {channel_slug}: rolling explainer is not last message")
@@ -807,7 +807,7 @@ def verify_step2(
             f"for {day_key}: evening_winners.py ran but found no eligible winners."
         )
         print(
-            f"\n--- Step-2 skipped: winners_state.status=skipped "
+            "\n--- Step-2 skipped: winners_state.status=skipped "
             f"(reason={skipped_reason}) for {day_key} ---"
         )
         return ch
@@ -1101,7 +1101,7 @@ def main() -> None:
     if specs:
         print(f"Loaded {CHANNEL_SPECS_FILE} ({len(specs)} channel specs)")
     else:
-        print(f"WARN: No channel specs loaded — using defaults")
+        print("WARN: No channel specs loaded — using defaults")
 
     daily_posts = load_daily_posts()
     day_entry = daily_posts.get(day_key)


### PR DESCRIPTION
## Summary

Removes 12 useless `f` prefixes from string literals across 4 files. Each affected string has no `{...}` placeholder, so the `f` prefix is dead code (Ruff F541 rule). These appear in multi-line string concatenations where some lines legitimately interpolate variables but adjacent literal-only lines kept the `f` prefix unnecessarily.

## Changes

### main.py (5 removals)

- `L761` URL concatenation: kept `f` only on the line with `{app_id}`
- `L2571` Instagram session warning — multi-line health monitor message
- `L2582-2583` test_login() failure message (2 lines)
- `L2591` auth exception message

### gaming_library.py (3 removals)

- `L1172-1177` Discord permissions warning multi-line message

### scripts/sync_weekly_schedule_responses.py (1 removal)

- `L1154` SKIP reminder log line

### scripts/verify_discord_output.py (3 removals)

- `L420` rolling explainer error message
- `L810` Step-2 skipped log
- `L1104` WARN print statement

## Safety verification

Each commit:
1. Used exact-string replacement (no regex on source)
2. Confirmed all 4 replacements matched the source verbatim
3. Post-patch verification: 0 useless f-strings remain in each modified file
4. Critical functions preserved (verified per-file: load_gaming_library, run_daily_workflow, fetch_instagram_posts, check_message, etc.)

Zero functional change — `f"text"` and `"text"` evaluate to identical strings when no `{...}` placeholder exists.

## Diff size

- `main.py`: 108,182 → 108,177 bytes (-5)
- `gaming_library.py`: 53,855 → 53,852 bytes (-3)
- `scripts/sync_weekly_schedule_responses.py`: 48,738 → 48,737 bytes (-1)
- `scripts/verify_discord_output.py`: 50,804 → 50,801 bytes (-3)
- **Total: -12 bytes / 12 useless `f` prefixes removed**

## Verification plan

- Will trigger fresh `daily.yml` run after merge to empirically confirm no regression
- All other scheduled workflows will run on their normal cadence and validate