### PR TITLE
ci: pin python-version to 3.11 in 2 weekly-scheduling workflows

### DIFF
--- a/.github/workflows/weekly-scheduling-bot.yml
+++ b/.github/workflows/weekly-scheduling-bot.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/weekly-scheduling-responses-sync.yml
+++ b/.github/workflows/weekly-scheduling-responses-sync.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
## Summary

Found via exhaustive audit: 2 of 7 Python-using workflows had `python-version: '3.x'` (floating to latest) instead of the pinned `"3.11"` used by the other 5. This is a production stability concern — if a future Python release (3.13+) introduces breaking changes, only those 2 workflows would be affected, making the failure asymmetric and harder to diagnose.

## Workflows fixed

- `.github/workflows/weekly-scheduling-bot.yml:L38` — `'3.x'` → `"3.11"`
- `.github/workflows/weekly-scheduling-responses-sync.yml:L42` — `'3.x'` → `"3.11"`

## Already-pinned workflows (for reference)

- `.github/workflows/bot-health-report.yml` — `"3.11"` ✅
- `.github/workflows/daily.yml` — `"3.11"` ✅
- `.github/workflows/evening-winners.yml` — `"3.11"` ✅
- `.github/workflows/gaming-library-daily.yml` — `"3.11"` ✅
- `.github/workflows/gaming-library-sync.yml` — `"3.11"` ✅

## Safety

These workflows have been running on `3.x` (which currently resolves to Python 3.12 or 3.13) successfully — the code happens to be compatible. But pinning to 3.11 gives:

1. **Consistency** — all 7 Python workflows now use the same version
2. **Reproducibility** — future runs produce same behavior
3. **No surprises** — when a new Python releases, we make a deliberate decision to upgrade

## Verification plan

- After merge, the next scheduled run of `weekly-scheduling-responses-sync.yml` (every 3 hours) will validate the change
- The next Saturday `weekly-scheduling-bot.yml` run will validate that one